### PR TITLE
EventListener removal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [1.1.2]
+        deno-version: [1.2.0]
 
     steps:
       - name: Git Checkout Deno Module

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sent to the server when a disconnect happens are lost. A client can queue
 new messages to be sent when the connection resumes. If the connection
 cannot be re-established the client will give up and `close` the connection.
 
-To learn when a connection closes, wait for the promise returned by the `status()`
+To learn when a connection closes, wait for the promise returned by the `closed()`
 function. If the close was due to an error, it will resolve to an error.
 
 To disconnect from the nats-server, you call `close()` on the connection.
@@ -65,7 +65,7 @@ const dials: Promise<NatsConnection>[] = [];
 
 const conns: NatsConnection[] = [];
 // wait until all the dialed connections resolve or fail
-// allSettled returns a tupple with `status` and `value`:
+// allSettled returns a tupple with `closed` and `value`:
 await Promise.allSettled(dials)
   .then((a) => {
     // filter all the ones that succeeded
@@ -81,10 +81,10 @@ await Promise.allSettled(dials)
 // Print where we connected, and register a close handler
 conns.forEach((nc) => {
   console.log(`connected to ${nc.getServer()}`);
-  // you can get notified when the client exits by getting status.
-  // status resolves void or with an error if the connection
+  // you can get notified when the client exits by getting `closed()`.
+  // closed resolves void or with an error if the connection
   // closed because of an error
-  nc.status()
+  nc.closed()
     .then((err) => {
       let m = `connection to ${nc.getServer()} closed`;
       if (err) {
@@ -194,7 +194,7 @@ printMsgs(s2);
 printMsgs(s3);
 
 // don't exit until the client closes
-await nc.status();
+await nc.closed();
 ```
 
 
@@ -225,7 +225,7 @@ const msub = nc.subscribe("admin.*");
 adminHandler(msub);
 
 // wait for the client to close here.
-await nc.status().then((err?: void | Error) => {
+await nc.closed().then((err?: void | Error) => {
   let m = `connection to ${nc.getServer()} closed`;
   if (err) {
     m = `${m} with an error: ${err.message}`;
@@ -318,7 +318,7 @@ async function createService(
     const nc = await connect(
       { url: "demo.nats.io:4222", name: `${n}` },
     );
-    nc.status()
+    nc.closed()
       .then((err) => {
         if (err) {
           console.error(
@@ -358,7 +358,7 @@ conns.push(...await createService("standalone"));
 
 const a: Promise<void | Error>[] = [];
 conns.forEach((c) => {
-  a.push(c.status());
+  a.push(c.closed());
 });
 await Promise.all(a);
 ```

--- a/doc/snippets/connect.ts
+++ b/doc/snippets/connect.ts
@@ -32,7 +32,7 @@ const dials: Promise<NatsConnection>[] = [];
 
 const conns: NatsConnection[] = [];
 // wait until all the dialed connections resolve or fail
-// allSettled returns a tupple with `status` and `value`:
+// allSettled returns a tupple with `closed` and `value`:
 await Promise.allSettled(dials)
   .then((a) => {
     // filter all the ones that succeeded
@@ -48,10 +48,10 @@ await Promise.allSettled(dials)
 // Print where we connected, and register a close handler
 conns.forEach((nc) => {
   console.log(`connected to ${nc.getServer()}`);
-  // you can get notified when the client exits by getting status.
-  // status resolves void or with an error if the connection
+  // you can get notified when the client exits by getting closed.
+  // closed resolves void or with an error if the connection
   // closed because of an error
-  nc.status()
+  nc.closed()
     .then((err) => {
       let m = `connection to ${nc.getServer()} closed`;
       if (err) {

--- a/doc/snippets/queuegroups.ts
+++ b/doc/snippets/queuegroups.ts
@@ -25,7 +25,7 @@ async function createService(
     const nc = await connect(
       { url: "demo.nats.io:4222", name: `${n}` },
     );
-    nc.status()
+    nc.closed()
       .then((err) => {
         if (err) {
           console.error(
@@ -65,6 +65,6 @@ conns.push(...await createService("standalone"));
 
 const a: Promise<void | Error>[] = [];
 conns.forEach((c) => {
-  a.push(c.status());
+  a.push(c.closed());
 });
 await Promise.all(a);

--- a/doc/snippets/service.ts
+++ b/doc/snippets/service.ts
@@ -31,7 +31,7 @@ const msub = nc.subscribe("admin.*");
 adminHandler(msub);
 
 // wait for the client to close here.
-await nc.status().then((err?: void | Error) => {
+await nc.closed().then((err?: void | Error) => {
   let m = `connection to ${nc.getServer()} closed`;
   if (err) {
     m = `${m} with an error: ${err.message}`;

--- a/doc/snippets/wildcard_subscriptions.ts
+++ b/doc/snippets/wildcard_subscriptions.ts
@@ -40,4 +40,4 @@ printMsgs(s2);
 printMsgs(s3);
 
 // don't exit until the client closes
-await nc.status();
+await nc.closed();

--- a/examples/bench.ts
+++ b/examples/bench.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 import { connect, Nuid } from "../src/mod.ts";
 const defaults = {
   s: "nats://127.0.0.1:4222",

--- a/examples/bench.ts
+++ b/examples/bench.ts
@@ -73,7 +73,7 @@ if (argv.req) {
   }
 }
 
-nc.status()
+nc.closed()
   .then((err) => {
     if (err) {
       console.error(`bench closed with an error: ${err.message}`);

--- a/examples/nats-events.ts
+++ b/examples/nats-events.ts
@@ -18,23 +18,12 @@ const argv = parse(
 const opts = { url: argv.s } as ConnectionOptions;
 
 const nc = await connect(opts);
-console.info(`connected ${nc.getServer()}`);
-
-nc.addEventListener(Events.DISCONNECT, () => {
-  console.info(`disconnected ${nc.getServer()}`);
-});
-
-nc.addEventListener(Events.RECONNECT, () => {
-  console.info(`reconnected ${nc.getServer()}`);
-});
-
-nc.addEventListener(
-  Events.UPDATE,
-  ((evt: CustomEvent) => {
-    console.info(`cluster updated`);
-    console.table(evt.detail);
-  }) as EventListener,
-);
+(async () => {
+  console.info(`connected ${nc.getServer()}`);
+  for await (const s of nc.status()) {
+    console.info(`${s.type}: ${s.data}`);
+  }
+})().then();
 
 await nc.closed()
   .then((err) => {

--- a/examples/nats-events.ts
+++ b/examples/nats-events.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 import { ConnectionOptions, connect, Events } from "../src/mod.ts";
 
 const argv = parse(

--- a/examples/nats-events.ts
+++ b/examples/nats-events.ts
@@ -36,7 +36,7 @@ nc.addEventListener(
   }) as EventListener,
 );
 
-await nc.status()
+await nc.closed()
   .then((err) => {
     if (err) {
       console.error(`closed with an error: ${err.message}`);

--- a/examples/nats-pub.ts
+++ b/examples/nats-pub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 import { ConnectionOptions, connect } from "../src/mod.ts";
 import { delay } from "../nats-base-client/mod.ts";
 

--- a/examples/nats-pub.ts
+++ b/examples/nats-pub.ts
@@ -35,7 +35,7 @@ if (argv.h || argv.help || !subject) {
 }
 
 const nc = await connect(opts);
-nc.status()
+nc.closed()
   .then((err) => {
     if (err) {
       console.error(`closed with an error: ${err.message}`);

--- a/examples/nats-rep.ts
+++ b/examples/nats-rep.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 import { ConnectionOptions, connect } from "../src/mod.ts";
 
 const argv = parse(

--- a/examples/nats-rep.ts
+++ b/examples/nats-rep.ts
@@ -32,7 +32,7 @@ if (argv.h || argv.help || !subject || (argv._[1] && argv.q)) {
 
 const nc = await connect(opts);
 console.info(`connected ${nc.getServer()}`);
-nc.status()
+nc.closed()
   .then((err) => {
     if (err) {
       console.error(`closed with an error: ${err.message}`);

--- a/examples/nats-req.ts
+++ b/examples/nats-req.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 import { ConnectionOptions, connect } from "../src/mod.ts";
 import { delay } from "../nats-base-client/mod.ts";
 

--- a/examples/nats-req.ts
+++ b/examples/nats-req.ts
@@ -37,7 +37,7 @@ if (argv.h || argv.help || !subject) {
 }
 
 const nc = await connect(opts);
-nc.status()
+nc.closed()
   .then((err) => {
     if (err) {
       console.error(`closed with an error: ${err.message}`);

--- a/examples/nats-sub.ts
+++ b/examples/nats-sub.ts
@@ -27,7 +27,7 @@ if (argv.h || argv.help || !subject) {
 
 const nc = await connect(opts);
 console.info(`connected ${nc.getServer()}`);
-nc.status()
+nc.closed()
   .then((err) => {
     if (err) {
       console.error(`closed with an error: ${err.message}`);

--- a/examples/nats-sub.ts
+++ b/examples/nats-sub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 import { ConnectionOptions, connect } from "../src/mod.ts";
 
 const argv = parse(

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -3,6 +3,7 @@ export { Nuid } from "./nuid.ts";
 export { ErrorCode, NatsError } from "./error.ts";
 export {
   Events,
+  Status,
   ConnectionOptions,
   Msg,
   Payload,

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -14,7 +14,6 @@ export {
 export {
   Transport,
   setTransportFactory,
-  TransportEvents,
 } from "./transport.ts";
 export {
   Connect,

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -20,7 +20,6 @@ import {
   ConnectionOptions,
   Msg,
   SubscriptionOptions,
-  Events,
   Status,
   //@ts-ignore
 } from "./mod.ts";
@@ -34,20 +33,19 @@ import {
 import { ErrorCode, NatsError } from "./error.ts";
 //@ts-ignore
 import { Nuid } from "./nuid.ts";
-import { DebugEvents, defaultReq } from "./types.ts";
+import { defaultReq } from "./types.ts";
 import { parseOptions } from "./options.ts";
 import { QueuedIterator } from "./queued_iterator.ts";
 
 export const nuid = new Nuid();
 
-export class NatsConnection extends EventTarget {
+export class NatsConnection {
   options: ConnectionOptions;
   protocol!: ProtocolHandler;
   draining: boolean = false;
   listeners: QueuedIterator<Status>[] = [];
 
   private constructor(opts: ConnectionOptions) {
-    super();
     this.options = parseOptions(opts);
   }
 

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -74,7 +74,7 @@ export class NatsConnection extends EventTarget {
     });
   }
 
-  status(): Promise<void | Error> {
+  closed(): Promise<void | Error> {
     return this.protocol.closed;
   }
 

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -24,7 +24,7 @@ import {
   Base,
 } from "./types.ts";
 //@ts-ignore
-import { Transport, newTransport, TransportEvents } from "./transport.ts";
+import { Transport, newTransport } from "./transport.ts";
 //@ts-ignore
 import { ErrorCode, NatsError } from "./error.ts";
 import {
@@ -495,16 +495,13 @@ export class ProtocolHandler extends EventTarget {
     };
 
     this.transport = newTransport();
-    this.transport.addEventListener(
-      TransportEvents.CLOSE,
-      (async (evt: CustomEvent) => {
-        evt.stopPropagation();
+    this.transport.closed()
+      .then(async (err?) => {
         if (this.state !== ParserState.CLOSED) {
           await this.disconnected(this.transport.closeError);
           return;
         }
-      }) as EventListener,
-    );
+      });
 
     return pong;
   }

--- a/nats-base-client/queued_iterator.ts
+++ b/nats-base-client/queued_iterator.ts
@@ -1,0 +1,59 @@
+import { deferred, Deferred } from "./util.ts";
+
+export class QueuedIterator<T> {
+  processed = 0;
+  received = 0; // this is updated by the protocol
+  protected done: boolean = false;
+  private signal: Deferred<void> = deferred<void>();
+  private yields: T[] = [];
+  private err?: Error;
+
+  [Symbol.asyncIterator]() {
+    return this.iterate();
+  }
+
+  push(v: T) {
+    if (this.done) {
+      return;
+    }
+    this.yields.push(v);
+    this.signal.resolve();
+  }
+
+  async *iterate(): AsyncIterableIterator<T> {
+    while (true) {
+      await this.signal;
+      if (this.err) {
+        throw this.err;
+      }
+      while (this.yields.length > 0) {
+        this.processed++;
+        const v = this.yields.shift();
+        yield v!;
+      }
+      if (this.done) {
+        break;
+      } else {
+        this.signal = deferred();
+      }
+    }
+  }
+
+  stop(err?: Error): void {
+    this.err = err;
+    this.done = true;
+    this.signal.resolve();
+  }
+
+  getProcessed(): number {
+    return this.processed;
+  }
+
+  getPending(): number {
+    return this.yields.length;
+  }
+
+  getReceived(): number {
+    return this.received;
+  }
+}

--- a/nats-base-client/transport.ts
+++ b/nats-base-client/transport.ts
@@ -15,10 +15,6 @@
 //@ts-ignore
 import { ConnectionOptions } from "./types.ts";
 
-export const TransportEvents = Object.freeze({
-  CLOSE: "close",
-});
-
 let transportFactory: TransportFactory;
 export function setTransportFactory(fn: TransportFactory): void {
   transportFactory = fn;
@@ -35,7 +31,7 @@ export interface TransportFactory {
   (): Transport;
 }
 
-export interface Transport extends AsyncIterable<Uint8Array>, EventTarget {
+export interface Transport extends AsyncIterable<Uint8Array> {
   readonly isClosed: boolean;
   readonly lang: string;
   readonly version: string;
@@ -53,4 +49,6 @@ export interface Transport extends AsyncIterable<Uint8Array>, EventTarget {
   send(frame: Uint8Array): Promise<void>;
 
   close(err?: Error): Promise<void>;
+
+  closed(): Promise<void | Error>;
 }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -22,6 +22,11 @@ export const Events = Object.freeze({
   UPDATE: "update",
 });
 
+export interface Status {
+  type: string;
+  data: string | ServersChanged;
+}
+
 export const DebugEvents = Object.freeze({
   RECONNECTING: "reconnecting",
 });

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { BufWriter } from "https://deno.land/std/io/mod.ts";
-import { Deferred, deferred } from "https://deno.land/std/async/mod.ts";
+import { BufWriter } from "https://deno.land/std@0.61.0/io/mod.ts";
+import { Deferred, deferred } from "https://deno.land/std@0.61.0/async/mod.ts";
 import Conn = Deno.Conn;
 import {
   ConnectionOptions,

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -15,7 +15,7 @@
 
 import {
   fail,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   connect,
   ErrorCode,

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -84,7 +84,7 @@ Deno.test("auth - sub permissions", async () => {
   const nc = await connect(
     { port: ns.port, user: "derek", pass: "foobar" },
   );
-  nc.status().then((err) => {
+  nc.closed().then((err) => {
     assertErrorCode(err as Error, ErrorCode.PERMISSIONS_VIOLATION);
     lock.unlock();
   });
@@ -108,7 +108,7 @@ Deno.test("auth - pub perm", async () => {
   const nc = await connect(
     { port: ns.port, user: "derek", pass: "foobar" },
   );
-  nc.status().then((err) => {
+  nc.closed().then((err) => {
     assertErrorCode(err as Error, ErrorCode.PERMISSIONS_VIOLATION);
     lock.unlock();
   });

--- a/tests/autounsub_test.ts
+++ b/tests/autounsub_test.ts
@@ -15,7 +15,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 import {
   ErrorCode,

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -105,7 +105,7 @@ Deno.test("basics - subscribe and unsubscribe", async () => {
   assertEquals(nc.protocol.subscriptions.size(), 1);
   let s = nc.protocol.subscriptions.get(1);
   assert(s);
-  assertEquals(s.received, 0);
+  assertEquals(s.getReceived(), 0);
   assertEquals(s.subject, subj);
   assert(s.callback);
   assertEquals(s.max, 1000);
@@ -122,7 +122,7 @@ Deno.test("basics - subscribe and unsubscribe", async () => {
   await nc.flush();
   s = nc.protocol.subscriptions.get(1);
   assert(s);
-  assertEquals(s.received, 1);
+  assertEquals(s.getReceived(), 1);
 
   // verify cleanup
   sub.unsubscribe();

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -373,7 +373,7 @@ Deno.test("basics - close listener is called", async () => {
   const nc = await connect(
     { port: cs.getPort(), reconnect: false },
   );
-  nc.status().then((err) => {
+  nc.closed().then((err) => {
     lock.unlock();
   });
 
@@ -382,7 +382,7 @@ Deno.test("basics - close listener is called", async () => {
   await nc.close();
 });
 
-Deno.test("basics - status returns error", async () => {
+Deno.test("basics - closed returns error", async () => {
   const lock = Lock(1);
   const cs = new TestServer(false, (ca: Connection) => {
     setTimeout(async () => {
@@ -391,7 +391,7 @@ Deno.test("basics - status returns error", async () => {
   });
 
   const nc = await connect({ url: `127.0.0.1:${cs.getPort()}` });
-  await nc.status()
+  await nc.closed()
     .then((v) => {
       assertEquals((v as Error).message, "'here'");
       lock.unlock();

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -363,7 +363,7 @@ Deno.test("basics - request timeout", async () => {
   assert(timedOut);
 });
 
-Deno.test("basics - close listener is called", async () => {
+Deno.test("basics - close promise resolves", async () => {
   const lock = Lock();
   const cs = new TestServer(false, (ca: Connection) => {
     setTimeout(() => {

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -3,7 +3,7 @@ import {
   assertEquals,
   assertThrowsAsync,
   fail,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   connect,
   ErrorCode,

--- a/tests/bench_test.ts
+++ b/tests/bench_test.ts
@@ -17,7 +17,7 @@ import {
   connect,
   Nuid,
 } from "../src/mod.ts";
-import { Lock, NatsServer } from "./helpers/mod.ts";
+import { Lock } from "./helpers/mod.ts";
 
 const u = "nats://demo.nats.io:4222";
 const nuid = new Nuid();

--- a/tests/bench_test.ts
+++ b/tests/bench_test.ts
@@ -54,5 +54,5 @@ Deno.test(`bench - pubonly`, async () => {
     nc.publish(subj);
   }
   await nc.drain();
-  await nc.status();
+  await nc.closed();
 });

--- a/tests/binary_test.ts
+++ b/tests/binary_test.ts
@@ -15,7 +15,7 @@
 
 import {
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   connect,
   Nuid,

--- a/tests/databuffer_test.ts
+++ b/tests/databuffer_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { DataBuffer } from "../nats-base-client/mod.ts";
 
 Deno.test("databuffer - empty", () => {

--- a/tests/disconnect_test.ts
+++ b/tests/disconnect_test.ts
@@ -18,7 +18,7 @@ import { Lock, NatsServer } from "./helpers/mod.ts";
 import { ParserState } from "../nats-base-client/mod.ts";
 import {
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 Deno.test("disconnect - close handler is called on close", async () => {
   const ns = await NatsServer.start();

--- a/tests/disconnect_test.ts
+++ b/tests/disconnect_test.ts
@@ -26,7 +26,7 @@ Deno.test("disconnect - close handler is called on close", async () => {
   let nc = await connect(
     { port: ns.port, reconnect: false },
   );
-  nc.status().then(() => {
+  nc.closed().then(() => {
     lock.unlock();
   });
 
@@ -40,7 +40,7 @@ Deno.test("disconnect - close process inbound ignores", async () => {
   let nc = await connect(
     { port: ns.port, reconnect: false },
   );
-  nc.status().then(() => {
+  nc.closed().then(() => {
     assertEquals(ParserState.CLOSED, nc.protocol.state);
     lock.unlock();
   });

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -122,7 +122,7 @@ Deno.test("drain - subscription drain", async () => {
   assertEquals(c1 + c2, 10000);
   assert(c1 >= 1, "s1 got more than one message");
   assert(c2 >= 1, "s2 got more than one message");
-  assert(s1.isCancelled());
+  assert(s1.isClosed());
   await nc.close();
 });
 
@@ -272,7 +272,7 @@ Deno.test("drain - reject subscribe on draining", async () => {
 Deno.test("drain - reject subscription drain on closed sub", async () => {
   let nc = await connect({ url: u });
   let sub = nc.subscribe("foo");
-  await sub.drain();
+  sub.close();
   const err = await assertThrowsAsync((): Promise<any> => {
     return sub.drain();
   });
@@ -297,19 +297,15 @@ Deno.test("drain - reject subscription drain on closed", async () => {
   assertErrorCode(err, ErrorCode.CONNECTION_CLOSED);
 });
 
-Deno.test("drain - reject subscription drain on draining sub", async () => {
-  let nc = await connect({ url: u });
-  let subj = nuid.next();
-  let sub = nc.subscribe(subj, {
-    callback: async () => {
-      sub.drain();
-      const err = await assertThrowsAsync(() => {
-        return sub.drain();
-      });
-      await nc.close();
-      assertErrorCode(err, ErrorCode.SUB_DRAINING);
-    },
-  });
+Deno.test("drain - multiple sub drain returns same promise", async () => {
+  const nc = await connect({ url: u });
+  const subj = nuid.next();
+  const sub = nc.subscribe(subj);
+  const p1 = sub.drain();
+  const p2 = sub.drain();
+  assertEquals(p1, p2);
   nc.publish(subj);
   await nc.flush();
+  await p1;
+  await nc.close();
 });

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -19,7 +19,7 @@ import {
   assertThrows,
   assertThrowsAsync,
   fail,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { connect, ErrorCode, Nuid, Msg } from "../src/mod.ts";
 
 import { assertErrorCode, Lock } from "./helpers/mod.ts";

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -11,7 +11,7 @@ Deno.test("events - close on close", async () => {
     { port: ns.port },
   );
   nc.close();
-  const status = await nc.status();
+  const status = await nc.closed();
   await ns.stop();
   assertEquals(status, undefined);
 });
@@ -25,13 +25,13 @@ Deno.test("events - disconnect and close", async () => {
   nc.addEventListener(Events.DISCONNECT, () => {
     lock.unlock();
   });
-  nc.status().then(() => {
+  nc.closed().then(() => {
     lock.unlock();
   });
   await ns.stop();
   await lock;
 
-  const v = await nc.status();
+  const v = await nc.closed();
 
   assertEquals(v, undefined);
 });

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -2,7 +2,7 @@ import { NatsServer, Lock } from "../tests/helpers/mod.ts";
 import { connect, Events, ServersChanged } from "../src/mod.ts";
 import {
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 Deno.test("events - close on close", async () => {
   const ns = await NatsServer.start();

--- a/tests/helpers/asserts.ts
+++ b/tests/helpers/asserts.ts
@@ -1,4 +1,4 @@
-import { AssertionError } from "https://deno.land/std/testing/asserts.ts";
+import { AssertionError } from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { NatsError } from "../../src/mod.ts";
 
 export function assertErrorCode(err: Error, ...code: string[]) {

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -1,7 +1,7 @@
 import {
   NatsServer,
 } from "./mod.ts";
-import { parse } from "https://deno.land/std/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.61.0/flags/mod.ts";
 
 const defaults = {
   c: 2,

--- a/tests/helpers/conf_test.ts
+++ b/tests/helpers/conf_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { toConf } from "./launcher.ts";
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 Deno.test("conf - serializing simple", () => {
   let x = {

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -1,4 +1,4 @@
-import * as path from "https://deno.land/std/path/mod.ts";
+import * as path from "https://deno.land/std@0.61.0/path/mod.ts";
 import { check } from "./mod.ts";
 
 export interface PortInfo {

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -86,7 +86,7 @@ Deno.test("iterators - permission error breaks and closes", async () => {
   });
 
   await lock;
-  await nc.status().then((err) => {
+  await nc.closed().then((err) => {
     assertErrorCode(err as NatsError, ErrorCode.PERMISSIONS_VIOLATION);
   });
   await nc.close();

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -28,7 +28,7 @@ Deno.test("iterators - return breaks and closes", async () => {
   const sub = nc.subscribe(subj);
   const done = (async () => {
     for await (const m of sub) {
-      if (sub.received > 1) {
+      if (sub.getReceived() > 1) {
         sub.return();
       }
     }
@@ -36,7 +36,7 @@ Deno.test("iterators - return breaks and closes", async () => {
   nc.publish(subj);
   nc.publish(subj);
   await done;
-  assertEquals(sub.received, 2);
+  assertEquals(sub.getReceived(), 2);
   await nc.close();
 });
 
@@ -54,7 +54,7 @@ Deno.test("iterators - autounsub breaks and closes", async () => {
   nc.publish(subj);
   await done;
   await lock;
-  assertEquals(sub.received, 2);
+  assertEquals(sub.getReceived(), 2);
   await nc.close();
 });
 

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -16,7 +16,7 @@ import { connect } from "../src/connect.ts";
 import { ErrorCode, NatsError, Nuid } from "../nats-base-client/mod.ts";
 import {
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 
 const u = "demo.nats.io:4222";

--- a/tests/json_test.ts
+++ b/tests/json_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "https://deno.land/std/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   connect,
   ErrorCode,

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -16,7 +16,7 @@ import {
   assertEquals,
   assertMatch,
   assert,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 import { connect } from "../src/mod.ts";
 import { DenoTransport } from "../src/deno_transport.ts";

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -117,7 +117,6 @@ Deno.test("protocol - subs all", () => {
   const subs = new Subscriptions();
   const s = new Subscription({} as ProtocolHandler, "hello");
   s.timeout = 1;
-  s.received = 0;
   subs.add(s);
   assertEquals(subs.size(), 1);
   assertEquals(s.sid, 1);

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -26,7 +26,7 @@ import { Lock } from "./helpers/mod.ts";
 import {
   assertEquals,
   equal,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   MuxSubscription,
   Subscriptions,

--- a/tests/queues_test.ts
+++ b/tests/queues_test.ts
@@ -19,8 +19,7 @@ import {
 } from "../src/mod.ts";
 import {
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
-import { Lock } from "./helpers/mod.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 const u = "demo.nats.io:4222";
 const nuid = new Nuid();

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -71,7 +71,7 @@ Deno.test("reconnect - events", async () => {
   });
   await srv.stop();
   try {
-    await nc.status();
+    await nc.closed();
   } catch (err) {
     assertErrorCode(err, ErrorCode.CONNECTION_REFUSED);
   }
@@ -96,7 +96,7 @@ Deno.test("reconnect - reconnect not emitted if suppressed", async () => {
   });
 
   await srv.stop();
-  await nc.status();
+  await nc.closed();
 });
 
 Deno.test("reconnect - reconnecting after proper delay", async () => {
@@ -115,7 +115,7 @@ Deno.test("reconnect - reconnecting after proper delay", async () => {
     assert(elapsed >= 500 && elapsed <= 600);
   });
 
-  await nc.status();
+  await nc.closed();
 });
 
 Deno.test("reconnect - indefinite reconnects", async () => {
@@ -151,7 +151,7 @@ Deno.test("reconnect - indefinite reconnects", async () => {
     lock.unlock();
   }, 1000);
 
-  await nc.status();
+  await nc.closed();
   await srv.stop();
   await lock;
   await srv.stop();
@@ -183,8 +183,8 @@ Deno.test("reconnect - jitter", async () => {
   });
 
   await srv.stop();
-  await nc.status();
-  await dc.status();
+  await nc.closed();
+  await dc.closed();
   assert(called);
   assert(hasDefaultFn);
 });

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -61,14 +61,20 @@ Deno.test("reconnect - events", async () => {
   });
 
   let disconnects = 0;
-  nc.addEventListener(Events.DISCONNECT, () => {
-    disconnects++;
-  });
-
   let reconnecting = 0;
-  nc.addEventListener(DebugEvents.RECONNECTING, () => {
-    reconnecting++;
-  });
+
+  (async () => {
+    for await (const e of nc.status()) {
+      switch (e.type) {
+        case Events.DISCONNECT:
+          disconnects++;
+          break;
+        case DebugEvents.RECONNECTING:
+          reconnecting++;
+          break;
+      }
+    }
+  })().then();
   await srv.stop();
   try {
     await nc.closed();
@@ -87,13 +93,18 @@ Deno.test("reconnect - reconnect not emitted if suppressed", async () => {
   });
 
   let disconnects = 0;
-  nc.addEventListener(Events.DISCONNECT, () => {
-    disconnects++;
-  });
-
-  nc.addEventListener(DebugEvents.RECONNECTING, () => {
-    fail("shouldn't have emitted reconnecting");
-  });
+  (async () => {
+    for await (const e of nc.status()) {
+      switch (e.type) {
+        case Events.DISCONNECT:
+          disconnects++;
+          break;
+        case DebugEvents.RECONNECTING:
+          fail("shouldn't have emitted reconnecting");
+          break;
+      }
+    }
+  })().then();
 
   await srv.stop();
   await nc.closed();
@@ -108,13 +119,18 @@ Deno.test("reconnect - reconnecting after proper delay", async () => {
   });
   // @ts-ignore
   const serverLastConnect = nc.protocol.servers.getCurrentServer().lastConnect;
+
+  (async () => {
+    for await (const e of nc.status()) {
+      switch (e.type) {
+        case DebugEvents.RECONNECTING:
+          const elapsed = Date.now() - serverLastConnect;
+          assert(elapsed >= 500 && elapsed <= 600);
+          break;
+      }
+    }
+  })().then();
   await srv.stop();
-
-  nc.addEventListener(DebugEvents.RECONNECTING, () => {
-    const elapsed = Date.now() - serverLastConnect;
-    assert(elapsed >= 500 && elapsed <= 600);
-  });
-
   await nc.closed();
 });
 
@@ -128,20 +144,24 @@ Deno.test("reconnect - indefinite reconnects", async () => {
   });
 
   let disconnects = 0;
-  nc.addEventListener(Events.DISCONNECT, () => {
-    disconnects++;
-  });
-
   let reconnects = 0;
-  nc.addEventListener(DebugEvents.RECONNECTING, () => {
-    reconnects++;
-  });
-
   let reconnect = false;
-  nc.addEventListener(Events.RECONNECT, () => {
-    reconnect = true;
-    nc.close();
-  });
+  (async () => {
+    for await (const e of nc.status()) {
+      switch (e.type) {
+        case Events.DISCONNECT:
+          disconnects++;
+          break;
+        case Events.RECONNECT:
+          reconnect = true;
+          nc.close();
+          break;
+        case DebugEvents.RECONNECTING:
+          reconnects++;
+          break;
+      }
+    }
+  })().then();
 
   await srv.stop();
 

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -17,7 +17,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   connect,
   ErrorCode,

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -1,8 +1,22 @@
-import { Server, Servers } from "../nats-base-client/servers.ts";
+/*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { Servers } from "../nats-base-client/servers.ts";
 import {
   assertEquals,
-  assert,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { ServerInfo } from "../nats-base-client/types.ts";
 
 Deno.test("servers - single", () => {

--- a/tests/token_test.ts
+++ b/tests/token_test.ts
@@ -30,7 +30,7 @@ Deno.test("token empty", async () => {
     const nc = await connect(
       { port: ns.port, reconnect: false },
     );
-    nc.status().then((err) => {
+    nc.closed().then((err) => {
       console.table(err);
     });
     await nc.close();

--- a/tests/token_test.ts
+++ b/tests/token_test.ts
@@ -14,7 +14,7 @@
  */
 import {
   fail,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { connect } from "../src/mod.ts";
 import {
   assertErrorCode,

--- a/tests/types_test.ts
+++ b/tests/types_test.ts
@@ -24,7 +24,7 @@ import { DataBuffer } from "../nats-base-client/mod.ts";
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std/testing/asserts.ts";
+} from "https://deno.land/std@0.61.0/testing/asserts.ts";
 
 const u = "demo.nats.io:4222";
 


### PR DESCRIPTION
On Safari, EventTarget is not available, so removed usage of EventTarget APIs. Now lifecycle events are async iterators, eliminating callbacks patterns. 