### PR TITLE
[compat] removed es getter from buffer/parser uses

### DIFF
--- a/nats-base-client/buffer.ts
+++ b/nats-base-client/buffer.ts
@@ -94,11 +94,11 @@ export class Buffer implements Reader, Writer {
     return this._buf.byteLength <= this._off;
   }
 
-  get length(): number {
+  length(): number {
     return this._buf.byteLength - this._off;
   }
 
-  get capacity(): number {
+  capacity(): number {
     return this._buf.buffer.byteLength;
   }
 
@@ -107,7 +107,7 @@ export class Buffer implements Reader, Writer {
       this.reset();
       return;
     }
-    if (n < 0 || n > this.length) {
+    if (n < 0 || n > this.length()) {
       throw Error("bytes.Buffer: truncation out of range");
     }
     this._reslice(this._off + n);
@@ -120,7 +120,7 @@ export class Buffer implements Reader, Writer {
 
   _tryGrowByReslice = (n: number): number => {
     const l = this._buf.byteLength;
-    if (n <= this.capacity - l) {
+    if (n <= this.capacity() - l) {
       this._reslice(l + n);
       return l;
     }
@@ -169,7 +169,7 @@ export class Buffer implements Reader, Writer {
   }
 
   _grow = (n: number): number => {
-    const m = this.length;
+    const m = this.length();
     // If buffer is empty, reset to recover space.
     if (m === 0 && this._off !== 0) {
       this.reset();
@@ -179,7 +179,7 @@ export class Buffer implements Reader, Writer {
     if (i >= 0) {
       return i;
     }
-    const c = this.capacity;
+    const c = this.capacity();
     if (n <= Math.floor(c / 2) - m) {
       // We can slide things down instead of allocating a new
       // ArrayBuffer. We only need m+n <= c to slide, but
@@ -212,12 +212,12 @@ export class Buffer implements Reader, Writer {
     let n = 0;
     const tmp = new Uint8Array(MIN_READ);
     while (true) {
-      const shouldGrow = this.capacity - this.length < MIN_READ;
+      const shouldGrow = this.capacity() - this.length() < MIN_READ;
       // read into tmp buffer if there's not enough room
       // otherwise read directly into the internal buffer
       const buf = shouldGrow
         ? tmp
-        : new Uint8Array(this._buf.buffer, this.length);
+        : new Uint8Array(this._buf.buffer, this.length());
 
       const nread = r.read(buf);
       if (nread === null) {
@@ -226,7 +226,7 @@ export class Buffer implements Reader, Writer {
 
       // write will grow if needed
       if (shouldGrow) this.write(buf.subarray(0, nread));
-      else this._reslice(this.length + nread);
+      else this._reslice(this.length() + nread);
 
       n += nread;
     }

--- a/nats-base-client/parser.ts
+++ b/nats-base-client/parser.ts
@@ -81,12 +81,10 @@ export class Parser {
   ma: MsgArg = {} as MsgArg;
   argBuf?: Buffer;
   msgBuf?: Buffer;
-  scratch: Buffer;
 
   constructor(dispatcher: Dispatcher<ParserEvent>) {
     this.dispatcher = dispatcher;
     this.state = State.OP_START;
-    this.scratch = new Buffer();
   }
 
   parse(buf: Uint8Array): void {
@@ -202,7 +200,7 @@ export class Parser {
           break;
         case State.MSG_PAYLOAD:
           if (this.msgBuf) {
-            if (this.msgBuf.length >= this.ma.size) {
+            if (this.msgBuf.length() >= this.ma.size) {
               const data = this.msgBuf.bytes({ copy: false });
               this.dispatcher.push(
                 { kind: Kind.MSG, msg: this.ma, data: data },
@@ -211,7 +209,7 @@ export class Parser {
               this.msgBuf = undefined;
               this.state = State.MSG_END;
             } else {
-              let toCopy = this.ma.size - this.msgBuf.length;
+              let toCopy = this.ma.size - this.msgBuf.length();
               const avail = buf.length - i;
 
               if (avail < toCopy) {

--- a/tests/buffer_test.ts
+++ b/tests/buffer_test.ts
@@ -39,11 +39,11 @@ function init(): void {
 
 function check(buf: Buffer, s: string): void {
   const bytes = buf.bytes();
-  assertEquals(buf.length, bytes.byteLength);
+  assertEquals(buf.length(), bytes.byteLength);
   const decoder = new TextDecoder();
   const bytesStr = decoder.decode(bytes);
   assertEquals(bytesStr, s);
-  assertEquals(buf.length, s.length);
+  assertEquals(buf.length(), s.length);
 }
 
 // Fill buf through n writes of byte slice fub.
@@ -158,8 +158,8 @@ Deno.test("buffer - write string", () => {
 Deno.test("buffer - write empty string", () => {
   const buf = new Buffer();
   buf.writeString("");
-  assertEquals(buf.length, 0);
-  assertEquals(buf.capacity, 0);
+  assertEquals(buf.length(), 0);
+  assertEquals(buf.capacity(), 0);
 });
 
 Deno.test("buffer - read empty at EOF", () => {
@@ -238,7 +238,7 @@ Deno.test("buffer - grow read close to max buffer", () => {
     const buf = new Buffer();
     buf.readFrom(reader);
 
-    assertEquals(buf.length, capacity);
+    assertEquals(buf.length(), capacity);
   }
 });
 
@@ -249,7 +249,7 @@ Deno.test("buffer - read close to max buffer with initial grow", () => {
     const buf = new Buffer();
     buf.grow(MAX_SIZE);
     buf.readFrom(reader);
-    assertEquals(buf.length, capacity);
+    assertEquals(buf.length(), capacity);
   }
 });
 
@@ -268,7 +268,7 @@ Deno.test("buffer - large byte reads", () => {
 
 Deno.test("buffer - cap with pre allocated slice", () => {
   const buf = new Buffer(new ArrayBuffer(10));
-  assertEquals(buf.capacity, 10);
+  assertEquals(buf.capacity(), 10);
 });
 
 Deno.test("buffer - read from sync", () => {

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -303,7 +303,7 @@ Deno.test("parser - split msg", () => {
   p.parse(payload);
   assertEquals(p.state, State.MSG_PAYLOAD);
   assertEquals(p.ma.size, 103);
-  assertEquals(p.msgBuf.length, 103);
+  assertEquals(p.msgBuf.length(), 103);
   p.parse(te.encode("\r\n"));
   assertEquals(p.state, State.OP_START);
   assertEquals(p.msgBuf, undefined);


### PR DESCRIPTION
Safari doesn't yet support ES getter/setter, removed uses of getter in nats-base-client