### PR TITLE
[chore] - cleanup exports, tests, etc.

### DIFF
--- a/nats-base-client/authenticator.ts
+++ b/nats-base-client/authenticator.ts
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {
   fromSeed,
   encode,

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -1,0 +1,56 @@
+export { NatsConnection } from "./nats.ts";
+export { Nuid } from "./nuid.ts";
+export { ErrorCode, NatsError } from "./error.ts";
+export {
+  Events,
+  DebugEvents,
+  Status,
+  ConnectionOptions,
+  Msg,
+  Payload,
+  ServersChanged,
+  SubscriptionOptions,
+  Subscription,
+  ServerInfo,
+} from "./types.ts";
+export {
+  SubscriptionImpl,
+} from "./subscription.ts";
+export {
+  Subscriptions,
+} from "./subscriptions.ts";
+export {
+  Transport,
+  setTransportFactory,
+} from "./transport.ts";
+export {
+  Connect,
+  ParserState,
+  ProtocolHandler,
+  INFO,
+  createInbox,
+} from "./protocol.ts";
+export {
+  render,
+  extractProtocolMessage,
+  Timeout,
+  delay,
+  Deferred,
+  deferred,
+  timeout,
+} from "./util.ts";
+export {
+  NatsHeaders,
+  MsgHdrs,
+  headers,
+} from "./headers.ts";
+export { MuxSubscription } from "./muxsubscription.ts";
+export { DataBuffer } from "./databuffer.ts";
+export { checkOptions } from "./options.ts";
+export { Request } from "./request.ts";
+export {
+  Authenticator,
+  nkeyAuthenticator,
+  jwtAuthenticator,
+  credsAuthenticator,
+} from "./authenticator.ts";

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -1,48 +1,20 @@
-export { NatsConnection } from "./nats.ts";
-export { Nuid } from "./nuid.ts";
-export { ErrorCode, NatsError } from "./error.ts";
-export {
-  Events,
-  Status,
-  ConnectionOptions,
-  Msg,
-  Payload,
-  ServersChanged,
-  SubscriptionOptions,
-  Subscription,
-} from "./types.ts";
-export {
-  Transport,
-  setTransportFactory,
-} from "./transport.ts";
-export {
-  Connect,
-  MuxSubscription,
-  ParserState,
-  ProtocolHandler,
-  SubscriptionImpl,
-  Request,
-} from "./protocol.ts";
-export {
-  render,
-  extractProtocolMessage,
-  INFO,
-  Timeout,
-  delay,
-  Deferred,
-  deferred,
-} from "./util.ts";
-export {
-  NatsHeaders,
-  MsgHdrs,
-  headers,
-} from "./headers.ts";
-export { DataBuffer } from "./databuffer.ts";
-export { checkOptions } from "./options.ts";
-
 export {
   Authenticator,
-  nkeyAuthenticator,
-  jwtAuthenticator,
+  ConnectionOptions,
+  createInbox,
   credsAuthenticator,
-} from "./authenticator.ts";
+  ErrorCode,
+  Events,
+  headers,
+  jwtAuthenticator,
+  Msg,
+  NatsConnection,
+  NatsError,
+  NatsHeaders,
+  nkeyAuthenticator,
+  Payload,
+  ServersChanged,
+  Status,
+  Subscription,
+  SubscriptionOptions,
+} from "./internal_mod.ts";

--- a/nats-base-client/msgImpl.ts
+++ b/nats-base-client/msgImpl.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Msg } from "./types.ts";
+import { MsgHdrs } from "./headers.ts";
+import { Publisher } from "./protocol.ts";
+
+export class MsgImpl implements Msg {
+  publisher: Publisher;
+  subject!: string;
+  sid!: number;
+  reply?: string;
+  data?: any;
+  headers?: MsgHdrs;
+
+  constructor(publisher: Publisher) {
+    this.publisher = publisher;
+  }
+
+  // eslint-ignore-next-line @typescript-eslint/no-explicit-any
+  respond(data?: any, headers?: MsgHdrs): boolean {
+    if (this.reply) {
+      this.publisher.publish(this.reply, data, { headers: headers });
+      return true;
+    }
+    return false;
+  }
+}

