### PR TITLE
[chore] simplified connection options by removing URL as really we just handle hostports

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ import { connect, NatsConnection } from "src/mod.ts";
 // common options that you could pass look like:
 const localhostAtStandardPort = {};
 const localPort = { port: 4222 };
-const hostAtStdPort = { url: "demo.nats.io" };
-const hostPort = { url: "demo.nats.io:4222" };
+const hostAtStdPort = { servers: "demo.nats.io" };
+const hostPort = { servers: "demo.nats.io:4222" };
 
 // let's try to connect to all the above, some may fail
 const dials: Promise<NatsConnection>[] = [];
@@ -115,7 +115,7 @@ of your data as necessary.
 import { connect, StringCodec } from "../../src/mod.ts";
 
 // to create a connection to a nats-server:
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 
 // create a codec
 const sc = StringCodec();
@@ -150,7 +150,7 @@ getting the messages you unsubscribe.
 import { connect, JSONCodec } from "../../src/mod.ts";
 
 // to create a connection to a nats-server:
-const nc = await connect({ url: "demo.nats.io" });
+const nc = await connect({ servers: "demo.nats.io" });
 
 // create a codec
 const jc = JSONCodec();
@@ -183,7 +183,7 @@ will get a chance at processing the message.
 
 ```javascript
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 const sc = StringCodec();
 
 // subscriptions can have wildcard subjects
@@ -230,7 +230,7 @@ not only to provide a service, but also to control the service.
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
 
 // create a connection
-const nc = await connect({ url: "demo.nats.io" });
+const nc = await connect({ servers: "demo.nats.io" });
 
 // create a codec
 const sc = StringCodec();
@@ -305,7 +305,7 @@ async function adminHandler(sub: Subscription) {
 import { connect, StringCodec } from "../../src/mod.ts";
 
 // create a connection
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 
 // create an encoder
 const sc = StringCodec();
@@ -348,7 +348,7 @@ async function createService(
   for (let i = 1; i <= count; i++) {
     const n = queue ? `${name}-${i}` : name;
     const nc = await connect(
-      { url: "demo.nats.io:4222", name: `${n}` },
+      { servers: "demo.nats.io:4222", name: `${n}` },
     );
     nc.closed()
       .then((err) => {
@@ -409,15 +409,15 @@ await Promise.all(a);
 // `token` options in the NatsConnectionOptions
 import { connect } from "src/mod.ts";
 
-const nc1 = await connect({url: "nats://127.0.0.1:4222", user: "jenny", pass: "867-5309"});
+const nc1 = await connect({servers: "127.0.0.1:4222", user: "jenny", pass: "867-5309"});
 const nc2 = await connect({port: 4222, token: "t0pS3cret!"});
 ```
 
 ### Flush
 ```javascript
-// flush sends a PING request to the server and returns a promise
-// when the server responds with a PONG. The flush guarantees that
-// things you published have been delivered to the server. Typically
+// flush sends a PING request to the servers and returns a promise
+// when the servers responds with a PONG. The flush guarantees that
+// things you published have been delivered to the servers. Typically
 // it is not necessary to use flush, but on tests it can be invaluable.
 nc.publish('foo');
 nc.publish('bar');

--- a/doc/snippets/autounsub.ts
+++ b/doc/snippets/autounsub.ts
@@ -17,7 +17,7 @@
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
 
 // create a connection
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 
 // create a simple subscriber that listens for only one message
 // and then auto unsubscribes, ending the async iterator

--- a/doc/snippets/basics.ts
+++ b/doc/snippets/basics.ts
@@ -17,7 +17,7 @@
 import { connect, StringCodec } from "../../src/mod.ts";
 
 // to create a connection to a nats-server:
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 
 // create a codec
 const sc = StringCodec();

--- a/doc/snippets/queuegroups.ts
+++ b/doc/snippets/queuegroups.ts
@@ -28,7 +28,7 @@ async function createService(
   for (let i = 1; i <= count; i++) {
     const n = queue ? `${name}-${i}` : name;
     const nc = await connect(
-      { url: "demo.nats.io:4222", name: `${n}` },
+      { servers: "demo.nats.io:4222", name: `${n}` },
     );
     nc.closed()
       .then((err) => {

--- a/doc/snippets/service.ts
+++ b/doc/snippets/service.ts
@@ -17,7 +17,7 @@
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
 
 // create a connection
-const nc = await connect({ url: "demo.nats.io" });
+const nc = await connect({ servers: "demo.nats.io" });
 
 // create a codec
 const sc = StringCodec();

--- a/doc/snippets/service_client.ts
+++ b/doc/snippets/service_client.ts
@@ -17,7 +17,7 @@
 import { connect, StringCodec } from "../../src/mod.ts";
 
 // create a connection
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 
 // create an encoder
 const sc = StringCodec();

--- a/doc/snippets/stream.ts
+++ b/doc/snippets/stream.ts
@@ -17,7 +17,7 @@
 import { connect, JSONCodec } from "../../src/mod.ts";
 
 // to create a connection to a nats-server:
-const nc = await connect({ url: "demo.nats.io" });
+const nc = await connect({ servers: "demo.nats.io" });
 
 // create a codec
 const jc = JSONCodec();

--- a/doc/snippets/sub_timeout.ts
+++ b/doc/snippets/sub_timeout.ts
@@ -17,7 +17,7 @@
 import { connect, ErrorCode } from "../../src/mod.ts";
 
 // to create a connection to a nats-server:
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 
 // create subscription with a timeout, if no message arrives
 // within the timeout, the subscription throws a timeout error

--- a/doc/snippets/wildcard_subscriptions.ts
+++ b/doc/snippets/wildcard_subscriptions.ts
@@ -14,7 +14,7 @@
  */
 
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
-const nc = await connect({ url: "demo.nats.io:4222" });
+const nc = await connect({ servers: "demo.nats.io:4222" });
 const sc = StringCodec();
 
 // subscriptions can have wildcard subjects

--- a/examples/bench.ts
+++ b/examples/bench.ts
@@ -3,7 +3,7 @@
 import { parse } from "https://deno.land/std@0.63.0/flags/mod.ts";
 import { connect, Nuid } from "../src/mod.ts";
 const defaults = {
-  s: "nats://127.0.0.1:4222",
+  s: "127.0.0.1:4222",
   c: 1000000,
 };
 
@@ -30,7 +30,7 @@ const server = String(argv.server);
 const count = parseInt(String(argv.count));
 const subj = String(argv.subj) || new Nuid().next();
 
-const nc = await connect({ url: server, debug: argv.debug });
+const nc = await connect({ servers: server, debug: argv.debug });
 const start = Date.now();
 
 if (argv.req) {

--- a/examples/nats-events.ts
+++ b/examples/nats-events.ts
@@ -10,12 +10,12 @@ const argv = parse(
       "s": ["server"],
     },
     default: {
-      s: "nats://127.0.0.1:4222",
+      s: "127.0.0.1:4222",
     },
   },
 );
 
-const opts = { url: argv.s } as ConnectionOptions;
+const opts = { servers: argv.s } as ConnectionOptions;
 
 const nc = await connect(opts);
 (async () => {

--- a/examples/nats-pub.ts
+++ b/examples/nats-pub.ts
@@ -14,7 +14,7 @@ const argv = parse(
       "i": ["interval"],
     },
     default: {
-      s: "nats://127.0.0.1:4222",
+      s: "127.0.0.1:4222",
       c: 1,
       i: 0,
     },
@@ -23,7 +23,7 @@ const argv = parse(
   },
 );
 
-const copts = { url: argv.s } as ConnectionOptions;
+const copts = { servers: argv.s } as ConnectionOptions;
 const subject = String(argv._[0]);
 const payload = argv._[1] || "";
 const count = (argv.c == -1 ? Number.MAX_SAFE_INTEGER : argv.c) || 1;

--- a/examples/nats-rep.ts
+++ b/examples/nats-rep.ts
@@ -13,7 +13,7 @@ const argv = parse(
       "e": ["echo"],
     },
     default: {
-      s: "nats://127.0.0.1:4222",
+      s: "127.0.0.1:4222",
       q: "",
     },
     boolean: ["echo", "headers", "debug"],
@@ -21,7 +21,7 @@ const argv = parse(
   },
 );
 
-const opts = { url: argv.s } as ConnectionOptions;
+const opts = { servers: argv.s } as ConnectionOptions;
 const subject = argv._[0] ? String(argv._[0]) : "";
 const payload = argv._[1] || "";
 

--- a/examples/nats-req.ts
+++ b/examples/nats-req.ts
@@ -14,7 +14,7 @@ const argv = parse(
       "t": ["timeout"],
     },
     default: {
-      s: "nats://127.0.0.1:4222",
+      s: "127.0.0.1:4222",
       c: 1,
       i: 0,
       t: 1000,
@@ -24,7 +24,7 @@ const argv = parse(
   },
 );
 
-const opts = { url: argv.s } as ConnectionOptions;
+const opts = { servers: argv.s } as ConnectionOptions;
 const subject = String(argv._[0]);
 const payload = argv._[1] || "";
 const count = (argv.c == -1 ? Number.MAX_SAFE_INTEGER : argv.c) || 1;

--- a/examples/nats-sub.ts
+++ b/examples/nats-sub.ts
@@ -11,7 +11,7 @@ const argv = parse(
       "q": ["queue"],
     },
     default: {
-      s: "nats://127.0.0.1:4222",
+      s: "127.0.0.1:4222",
       q: "",
     },
     boolean: ["headers", "debug"],
@@ -19,7 +19,7 @@ const argv = parse(
   },
 );
 
-const opts = { url: argv.s } as ConnectionOptions;
+const opts = { servers: argv.s } as ConnectionOptions;
 const subject = argv._[0] ? String(argv._[0]) : ">";
 
 if (argv.debug) {

--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -22,9 +22,9 @@ import {
   DEFAULT_MAX_PING_OUT,
   DEFAULT_MAX_RECONNECT_ATTEMPTS,
   DEFAULT_PING_INTERVAL,
-  DEFAULT_PRE,
+  DEFAULT_HOST,
   DEFAULT_RECONNECT_TIME_WAIT,
-  DEFAULT_URI,
+  DEFAULT_HOSTPORT,
 } from "./types.ts";
 import { buildAuthenticator } from "./authenticator.ts";
 
@@ -46,9 +46,15 @@ export function defaultOptions(): ConnectionOptions {
 }
 
 export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
-  opts = opts || { url: DEFAULT_URI };
+  opts = opts || { servers: [DEFAULT_HOSTPORT] };
   if (opts.port) {
-    opts.url = DEFAULT_PRE + opts.port;
+    opts.servers = [`${DEFAULT_HOST}:${opts.port}`];
+  }
+  if (typeof opts.servers === "string") {
+    opts.servers = [opts.servers];
+  }
+  if (opts.servers && opts.servers.length === 0) {
+    opts.servers = [DEFAULT_HOSTPORT];
   }
   const options = extend(defaultOptions(), opts);
 

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -133,8 +133,8 @@ export class ProtocolHandler {
     this.pongs = [];
     this.servers = new Servers(
       !options.noRandomize,
-      this.options.servers,
-      this.options.url,
+      //@ts-ignore
+      options.servers,
     );
     this.closed = deferred<Error | void>();
 

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -15,7 +15,7 @@
  */
 import {
   DEFAULT_PORT,
-  DEFAULT_URI,
+  DEFAULT_HOSTPORT,
   ServerInfo,
   ServersChanged,
 } from "./types.ts";
@@ -34,19 +34,14 @@ export class Server {
   gossiped: boolean;
 
   constructor(u: string, gossiped = false) {
-    // remove any of the standard protocols we are used to seeing
-    u = u.replace("tls://", "");
-    u = u.replace("ws://", "");
-    u = u.replace("wss://", "");
-    u = u.replace("nats://", "");
-
+    // remove any protocol that may have been provided
+    if (u.match(/^(.*:\/\/)(.*)/m)) {
+      u = u.replace(/^(.*:\/\/)(.*)/gm, "$2");
+    }
     // in web environments, URL may not be a living standard
     // that means that protocols other than HTTP/S are not
     // parsable correctly.
-    if (!/^.*:\/\/.*/.test(u)) {
-      u = `http://${u}`;
-    }
-    let url = new URL(u);
+    let url = new URL(`http://${u}`);
     if (!url.port) {
       url.port = `${DEFAULT_PORT}`;
     }
