### PR TITLE
[fix] internal close latch was set after close completed

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -129,9 +129,6 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       options.servers,
     );
     this.closed = deferred<Error | void>();
-    this.closed.then(() => {
-      this._closed = true;
-    });
     this.parser = new Parser(this);
 
     this.heartbeats = new Heartbeat(
@@ -568,7 +565,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   }
 
   private _close(err?: Error): Promise<void> {
-    if (this.isClosed()) {
+    if (this._closed) {
       return Promise.resolve();
     }
     this.heartbeats.cancel();
@@ -581,6 +578,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.listeners.forEach((l) => {
       l.stop();
     });
+    this._closed = true;
     return this.transport.close(err)
       .then(() => {
         return this.closed.resolve(err);

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -225,9 +225,9 @@ export class DenoTransport implements Transport {
     this.closeError = err;
     if (!err) {
       try {
-        // this is a noop for the server, but gives us a place to hang
+        // this is a noop but gives us a place to hang
         // a close and ensure that we sent all before closing
-        await this.enqueue(new TextEncoder().encode("+OK\r\n"));
+        await this.enqueue(new TextEncoder().encode(""));
       } catch (err) {
         if (this.options.debug) {
           console.log("transport close terminated with an error", err);


### PR DESCRIPTION
fixed an issue where the close option on the protocol was set after resolving a promise, this created a problem on node platform, where a close event is emitted from the socket and triggers a redial before the flag is set.