--- a/nats-base-client/msgbuffer.ts
+++ b/nats-base-client/msgbuffer.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Msg, Payload } from "./types.ts";
+import { ErrorCode, NatsError } from "./error.ts";
+import { MsgImpl } from "./msgImpl.ts";
+import { CR_LF_LEN } from "./util.ts";
+import { DataBuffer } from "./databuffer.ts";
+import { NatsHeaders } from "./headers.ts";
+import { Publisher } from "./protocol.ts";
+
+export class MsgBuffer {
+  msg: Msg;
+  length: number;
+  headerLen: number;
+  buf?: Uint8Array | null;
+  payload: string;
+  err: NatsError | null = null;
+  status: number = 0;
+
+  constructor(
+    publisher: Publisher,
+    chunks: RegExpExecArray,
+    payload: "string" | "json" | "binary" = "string",
+  ) {
+    this.msg = new MsgImpl(publisher);
+    this.msg.subject = chunks[1];
+    this.msg.sid = parseInt(chunks[2], 10);
+    this.msg.reply = chunks[4];
+    this.length =
+      (chunks.length === 7
+        ? parseInt(chunks[6], 10)
+        : parseInt(chunks[5], 10)) + CR_LF_LEN;
+    this.headerLen = (chunks.length === 7 ? parseInt(chunks[5], 10) : 0);
+
+    this.payload = payload;
+  }
+
+  fill(data: Uint8Array) {
+    if (!this.buf) {
+      this.buf = data;
+    } else {
+      this.buf = DataBuffer.concat(this.buf, data);
+    }
+    this.length -= data.length;
+
+    if (this.length === 0) {
+      const headers = this.headerLen
+        ? this.buf.slice(0, this.headerLen)
+        : undefined;
+      if (headers) {
+        this.msg.headers = NatsHeaders.decode(headers);
+      }
+      this.msg.data = this.buf.slice(this.headerLen, this.buf.length - 2);
+
+      switch (this.payload) {
+        case Payload.JSON:
+          this.msg.data = new TextDecoder("utf-8").decode(this.msg.data);
+          try {
+            this.msg.data = JSON.parse(this.msg.data);
+          } catch (err) {
+            this.err = NatsError.errorForCode(ErrorCode.BAD_JSON, err);
+          }
+          break;
+        case Payload.STRING:
+          this.msg.data = new TextDecoder("utf-8").decode(this.msg.data);
+          break;
+        case Payload.BINARY:
+          break;
+      }
+      this.buf = null;
+    }
+  }
+}

--- a/nats-base-client/muxsubscription.ts
+++ b/nats-base-client/muxsubscription.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Request } from "./request.ts";
+import { Msg } from "./types.ts";
+import { ErrorCode, NatsError } from "./error.ts";
+import { NatsHeaders } from "./headers.ts";
+import { createInbox } from "./protocol.ts";
+
+export class MuxSubscription {
+  baseInbox!: string;
+  reqs: Map<string, Request> = new Map<string, Request>();
+
+  size(): number {
+    return this.reqs.size;
+  }
+
+  init(): string {
+    this.baseInbox = `${createInbox()}.`;
+    return this.baseInbox;
+  }
+
+  add(r: Request) {
+    if (!isNaN(r.received)) {
+      r.received = 0;
+    }
+    this.reqs.set(r.token, r);
+  }
+
+  get(token: string): Request | undefined {
+    return this.reqs.get(token);
+  }
+
+  cancel(r: Request): void {
+    this.reqs.delete(r.token);
+  }
+
+  getToken(m: Msg): string | null {
+    let s = m.subject || "";
+    if (s.indexOf(this.baseInbox) === 0) {
+      return s.substring(this.baseInbox.length);
+    }
+    return null;
+  }
+
+  dispatcher() {
+    return (err: NatsError | null, m: Msg) => {
+      let token = this.getToken(m);
+      if (token) {
+        let r = this.get(token);
+        if (r) {
+          if (err === null && m.headers) {
+            const headers = m.headers as NatsHeaders;
+            if (headers.error) {
+              err = new NatsError(
+                headers.error.toString(),
+                ErrorCode.REQUEST_ERROR,
+              );
+            }
+          }
+          r.resolver(err, m);
+        }
+      }
+    };
+  }
+
+  close() {
+    const err = NatsError.errorForCode(ErrorCode.TIMEOUT);
+    this.reqs.forEach((req) => {
+      req.resolver(err, {} as Msg);
+    });
+  }
+}

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -23,16 +23,17 @@ import {
 } from "./mod.ts";
 import {
   ProtocolHandler,
-  Request,
-  RequestOptions,
-  SubscriptionImpl,
 } from "./protocol.ts";
