### PR TITLE
added more tests for connection refused, codecs, tls

### DIFF
--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -100,7 +100,7 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
 
 export function checkOptions(info: object, options: ConnectionOptions) {
   //@ts-ignore
-  const { proto, headers } = info;
+  const { proto, headers, tls_required } = info;
   if ((proto === undefined || proto < 1) && options.noEcho) {
     throw new NatsError("noEcho", ErrorCode.SERVER_OPTION_NA);
   }
@@ -119,5 +119,8 @@ export function checkOptions(info: object, options: ConnectionOptions) {
       "noResponders - requires headers",
       ErrorCode.SERVER_OPTION_NA,
     );
+  }
+  if (options.tls && !tls_required) {
+    throw new NatsError("tls", ErrorCode.SERVER_OPTION_NA);
   }
 }

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -24,6 +24,8 @@ import {
   render,
   Transport,
   checkOptions,
+  NatsError,
+  ErrorCode,
 } from "../nats-base-client/internal_mod.ts";
 import { TlsOptions } from "../nats-base-client/types.ts";
 
@@ -82,6 +84,9 @@ export class DenoTransport implements Transport {
       }
       return Promise.resolve();
     } catch (err) {
+      err = err.name === "ConnectionRefused"
+        ? NatsError.errorForCode(ErrorCode.CONNECTION_REFUSED)
+        : err;
       return Promise.reject(err);
     }
   }

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -145,6 +145,14 @@ Deno.test("auth - user and token is rejected", async () => {
     });
 });
 
+Deno.test("auth - token", async () => {
+  const ns = await NatsServer.start({ authorization: { token: "foo" } });
+  const nc = await connect({ port: ns.port, token: "foo" });
+  await nc.flush();
+  await nc.close();
+  await ns.stop();
+});
+
 Deno.test("auth - nkey", async () => {
   const kp = nkeys.createUser();
   const pk = kp.getPublicKey();

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -1,7 +1,20 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {
   assert,
   assertEquals,
-  assertThrowsAsync,
   fail,
 } from "https://deno.land/std@0.63.0/testing/asserts.ts";
 import {
@@ -58,9 +71,13 @@ Deno.test("basics - connect servers", async () => {
 });
 
 Deno.test("basics - fail connect", async () => {
-  await assertThrowsAsync(async (): Promise<void> => {
-    await connect({ servers: `127.0.0.1:32001` });
-  });
+  await connect({ servers: `127.0.0.1:32001` })
+    .then(() => {
+      fail();
+    })
+    .catch((err) => {
+      assertErrorCode(err, ErrorCode.CONNECTION_REFUSED);
+    });
 });
 
 Deno.test("basics - publish", async () => {
@@ -144,8 +161,8 @@ Deno.test("basics - subscriptions iterate", async () => {
   })();
   nc.publish(subj);
   await nc.flush();
-  await nc.close();
   await lock;
+  await nc.close();
 });
 
 Deno.test("basics - subscriptions pass exact subject to cb", async () => {
@@ -439,7 +456,7 @@ Deno.test("basics - subscription expecting 2 doesn't fire timeout", async () => 
   await nc.flush();
   await delay(1000);
 
-  assertEquals(1, sub.getReceived());
+  assertEquals(sub.getReceived(), 1);
   await nc.close();
 });
 

--- a/tests/codec_test.ts
+++ b/tests/codec_test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { StringCodec, JSONCodec } from "../nats-base-client/codec.ts";
+import {
+  assertEquals,
+} from "https://deno.land/std@0.63.0/testing/asserts.ts";
+
+Deno.test("codec - string", () => {
+  const sc = StringCodec();
+  const d = sc.encode("hello");
+  assertEquals(sc.decode(d), "hello");
+});
+
+Deno.test("codec - json", () => {
+  const sc = JSONCodec();
+  const o = { hello: "world" };
+  const d = sc.encode(o);
+  assertEquals(sc.decode(d), o);
+});

--- a/tests/tls_test.ts
+++ b/tests/tls_test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  assertEquals,
+  fail,
+} from "https://deno.land/std@0.63.0/testing/asserts.ts";
+import {
+  connect,
+  ErrorCode,
+} from "../src/mod.ts";
+import {
+  assertErrorCode,
+  Lock,
+  NatsServer,
+} from "./helpers/mod.ts";
+
+import { join, resolve } from "https://deno.land/std@0.63.0/path/mod.ts";
+
+Deno.test("tls - fail if server doesn't support TLS", async () => {
+  const lock = Lock();
+  await connect({ servers: "demo.nats.io:4222", tls: {} })
+    .then(() => {
+      fail("shouldn't have connected");
+    })
+    .catch((err) => {
+      assertErrorCode(err, ErrorCode.SERVER_OPTION_NA);
+      lock.unlock();
+    });
+  await lock;
+});
+
+Deno.test("tls - connects to tls without option", async () => {
+  const nc = await connect({ servers: "demo.nats.io:4443" });
+  await nc.flush();
+  await nc.close();
+});
+
+Deno.test("tls - custom ca fails without root", async () => {
+  const cwd = Deno.cwd();
+  const config = {
+    host: "0.0.0.0",
+    tls: {
+      cert_file: resolve(join(cwd, "./tests/certs/localhost.crt")),
+      key_file: resolve(join(cwd, "./tests/certs/localhost.key")),
+      ca_file: resolve(join(cwd, "./tests/certs/RootCA.crt")),
+    },
+  };
+
+  const ns = await NatsServer.start(config);
+  const lock = Lock();
+  await connect({ servers: `localhost:${ns.port}` })
+    .then(() => {
+      fail("shouldn't have connected without client ca");
+    })
+    .catch((err) => {
+      // this is a bogus error name - but at least we know we are rejected
+      assertEquals(err.name, "InvalidData");
+      lock.unlock();
+    });
+
+  await lock;
+  await ns.stop();
+});
+
+Deno.test("tls - custom ca with root connects", async () => {
+  const cwd = Deno.cwd();
+  const config = {
+    host: "0.0.0.0",
+    tls: {
+      cert_file: resolve(join(cwd, "./tests/certs/localhost.crt")),
+      key_file: resolve(join(cwd, "./tests/certs/localhost.key")),
+      ca_file: resolve(join(cwd, "./tests/certs/RootCA.crt")),
+    },
+  };
+
+  const ns = await NatsServer.start(config);
+  const nc = await connect({
+    servers: `localhost:${ns.port}`,
+    tls: {
+      caFile: config.tls.ca_file,
+    },
+  });
+  await nc.flush();
+  await nc.close();
+  await ns.stop();
+});


### PR DESCRIPTION
- added check to verify that tls is available when a tls option is specified.
- added check for "ConnectionRefused", and typed as NatsErrors - different transports will need to do same.
- added check for authentication token
- added check for connection refused error on client code
- added tests for string/json codecs
- added basic TLS tests - other transports will need to expand according to capabilities.