### PR TITLE
added `PublishOptions` and `NatsConnection` interfaces

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [X] Binary apis changed to be Uint8Array
 - [X] Subscriptions as iterators
 - [X] Stale connection
-- [ ] Remove encoders from client, changing payload signatures to Uint8Arrays only.
+- [X] Remove encoders from client, changing payload signatures to Uint8Arrays only.
 - [ ] Package nuidjs as its own project
 - [ ] Move nats-base-client to its own project
 - [ ] Transport send batching

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -1,4 +1,4 @@
-export { NatsConnection } from "./nats.ts";
+export { NatsConnectionImpl } from "./nats.ts";
 export { Nuid } from "./nuid.ts";
 export { ErrorCode, NatsError } from "./error.ts";
 export {
@@ -7,6 +7,8 @@ export {
   Empty,
   Events,
   Msg,
+  NatsConnection,
+  PublishOptions,
   RequestOptions,
   ServerInfo,
   ServersChanged,

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -16,6 +16,7 @@ export {
   NatsError,
   nkeyAuthenticator,
   Nuid,
+  PublishOptions,
   RequestOptions,
   ServersChanged,
   Status,

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -15,12 +15,6 @@
 
 import { isUint8Array } from "./util.ts";
 import {
-  ConnectionOptions,
-  Msg,
-  SubscriptionOptions,
-  Status,
-} from "./mod.ts";
-import {
   ProtocolHandler,
 } from "./protocol.ts";
 import {
@@ -28,15 +22,24 @@ import {
 } from "./subscription.ts";
 import { ErrorCode, NatsError } from "./error.ts";
 import { Nuid } from "./nuid.ts";
-import { Subscription, RequestOptions, Empty } from "./types.ts";
+import {
+  ConnectionOptions,
+  Subscription,
+  RequestOptions,
+  Empty,
+  PublishOptions,
+  Msg,
+  SubscriptionOptions,
+  Status,
+  NatsConnection,
+} from "./types.ts";
 import { parseOptions } from "./options.ts";
 import { QueuedIterator } from "./queued_iterator.ts";
-import { MsgHdrs } from "./headers.ts";
 import { Request } from "./request.ts";
 
 export const nuid = new Nuid();
 
-export class NatsConnection {
+export class NatsConnectionImpl implements NatsConnection {
   options: ConnectionOptions;
   protocol!: ProtocolHandler;
   draining: boolean = false;
@@ -48,7 +51,7 @@ export class NatsConnection {
 
   public static connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
     return new Promise<NatsConnection>((resolve, reject) => {
-      let nc = new NatsConnection(opts);
+      let nc = new NatsConnectionImpl(opts);
       ProtocolHandler.connect(nc.options, nc)
         .then((ph: ProtocolHandler) => {
           nc.protocol = ph;
@@ -78,7 +81,7 @@ export class NatsConnection {
   publish(
     subject: string,
     data: Uint8Array = Empty,
-    options?: { reply?: string; headers?: MsgHdrs },
+    options?: PublishOptions,
   ): void {
     subject = subject || "";
     if (subject.length === 0) {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -56,6 +56,24 @@ export interface ConnectFn {
   (opts: ConnectionOptions): Promise<NatsConnection>;
 }
 
+export interface NatsConnection {
+  closed(): Promise<void | Error>;
+  close(): Promise<void>;
+  publish(subject: string, data?: Uint8Array, options?: PublishOptions): void;
+  subscribe(subject: string, opts?: SubscriptionOptions): Subscription;
+  request(
+    subject: string,
+    data?: Uint8Array,
+    opts?: RequestOptions,
+  ): Promise<Msg>;
+  flush(): Promise<void>;
+  drain(): Promise<void>;
+  isClosed(): boolean;
+  isDraining(): boolean;
+  getServer(): string;
+  status(): AsyncIterable<Status>;
+}
+
 export interface ConnectionOptions {
   authenticator?: Authenticator;
   debug?: boolean;
@@ -153,5 +171,10 @@ export interface Subscription extends AsyncIterable<Msg> {
 
 export interface RequestOptions {
   timeout: number;
+  headers?: MsgHdrs;
+}
+
+export interface PublishOptions {
+  reply?: string;
   headers?: MsgHdrs;
 }

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -4,6 +4,7 @@ import {
   ConnectionOptions,
   setTransportFactory,
   Transport,
+  NatsConnectionImpl,
 } from "../nats-base-client/internal_mod.ts";
 
 export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
@@ -11,5 +12,5 @@ export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
     return new DenoTransport();
   });
 
-  return NatsConnection.connect(opts);
+  return NatsConnectionImpl.connect(opts);
 }

--- a/tests/autounsub_test.ts
+++ b/tests/autounsub_test.ts
@@ -24,6 +24,7 @@ import {
   Empty,
 } from "../src/mod.ts";
 import { Lock } from "./helpers/mod.ts";
+import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
 
 const u = "demo.nats.io:4222";
 
@@ -145,7 +146,7 @@ Deno.test("autounsub - manual request receives expected count with multiple help
 });
 
 Deno.test("autounsub - check subscription leaks", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ url: u }) as NatsConnectionImpl;
   let subj = createInbox();
   let sub = nc.subscribe(subj);
   sub.unsubscribe();
@@ -154,7 +155,7 @@ Deno.test("autounsub - check subscription leaks", async () => {
 });
 
 Deno.test("autounsub - check request leaks", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ url: u }) as NatsConnectionImpl;
   let subj = createInbox();
 
   // should have no subscriptions
@@ -189,7 +190,7 @@ Deno.test("autounsub - check request leaks", async () => {
 });
 
 Deno.test("autounsub - check cancelled request leaks", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ url: u }) as NatsConnectionImpl;
   let subj = createInbox();
 
   // should have no subscriptions

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -22,6 +22,7 @@ import {
 import {
   deferred,
   delay,
+  NatsConnectionImpl,
   SubscriptionImpl,
 } from "../nats-base-client/internal_mod.ts";
 
@@ -99,7 +100,7 @@ Deno.test("basics - pubsub", async () => {
 
 Deno.test("basics - subscribe and unsubscribe", async () => {
   const subj = createInbox();
-  const nc = await connect({ url: u });
+  const nc = await connect({ url: u }) as NatsConnectionImpl;
   const sub = nc.subscribe(subj, { max: 1000, queue: "aaa" });
 
   // check the subscription
@@ -351,7 +352,7 @@ Deno.test("basics - request timeout", async () => {
 });
 
 Deno.test("basics - request cancel rejects", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ url: u }) as NatsConnectionImpl;
   const s = createInbox();
   const lock = Lock();
 

--- a/tests/disconnect_test.ts
+++ b/tests/disconnect_test.ts
@@ -15,7 +15,10 @@
 
 import { connect } from "../src/mod.ts";
 import { Lock, NatsServer } from "./helpers/mod.ts";
-import { ParserState } from "../nats-base-client/internal_mod.ts";
+import {
+  NatsConnectionImpl,
+  ParserState,
+} from "../nats-base-client/internal_mod.ts";
 import {
   assertEquals,
 } from "https://deno.land/std@0.63.0/testing/asserts.ts";
@@ -39,7 +42,7 @@ Deno.test("disconnect - close process inbound ignores", async () => {
   let lock = Lock(1);
   let nc = await connect(
     { port: ns.port, reconnect: false },
-  );
+  ) as NatsConnectionImpl;
   nc.closed().then(() => {
     assertEquals(ParserState.CLOSED, nc.protocol.state);
     lock.unlock();

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -32,6 +32,7 @@ import {
 import {
   deferred,
   DebugEvents,
+  NatsConnectionImpl,
 } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("reconnect - should receive when some servers are invalid", async () => {
@@ -199,7 +200,7 @@ Deno.test("reconnect - jitter", async () => {
   let dc = await connect({
     port: srv.port,
     reconnect: false,
-  });
+  }) as NatsConnectionImpl;
   hasDefaultFn = typeof dc.options.reconnectDelayHandler === "function";
 
   let nc = await connect({
@@ -221,7 +222,7 @@ Deno.test("reconnect - internal disconnect forces reconnect", async () => {
     port: srv.port,
     reconnect: true,
     reconnectTimeWait: 200,
-  });
+  }) as NatsConnectionImpl;
 
   let stale = false;
   let disconnect = false;


### PR DESCRIPTION
made `NatsConnection` an interface - implementation is `NatsConnectionImpl` this will allow js/streaming/nkit clients to not care about the underlying implementation and simply use whatever connection they are given to do their thing.