+import {
+  SubscriptionImpl,
+} from "./subscription.ts";
 import { ErrorCode, NatsError } from "./error.ts";
 import { Nuid } from "./nuid.ts";
-import { Subscription } from "./types.ts";
+import { Subscription, RequestOptions } from "./types.ts";
 import { parseOptions } from "./options.ts";
 import { QueuedIterator } from "./queued_iterator.ts";
 import { MsgHdrs } from "./headers.ts";
+import { Request } from "./request.ts";
 
 export const nuid = new Nuid();
 

--- a/nats-base-client/request.ts
+++ b/nats-base-client/request.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Deferred, deferred, extend, timeout, Timeout } from "./util.ts";
+import { Msg, RequestOptions } from "./types.ts";
+import { ErrorCode, NatsError } from "./error.ts";
+import { MuxSubscription } from "./muxsubscription.ts";
+import { nuid } from "./nats.ts";
+
+export class Request {
+  token: string;
+  received: number = 0;
+  deferred: Deferred<Msg> = deferred();
+  timer: Timeout<Msg>;
+  private mux: MuxSubscription;
+
+  constructor(
+    mux: MuxSubscription,
+    opts: RequestOptions = { timeout: 1000 },
+  ) {
+    this.mux = mux;
+    this.token = nuid.next();
+    extend(this, opts);
+    this.timer = timeout<Msg>(opts.timeout);
+  }
+
+  resolver(err: Error | null, msg: Msg): void {
+    if (this.timer) {
+      this.timer.cancel();
+    }
+    if (err) {
+      this.deferred.reject(err);
+    } else {
+      this.deferred.resolve(msg);
+    }
+    this.cancel();
+  }
+
+  cancel(): void {
+    if (this.timer) {
+      this.timer.cancel();
+    }
+    this.mux.cancel(this);
+    this.deferred.reject(NatsError.errorForCode(ErrorCode.CANCELLED));
+  }
+}