@@ -103,7 +98,7 @@ export class Servers {
       }
     } else {
       if (this.servers.length === 0) {
-        this.addServer(DEFAULT_URI, false);
+        this.addServer(DEFAULT_HOSTPORT, false);
       }
     }
     this.currentServer = this.servers[0];

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -39,8 +39,8 @@ export const DebugEvents = Object.freeze({
 });
 
 export const DEFAULT_PORT = 4222;
-export const DEFAULT_PRE = "nats://127.0.0.1:";
-export const DEFAULT_URI = DEFAULT_PRE + DEFAULT_PORT;
+export const DEFAULT_HOST = "127.0.0.1";
+export const DEFAULT_HOSTPORT = `${DEFAULT_HOST}:${DEFAULT_PORT}`;
 
 // DISCONNECT Parameters, 2 sec wait, 10 tries
 export const DEFAULT_RECONNECT_TIME_WAIT = 2 * 1000;
@@ -93,11 +93,10 @@ export interface ConnectionOptions {
   reconnectJitter?: number;
   reconnectJitterTLS?: number;
   reconnectTimeWait?: number;
-  servers?: Array<string>;
+  servers?: Array<string> | string;
   timeout?: number;
   tls?: boolean | TlsOptions;
   token?: string;
-  url?: string;
   user?: string;
   verbose?: boolean;
   waitOnFirstConnect?: boolean;

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -135,7 +135,7 @@ Deno.test("auth - pub perm", async () => {
 });
 
 Deno.test("auth - user and token is rejected", async () => {
-  connect({ url: "nats://127.0.0.1:4222", user: "derek", token: "foobar" })
+  connect({ servers: "127.0.0.1:4222", user: "derek", token: "foobar" })
     .then(async (nc) => {
       await nc.close();
       fail("should not have connected");

--- a/tests/autounsub_test.ts
+++ b/tests/autounsub_test.ts
@@ -29,7 +29,7 @@ import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
 const u = "demo.nats.io:4222";
 
 Deno.test("autounsub - max option", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 10 });
   for (let i = 0; i < 20; i++) {
@@ -41,7 +41,7 @@ Deno.test("autounsub - max option", async () => {
 });
 
 Deno.test("autounsub - unsubscribe", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 10 });
   sub.unsubscribe(11);
@@ -54,7 +54,7 @@ Deno.test("autounsub - unsubscribe", async () => {
 });
 
 Deno.test("autounsub - can unsub from auto-unsubscribed", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1 });
   for (let i = 0; i < 20; i++) {
@@ -67,7 +67,7 @@ Deno.test("autounsub - can unsub from auto-unsubscribed", async () => {
 });
 
 Deno.test("autounsub - can break to unsub", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 20 });
   const iter = (async () => {
@@ -85,7 +85,7 @@ Deno.test("autounsub - can break to unsub", async () => {
 });
 
 Deno.test("autounsub - can change auto-unsub to a higher value", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 1 });
   sub.unsubscribe(10);
@@ -98,7 +98,7 @@ Deno.test("autounsub - can change auto-unsub to a higher value", async () => {
 });
 
 Deno.test("autounsub - request receives expected count with multiple helpers", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
 
   const fn = (async (sub: Subscription) => {
@@ -123,7 +123,7 @@ Deno.test("autounsub - request receives expected count with multiple helpers", a
 });
 
 Deno.test("autounsub - manual request receives expected count with multiple helpers", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const lock = Lock(5);
 
@@ -146,7 +146,7 @@ Deno.test("autounsub - manual request receives expected count with multiple help
 });
 
 Deno.test("autounsub - check subscription leaks", async () => {
-  let nc = await connect({ url: u }) as NatsConnectionImpl;
+  let nc = await connect({ servers: u }) as NatsConnectionImpl;
   let subj = createInbox();
   let sub = nc.subscribe(subj);
   sub.unsubscribe();
@@ -155,7 +155,7 @@ Deno.test("autounsub - check subscription leaks", async () => {
 });
 
 Deno.test("autounsub - check request leaks", async () => {
-  let nc = await connect({ url: u }) as NatsConnectionImpl;
+  let nc = await connect({ servers: u }) as NatsConnectionImpl;
   let subj = createInbox();
 
   // should have no subscriptions
@@ -190,7 +190,7 @@ Deno.test("autounsub - check request leaks", async () => {
 });
 
 Deno.test("autounsub - check cancelled request leaks", async () => {
-  let nc = await connect({ url: u }) as NatsConnectionImpl;
+  let nc = await connect({ servers: u }) as NatsConnectionImpl;
   let subj = createInbox();
 
   // should have no subscriptions

--- a/tests/bench_test.ts
+++ b/tests/bench_test.ts
@@ -19,12 +19,12 @@ import {
 } from "../src/mod.ts";
 import { Lock } from "./helpers/mod.ts";
 
-const u = "nats://demo.nats.io:4222";
+const u = "demo.nats.io:4222";
 
 let max = 1000;
 Deno.test(`bench - pubsub`, async () => {
   const lock = Lock(max, 30000);
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   nc.subscribe(subj, {
     callback: () => {
@@ -46,7 +46,7 @@ Deno.test(`bench - pubsub`, async () => {
 });
 
 Deno.test(`bench - pubonly`, async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
 
   for (let i = 0; i < max; i++) {

--- a/tests/binary_test.ts
+++ b/tests/binary_test.ts
@@ -30,7 +30,7 @@ const u = "demo.nats.io:4222";
 function macro(input: any) {
   return async () => {
     const subj = createInbox();
-    const nc = await connect({ url: u });
+    const nc = await connect({ servers: u });
     const dm = deferred<Msg>();
     const sub = nc.subscribe(subj, { max: 1 });
     const _ = (async () => {

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -34,7 +34,7 @@ import { deferred } from "../nats-base-client/internal_mod.ts";
 const u = "demo.nats.io:4222";
 
 Deno.test("drain - connection drains when no subs", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ servers: u });
   await nc.drain();
   await nc.close();
 });
@@ -44,7 +44,7 @@ Deno.test("drain - connection drain", async () => {
   const lock = Lock(max);
   const subj = createInbox();
 
-  const nc1 = await connect({ url: u });
+  const nc1 = await connect({ servers: u });
   let first = true;
   const closed = deferred<void>();
   await nc1.subscribe(subj, {
@@ -64,7 +64,7 @@ Deno.test("drain - connection drain", async () => {
     queue: "q1",
   });
 
-  const nc2 = await connect({ url: u });
+  const nc2 = await connect({ servers: u });
   let count = 0;
   await nc2.subscribe(subj, {
     callback: () => {
@@ -89,7 +89,7 @@ Deno.test("drain - connection drain", async () => {
 
 Deno.test("drain - subscription drain", async () => {
   let lock = Lock();
-  let nc = await connect({ url: u });
+  let nc = await connect({ servers: u });
   let subj = createInbox();
   let c1 = 0;
   let s1 = nc.subscribe(subj, {
@@ -135,7 +135,7 @@ Deno.test("drain - publisher drain", async () => {
   const lock = Lock();
   const subj = createInbox();
 
-  const nc1 = await connect({ url: u });
+  const nc1 = await connect({ servers: u });
   let c1 = 0;
   await nc1.subscribe(subj, {
     callback: () => {
@@ -156,7 +156,7 @@ Deno.test("drain - publisher drain", async () => {
     queue: "q1",
   });
 
-  const nc2 = await connect({ url: u });
+  const nc2 = await connect({ servers: u });
   let c2 = 0;
   await nc2.subscribe(subj, {
     callback: () => {
@@ -186,7 +186,7 @@ Deno.test("drain - publisher drain", async () => {
 
 Deno.test("drain - publish after drain fails", async () => {
   const subj = createInbox();
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   nc.subscribe(subj);
   await nc.drain();
 
@@ -205,7 +205,7 @@ Deno.test("drain - reject reqrep during connection drain", async () => {
   const subj = createInbox();
   const sc = StringCodec();
   // start a service for replies
-  let nc1 = await connect({ url: u });
+  let nc1 = await connect({ servers: u });
   await nc1.subscribe(subj, {
     callback: (_, msg: Msg) => {
       if (msg.reply) {
@@ -215,7 +215,7 @@ Deno.test("drain - reject reqrep during connection drain", async () => {
   });
   nc1.flush();
 
-  let nc2 = await connect({ url: u });
+  let nc2 = await connect({ servers: u });
   let first = true;
   let done = Lock();
   await nc2.subscribe(subj, {
@@ -247,7 +247,7 @@ Deno.test("drain - reject reqrep during connection drain", async () => {
 });
 
 Deno.test("drain - reject drain on closed", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   await nc.close();
   const err = await assertThrowsAsync(() => {
     return nc.drain();
@@ -256,7 +256,7 @@ Deno.test("drain - reject drain on closed", async () => {
 });
 
 Deno.test("drain - reject drain on draining", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const done = nc.drain();
   const err = await assertThrowsAsync(() => {
     return nc.drain();
@@ -266,7 +266,7 @@ Deno.test("drain - reject drain on draining", async () => {
 });
 
 Deno.test("drain - reject subscribe on draining", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const done = nc.drain();
   const err = await assertThrowsAsync(async (): Promise<any> => {
     return nc.subscribe("foo");
@@ -276,7 +276,7 @@ Deno.test("drain - reject subscribe on draining", async () => {
 });
 
 Deno.test("drain - reject subscription drain on closed sub", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ servers: u });
   let sub = nc.subscribe("foo");
   sub.unsubscribe();
   const err = await assertThrowsAsync((): Promise<any> => {
@@ -287,14 +287,14 @@ Deno.test("drain - reject subscription drain on closed sub", async () => {
 });
 
 Deno.test("drain - connection is closed after drain", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ servers: u });
   nc.subscribe("foo");
   await nc.drain();
   assert(nc.isClosed());
 });
 
 Deno.test("drain - reject subscription drain on closed", async () => {
-  let nc = await connect({ url: u });
+  let nc = await connect({ servers: u });
   let sub = nc.subscribe("foo");
   await nc.close();
   const err = await assertThrowsAsync(() => {
@@ -304,7 +304,7 @@ Deno.test("drain - reject subscription drain on closed", async () => {
 });
 
 Deno.test("drain - multiple sub drain returns same promise", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const p1 = sub.drain();

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -46,7 +46,7 @@ Deno.test("events - disconnect, reconnect", async () => {
   const cluster = await NatsServer.cluster();
   const nc = await connect(
     {
-      url: `${cluster[0].hostname}:${cluster[0].port}`,
+      servers: `${cluster[0].hostname}:${cluster[0].port}`,
       maxReconnectAttempts: 1,
       reconnectTimeWait: 0,
     },
@@ -77,7 +77,7 @@ Deno.test("events - update", async () => {
   const cluster = await NatsServer.cluster(1);
   const nc = await connect(
     {
-      url: `nats://127.0.0.1:${cluster[0].port}`,
+      servers: `127.0.0.1:${cluster[0].port}`,
     },
   );
   const lock = Lock(1, 5000);
@@ -104,7 +104,7 @@ Deno.test("events - ldm", async () => {
   const cluster = await NatsServer.cluster(2);
   const nc = await connect(
     {
-      url: `nats://127.0.0.1:${cluster[0].port}`,
+      servers: `127.0.0.1:${cluster[0].port}`,
     },
   );
   const lock = Lock(1, 5000);

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -21,7 +21,7 @@ Deno.test("headers - option", async () => {
   const srv = await NatsServer.start();
   const nc = await connect(
     {
-      url: `nats://127.0.0.1:${srv.port}`,
+      servers: `127.0.0.1:${srv.port}`,
       headers: true,
     },
   );
@@ -59,7 +59,7 @@ Deno.test("headers - pub throws if not enabled", async () => {
   const srv = await NatsServer.start();
   const nc = await connect(
     {
-      url: `nats://127.0.0.1:${srv.port}`,
+      servers: `127.0.0.1:${srv.port}`,
     },
   );
 
@@ -82,7 +82,7 @@ Deno.test("headers - client fails to connect if headers not available", async ()
   const lock = Lock();
   await connect(
     {
-      url: `nats://127.0.0.1:${srv.port}`,
+      servers: `127.0.0.1:${srv.port}`,
       headers: true,
     },
   ).catch((err) => {
@@ -98,7 +98,7 @@ Deno.test("headers - request headers", async () => {
   const sc = StringCodec();
   const srv = await NatsServer.start();
   const nc = await connect({
-    url: `nats://127.0.0.1:${srv.port}`,
+    servers: `nats://127.0.0.1:${srv.port}`,
     headers: true,
   });
   const s = createInbox();

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -21,7 +21,7 @@ import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 const u = "demo.nats.io:4222";
 
 Deno.test("iterators - unsubscribe breaks and closes", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj);
   const done = (async () => {
@@ -39,7 +39,7 @@ Deno.test("iterators - unsubscribe breaks and closes", async () => {
 });
 
 Deno.test("iterators - autounsub breaks and closes", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const sub = nc.subscribe(subj, { max: 2 });
   const lock = Lock(2);
@@ -93,7 +93,7 @@ Deno.test("iterators - permission error breaks and closes", async () => {
 
 Deno.test("iterators - unsubscribing closes", async () => {
   const nc = await connect(
-    { url: u },
+    { servers: u },
   );
   const subj = createInbox();
   const sub = nc.subscribe(subj);
@@ -112,7 +112,7 @@ Deno.test("iterators - unsubscribing closes", async () => {
 
 Deno.test("iterators - connection close closes", async () => {
   const nc = await connect(
-    { url: u },
+    { servers: u },
   );
   const subj = createInbox();
   const sub = nc.subscribe(subj);

--- a/tests/json_test.ts
+++ b/tests/json_test.ts
@@ -42,7 +42,7 @@ Deno.test("json - bad json error in callback", async () => {
 function macro(input: any) {
   return async () => {
     const jc = JSONCodec();
-    const nc = await connect({ url: u });
+    const nc = await connect({ servers: u });
     let lock = Lock();
     let subj = createInbox();
     nc.subscribe(subj, {

--- a/tests/noresponders_test.ts
+++ b/tests/noresponders_test.ts
@@ -25,7 +25,7 @@ Deno.test("noresponders - option", async () => {
   const srv = await NatsServer.start();
   const nc = await connect(
     {
-      url: `nats://127.0.0.1:${srv.port}`,
+      servers: `127.0.0.1:${srv.port}`,
       headers: true,
       noResponders: true,
     },
@@ -50,7 +50,7 @@ Deno.test("noresponders - list", async () => {
   const srv = await NatsServer.start();
   const nc = await connect(
     {
-      url: `nats://127.0.0.1:${srv.port}`,
+      servers: `nats://127.0.0.1:${srv.port}`,
       headers: true,
       noResponders: true,
     },

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -39,7 +39,7 @@ Deno.test("properties - connect is a function", () => {
 
 Deno.test("properties - default connect properties", () => {
   const opts = defaultOptions();
-  opts.url = "nats://127.0.0.1:4222";
+  opts.servers = "127.0.0.1:4222";
   const c = new Connect(
     { version, lang },
     opts,
@@ -59,7 +59,7 @@ Deno.test("properties - default connect properties", () => {
 
 Deno.test("properties - configured options", async () => {
   let opts = defaultOptions();
-  opts.url = "nats://127.0.0.1:4222";
+  opts.servers = "127.0.0.1:4222";
   opts.name = "test";
   opts.pass = "secret";
   opts.user = "me";

--- a/tests/queues_test.ts
+++ b/tests/queues_test.ts
@@ -25,7 +25,7 @@ import {
 const u = "demo.nats.io:4222";
 
 Deno.test("queues - deliver to single queue", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const subs = [];
   for (let i = 0; i < 5; i++) {
@@ -41,7 +41,7 @@ Deno.test("queues - deliver to single queue", async () => {
 });
 
 Deno.test("queues - deliver to multiple queues", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
 
   const fn = (queue: string) => {
@@ -70,7 +70,7 @@ Deno.test("queues - deliver to multiple queues", async () => {
 });
 
 Deno.test("queues - queues and subs independent", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const subs = [];
   let queueCount = 0;

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -37,7 +37,7 @@ import {
 
 Deno.test("reconnect - should receive when some servers are invalid", async () => {
   const lock = Lock(1);
-  const servers = ["nats://127.0.0.1:7", "demo.nats.io:4222"];
+  const servers = ["127.0.0.1:7", "demo.nats.io:4222"];
   const nc = await connect({ servers: servers, noRandomize: true });
   const subj = createInbox();
   await nc.subscribe(subj, {

--- a/tests/types_test.ts
+++ b/tests/types_test.ts
@@ -45,7 +45,7 @@ function mh(nc: NatsConnection, subj: string): Promise<Msg> {
 
 Deno.test("types - json types", async () => {
   const jc = JSONCodec();
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const dm = mh(nc, subj);
   nc.publish(subj, jc.encode(6691));
@@ -57,7 +57,7 @@ Deno.test("types - json types", async () => {
 
 Deno.test("types - string types", async () => {
   const sc = StringCodec();
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const dm = mh(nc, subj);
   nc.publish(subj, sc.encode("hello world"));
@@ -67,7 +67,7 @@ Deno.test("types - string types", async () => {
 });
 
 Deno.test("types - binary types", async () => {
-  const nc = await connect({ url: u });
+  const nc = await connect({ servers: u });
   const subj = createInbox();
   const dm = mh(nc, subj);
   const payload = DataBuffer.fromAscii("hello world");

--- a/workflows/test.yml
+++ b/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Set NATS Server Version
         run: echo '::set-env name=NATS_VERSION::v2.1.7'
-      - name: Get nats-server
+      - name: Get nats-servers
         run: |
           wget "https://github.com/nats-io/nats-server/releases/download/$NATS_VERSION/nats-server-$NATS_VERSION-linux-amd64.zip" -O tmp.zip
           unzip tmp.zip


### PR DESCRIPTION
- [BREAKING] removed `url` connection option. Instead, provide `servers` - this option can be a string or an array of strings.