--- a/nats-base-client/subscription.ts
+++ b/nats-base-client/subscription.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueuedIterator } from "./queued_iterator.ts";
+import { Base, Msg, Subscription, SubscriptionOptions } from "./types.ts";
+import { deferred, extend, timeout, Timeout } from "./util.ts";
+import { ErrorCode, NatsError } from "./error.ts";
+import { ProtocolHandler } from "./protocol.ts";
+
+export class SubscriptionImpl extends QueuedIterator<Msg>
+  implements Base, Subscription {
+  sid!: number;
+  queue?: string;
+  draining: boolean = false;
+  max?: number;
+  subject: string;
+  drained?: Promise<void>;
+  protocol: ProtocolHandler;
+  timer?: Timeout<void>;
+
+  constructor(
+    protocol: ProtocolHandler,
+    subject: string,
+    opts: SubscriptionOptions = {},
+  ) {
+    super();
+    extend(this, opts);
+    this.protocol = protocol;
+    this.subject = subject;
+    if (opts.timeout) {
+      this.timer = timeout<void>(opts.timeout);
+      this.timer
+        .then(() => {
+          // timer was cancelled
+          this.timer = undefined;
+        })
+        .catch((err) => {
+          // timer fired
+          this.stop(err);
+        });
+    }
+  }
+
+  callback(err: NatsError | null, msg: Msg) {
+    this.cancelTimeout();
+    err ? this.stop(err) : this.push(msg);
+  }
+
+  close(): void {
+    if (!this.isClosed()) {
+      this.cancelTimeout();
+      this.stop();
+    }
+  }
+
+  unsubscribe(max?: number): void {
+    this.protocol.unsubscribe(this, max);
+  }
+
+  cancelTimeout(): void {
+    if (this.timer) {
+      this.timer.cancel();
+      this.timer = undefined;
+    }
+  }
+
+  drain(): Promise<void> {
+    if (this.protocol.isClosed()) {
+      throw NatsError.errorForCode(ErrorCode.CONNECTION_CLOSED);
+    }
+    if (this.isClosed()) {
+      throw NatsError.errorForCode(ErrorCode.SUB_CLOSED);
+    }
+    if (!this.drained) {
+      this.protocol.unsub(this);
+      this.drained = this.protocol.flush(deferred<void>());
+      this.drained.then(() => {
+        this.protocol.subscriptions.cancel(this);
+      });
+    }
+    return this.drained;
+  }
+
+  isDraining(): boolean {
+    return this.draining;
+  }
+
+  isClosed(): boolean {
+    return this.done;
+  }
+
+  getSubject(): string {
+    return this.subject;
+  }
+
+  getMax(): number | undefined {
+    return this.max;
+  }
+
+  getID(): number {
+    return this.sid;
+  }
+}

--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SubscriptionImpl } from "./subscription.ts";
+import { NatsError } from "./error.ts";
+import { Msg } from "./types.ts";
+
+export class Subscriptions {
+  mux!: SubscriptionImpl;
+  subs: Map<number, SubscriptionImpl> = new Map<number, SubscriptionImpl>();
+  sidCounter: number = 0;
+
+  size(): number {
+    return this.subs.size;
+  }
+
+  add(s: SubscriptionImpl): SubscriptionImpl {
+    this.sidCounter++;
+    s.sid = this.sidCounter;
+    this.subs.set(s.sid, s as SubscriptionImpl);
+    return s;
+  }
+
+  setMux(s: SubscriptionImpl): SubscriptionImpl {
+    this.mux = s;
+    return s;
+  }
+
+  getMux(): SubscriptionImpl | null {
+    return this.mux;
+  }
+
+  get(sid: number): (SubscriptionImpl | undefined) {
+    return this.subs.get(sid);
+  }
+
+  all(): (SubscriptionImpl)[] {
+    let buf = [];
+    for (let s of this.subs.values()) {
+      buf.push(s);
+    }
+    return buf;
+  }
+
+  cancel(s: SubscriptionImpl): void {
+    if (s) {
+      s.close();
+      this.subs.delete(s.sid);
+    }
+  }
+
+  handleError(err?: NatsError) {
+    if (err) {
+      const re = /^'Permissions Violation for Subscription to "(\S+)"'/i;
+      const ma = re.exec(err.message);
+      if (ma) {
+        const subj = ma[1];
+        this.subs.forEach((sub) => {
+          if (subj == sub.subject) {
+            sub.callback(err, {} as Msg);
+            sub.close();
+          }
+        });
+      }
+    }
+  }
+
+  close() {
+    this.subs.forEach((sub) => {
+      sub.close();
+    });
+  }
+}

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -156,3 +156,7 @@ export interface Subscription extends AsyncIterable<Msg> {
   getID(): number;
   getMax(): number | undefined;
 }
+
+export interface RequestOptions {
+  timeout: number;
+}

--- a/nats-base-client/util.ts
+++ b/nats-base-client/util.ts
@@ -16,16 +16,6 @@
 import { DataBuffer } from "./databuffer.ts";
 import { ErrorCode, NatsError } from "./mod.ts";
 
-export const MSG =
-  /^MSG\s+([^\s\r\n]+)\s+([^\s\r\n]+)\s+(([^\s\r\n]+)[^\S\r\n]+)?(\d+)\r\n/i;
-export const HMSG =
-  /^HMSG\s+([^\s\r\n]+)\s+([^\s\r\n]+)\s+(([^\s\r\n]+)[^\S\r\n]+)?(\d+)\s+(\d+)\r\n/i;
-export const OK = /^\+OK\s*\r\n/i;
-export const ERR = /^-ERR\s+('.+')?\r\n/i;
-export const PING = /^PING\r\n/i;
-export const PONG = /^PONG\r\n/i;
-export const INFO = /^INFO\s+([^\r\n]+)\r\n/i;
-
 export const CR_LF = "\r\n";
 export const CR_LF_LEN = CR_LF.length;
 export const CRLF = DataBuffer.fromAscii(CR_LF);

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -4,7 +4,7 @@ import {
   ConnectionOptions,
   setTransportFactory,
   Transport,
-} from "../nats-base-client/mod.ts";
+} from "../nats-base-client/internal_mod.ts";
 
 export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
   setTransportFactory((): Transport => {

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -24,7 +24,7 @@ import {
   render,
   Transport,
   checkOptions,
-} from "../nats-base-client/mod.ts";
+} from "../nats-base-client/internal_mod.ts";
 
 const VERSION = "0.0.1";
 const LANG = "nats.deno";
@@ -95,7 +95,7 @@ export class DenoTransport implements Transport {
     while (true) {
       let c = await this.conn.read(this.buf);
       if (c) {
-        if (null === c) {
+        if (c === null) {
           // EOF
           return Promise.reject(
             new Error("socket closed while expecting INFO"),

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,13 +1,2 @@
-export {
-  ConnectionOptions,
-  ErrorCode,
-  Msg,
-  NatsConnection,
-  NatsError,
-  Nuid,
-  Payload,
-  ServersChanged,
-  Subscription,
-  Events,
-} from "../nats-base-client/mod.ts";
 export { connect } from "./connect.ts";
+export * from "../nats-base-client/mod.ts";

--- a/tests/bench_test.ts
+++ b/tests/bench_test.ts
@@ -15,18 +15,17 @@
 
 import {
   connect,
-  Nuid,
+  createInbox,
 } from "../src/mod.ts";
 import { Lock } from "./helpers/mod.ts";
 
 const u = "nats://demo.nats.io:4222";
-const nuid = new Nuid();
 
 let max = 1000;
 Deno.test(`bench - pubsub`, async () => {
   const lock = Lock(max, 30000);
   const nc = await connect({ url: u });
-  const subj = nuid.next();
+  const subj = createInbox();
   nc.subscribe(subj, {
     callback: () => {
       lock.unlock();
@@ -48,7 +47,7 @@ Deno.test(`bench - pubsub`, async () => {
 
 Deno.test(`bench - pubonly`, async () => {
   const nc = await connect({ url: u });
-  const subj = nuid.next();
+  const subj = createInbox();
 
   for (let i = 0; i < max; i++) {
     nc.publish(subj);

--- a/tests/databuffer_test.ts
+++ b/tests/databuffer_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { assertEquals } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { DataBuffer } from "../nats-base-client/mod.ts";
+import { DataBuffer } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("databuffer - empty", () => {
   let buf = new DataBuffer();

--- a/tests/disconnect_test.ts
+++ b/tests/disconnect_test.ts
@@ -15,7 +15,7 @@
 
 import { connect } from "../src/mod.ts";
 import { Lock, NatsServer } from "./helpers/mod.ts";
-import { ParserState } from "../nats-base-client/mod.ts";
+import { ParserState } from "../nats-base-client/internal_mod.ts";
 import {
   assertEquals,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -20,13 +20,17 @@ import {
   assertThrowsAsync,
   fail,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { connect, ErrorCode, Nuid, Msg } from "../src/mod.ts";
+import {
+  connect,
+  createInbox,
+  ErrorCode,
+  Msg,
+} from "../src/mod.ts";
 
 import { assertErrorCode, Lock } from "./helpers/mod.ts";
-import { deferred } from "../nats-base-client/util.ts";
+import { deferred } from "../nats-base-client/internal_mod.ts";
 
 const u = "demo.nats.io:4222";
-const nuid = new Nuid();
 
 Deno.test("drain - connection drains when no subs", async () => {
   let nc = await connect({ url: u });
@@ -37,7 +41,7 @@ Deno.test("drain - connection drains when no subs", async () => {
 Deno.test("drain - connection drain", async () => {
   const max = 1000;
   const lock = Lock(max);
-  const subj = nuid.next();
+  const subj = createInbox();
 
   const nc1 = await connect({ url: u });
   let first = true;
@@ -85,7 +89,7 @@ Deno.test("drain - connection drain", async () => {
 Deno.test("drain - subscription drain", async () => {
   let lock = Lock();
   let nc = await connect({ url: u });
-  let subj = nuid.next();
+  let subj = createInbox();
   let c1 = 0;
   let s1 = nc.subscribe(subj, {
     callback: () => {
@@ -128,7 +132,7 @@ Deno.test("drain - subscription drain", async () => {
 
 Deno.test("drain - publisher drain", async () => {
   const lock = Lock();
-  const subj = nuid.next();
+  const subj = createInbox();
 
   const nc1 = await connect({ url: u });
   let c1 = 0;
@@ -180,7 +184,7 @@ Deno.test("drain - publisher drain", async () => {
 });
 
 Deno.test("drain - publish after drain fails", async () => {
-  const subj = nuid.next();
+  const subj = createInbox();
   const nc = await connect({ url: u });
   nc.subscribe(subj);
   await nc.drain();
@@ -197,7 +201,7 @@ Deno.test("drain - publish after drain fails", async () => {
 
 Deno.test("drain - reject reqrep during connection drain", async () => {
   let lock = Lock();
-  let subj = nuid.next();
+  let subj = createInbox();
   // start a service for replies
   let nc1 = await connect({ url: u });
   await nc1.subscribe(subj, {
@@ -299,7 +303,7 @@ Deno.test("drain - reject subscription drain on closed", async () => {
 
 Deno.test("drain - multiple sub drain returns same promise", async () => {
   const nc = await connect({ url: u });
-  const subj = nuid.next();
+  const subj = createInbox();
   const sub = nc.subscribe(subj);
   const p1 = sub.drain();
   const p2 = sub.drain();

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -1,10 +1,9 @@
-import { NatsServer, Lock } from "../tests/helpers/mod.ts";
+import { NatsServer, Lock, ServerSignals } from "../tests/helpers/mod.ts";
 import { connect, Events, ServersChanged } from "../src/mod.ts";
 import {
   assertEquals,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { ServerSignals } from "./helpers/launcher.ts";
-import { delay } from "../nats-base-client/mod.ts";
+import { delay } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("events - close on close", async () => {
   const ns = await NatsServer.start();

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -1,15 +1,12 @@
-import { connect } from "../src/connect.ts";
+import { connect, ErrorCode, headers } from "../src/mod.ts";
 import { NatsServer } from "./helpers/launcher.ts";
-import { Lock } from "./helpers/lock.ts";
+import { Lock, assertErrorCode } from "./helpers/mod.ts";
 import {
   assertEquals,
   assertArrayContains,
   assert,
   fail,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { assertErrorCode } from "./helpers/mod.ts";
-import { ErrorCode } from "../src/mod.ts";
-import { headers, NatsHeaders } from "../nats-base-client/headers.ts";
 
 Deno.test("headers - option", async () => {
   const srv = await NatsServer.start();

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -1,8 +1,13 @@
 import * as path from "https://deno.land/std@0.61.0/path/mod.ts";
 import { check } from "./mod.ts";
-import { deferred, delay } from "../../nats-base-client/mod.ts";
-import { timeout } from "../../nats-base-client/util.ts";
-import { nuid } from "../../nats-base-client/nats.ts";
+import {
+  deferred,
+  delay,
+  timeout,
+  Nuid,
+} from "../../nats-base-client/internal_mod.ts";
+
+const nuid = new Nuid();
 
 export const ServerSignals = Object.freeze({
   QUIT: Deno.Signal.SIGQUIT,

--- a/tests/helpers/mod.ts
+++ b/tests/helpers/mod.ts
@@ -2,4 +2,4 @@ export { check } from "./delay.ts";
 export { Lock } from "./lock.ts";
 export { TestServer, Connection } from "./test_server.ts";
 export { assertErrorCode } from "./asserts.ts";
-export { NatsServer } from "./launcher.ts";
+export { NatsServer, ServerSignals } from "./launcher.ts";

--- a/tests/helpers/util.ts
+++ b/tests/helpers/util.ts
@@ -1,0 +1,23 @@
+import {
+  deferred,
+  Msg,
+  Subscription,
+  timeout,
+} from "../../nats-base-client/internal_mod.ts";
+
+export function consume(sub: Subscription, ms: number = 1000): Promise<Msg[]> {
+  const to = timeout<Msg[]>(ms);
+  const d = deferred<Msg[]>();
+  const msgs: Msg[] = [];
+  (async () => {
+    for await (const m of sub) {
+      msgs.push(m);
+    }
+    to.cancel();
+    d.resolve(msgs);
+  })().catch((err) => {
+    d.reject(err);
+  });
+
+  return Promise.race([to, d]);
+}

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -12,19 +12,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { connect } from "../src/connect.ts";
-import { ErrorCode, NatsError, Nuid } from "../nats-base-client/mod.ts";
+import { connect, createInbox, ErrorCode, NatsError } from "../src/mod.ts";
 import {
   assertEquals,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 
 const u = "demo.nats.io:4222";
-const nuid = new Nuid();
 
 Deno.test("iterators - unsubscribe breaks and closes", async () => {
   const nc = await connect({ url: u });
-  const subj = nuid.next();
+  const subj = createInbox();
   const sub = nc.subscribe(subj);
   const done = (async () => {
     for await (const m of sub) {
@@ -42,7 +40,7 @@ Deno.test("iterators - unsubscribe breaks and closes", async () => {
 
 Deno.test("iterators - autounsub breaks and closes", async () => {
   const nc = await connect({ url: u });
-  const subj = nuid.next();
+  const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 2 });
   const lock = Lock(2);
   const done = (async () => {
@@ -97,7 +95,7 @@ Deno.test("iterators - unsubscribing closes", async () => {
   const nc = await connect(
     { url: u },
   );
-  const subj = nuid.next();
+  const subj = createInbox();
   const sub = nc.subscribe(subj);
   const lock = Lock();
   const done = (async () => {
@@ -116,7 +114,7 @@ Deno.test("iterators - connection close closes", async () => {
   const nc = await connect(
     { url: u },
   );
-  const subj = nuid.next();
+  const subj = createInbox();
   const sub = nc.subscribe(subj);
   const lock = Lock();
   const done = (async () => {

--- a/tests/json_test.ts
+++ b/tests/json_test.ts
@@ -16,17 +16,16 @@
 import { assertEquals } from "https://deno.land/std@0.61.0/testing/asserts.ts";
 import {
   connect,
+  createInbox,
   ErrorCode,
   Msg,
   NatsError,
-  Nuid,
   Payload,
 } from "../src/mod.ts";
 
 import { Lock } from "./helpers/mod.ts";
 
 const u = "demo.nats.io:4222";
-const nuid = new Nuid();
 
 Deno.test("json - connect no json propagates options", async () => {
   let nc = await connect({ url: u });
@@ -66,7 +65,7 @@ function macro(input: any) {
   return async () => {
     const nc = await connect({ url: u, payload: Payload.JSON });
     let lock = Lock();
-    let subj = nuid.next();
+    let subj = createInbox();
     nc.subscribe(subj, {
       callback: (err: NatsError | null, msg: Msg) => {
         assertEquals(null, err);

--- a/tests/msgheaders_test.ts
+++ b/tests/msgheaders_test.ts
@@ -12,14 +12,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NatsHeaders } from "../nats-base-client/headers.ts";
 import {
   assert,
   assertEquals,
   assertThrows,
   assertArrayContains,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { NatsError } from "../src/mod.ts";
+import { NatsError, NatsHeaders } from "../src/mod.ts";
 
 Deno.test("msgheaders - basics", () => {
   const h = new NatsHeaders();

--- a/tests/noresponders_test.ts
+++ b/tests/noresponders_test.ts
@@ -13,18 +13,13 @@
  * limitations under the License.
  */
 
-import { connect } from "../src/connect.ts";
-import { NatsServer } from "./helpers/launcher.ts";
-import { Lock } from "./helpers/lock.ts";
+import { connect, createInbox, ErrorCode, headers } from "../src/mod.ts";
+import { NatsServer, Lock, assertErrorCode } from "./helpers/mod.ts";
 import {
   assertEquals,
   assert,
   fail,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { assertErrorCode } from "./helpers/mod.ts";
-import { ErrorCode } from "../src/mod.ts";
-import { headers, NatsHeaders } from "../nats-base-client/headers.ts";
-import { nuid } from "../nats-base-client/nats.ts";
 
 Deno.test("noresponders - option", async () => {
   const srv = await NatsServer.start();
@@ -37,8 +32,8 @@ Deno.test("noresponders - option", async () => {
   );
 
   const lock = Lock();
-  await nc.request(nuid.next())
-    .then((m) => {
+  await nc.request(createInbox())
+    .then(() => {
       fail("should have not resolved");
     })
     .catch((err) => {
@@ -61,7 +56,7 @@ Deno.test("noresponders - list", async () => {
     },
   );
 
-  const subj = nuid.next();
+  const subj = createInbox();
   const sub = nc.subscribe(subj);
   (async () => {
     for await (const m of sub) {

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -24,7 +24,7 @@ import {
   ConnectionOptions,
   Payload,
   Connect,
-} from "../nats-base-client/mod.ts";
+} from "../nats-base-client/internal_mod.ts";
 import { buildAuthenticator } from "../nats-base-client/authenticator.ts";
 import { extend } from "../nats-base-client/util.ts";
 

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {
   ConnectionOptions,
   ProtocolHandler,
@@ -20,18 +19,14 @@ import {
   SubscriptionImpl,
   Request,
   ErrorCode,
-} from "../nats-base-client/mod.ts";
-
+  Subscriptions,
+  MuxSubscription,
+} from "../nats-base-client/internal_mod.ts";
 import { assertErrorCode, Lock } from "./helpers/mod.ts";
-
 import {
   assertEquals,
   equal,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import {
-  MuxSubscription,
-  Subscriptions,
-} from "../nats-base-client/protocol.ts";
 
 Deno.test("protocol - partial messages correctly", async () => {
   let lock = Lock(1, 3);

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -17,7 +17,7 @@ import { Servers } from "../nats-base-client/servers.ts";
 import {
   assertEquals,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { ServerInfo } from "../nats-base-client/types.ts";
+import { ServerInfo } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("servers - single", () => {
   const servers = new Servers(false, [], "127.0.0.1:4222");

--- a/tests/token_test.ts
+++ b/tests/token_test.ts
@@ -15,12 +15,11 @@
 import {
   fail,
 } from "https://deno.land/std@0.61.0/testing/asserts.ts";
-import { connect } from "../src/mod.ts";
+import { connect, ErrorCode } from "../src/mod.ts";
 import {
   assertErrorCode,
   NatsServer,
 } from "./helpers/mod.ts";
-import { ErrorCode } from "../nats-base-client/mod.ts";
 
 const conf = { authorization: { token: "tokenxxxx" } };
 


### PR DESCRIPTION
- refactored protocol.ts into multiple files
- created single internal export that exposes client internal for tests
- simplified exported API for client
- removed references to nuid in favor of createInbox
- changed test subscriptions that use callbacks to use iterators where appropriate.