### PR TITLE
changed reads to allocate a new read buffer per read and thus eliminate buffer copies down stream

### DIFF
--- a/nats-base-client/databuffer.ts
+++ b/nats-base-client/databuffer.ts
@@ -51,8 +51,14 @@ export class DataBuffer {
 
   pack(): void {
     if (this.buffers.length > 1) {
-      let v = this.buffers.splice(0, this.buffers.length);
-      this.buffers.push(DataBuffer.concat(...v));
+      let v = new Uint8Array(this.byteLength);
+      let index = 0;
+      for (let i = 0; i < this.buffers.length; i++) {
+        v.set(this.buffers[i], index);
+        index += this.buffers[i].length;
+      }
+      this.buffers.length = 0;
+      this.buffers.push(v);
     }
   }
 
@@ -65,9 +71,9 @@ export class DataBuffer {
         if (n === undefined || n > max) {
           n = max;
         }
-        let d = v.slice(0, n);
+        let d = v.subarray(0, n);
         if (max > n) {
-          this.buffers.push(v.slice(n));
+          this.buffers.push(v.subarray(n));
         }
         this.byteLength = max - n;
         return d;

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -53,7 +53,7 @@ import {
 import { MsgImpl } from "./msg.ts";
 import { fastEncoder, fastDecoder } from "./encoders.ts";
 
-const FLUSH_THRESHOLD = 1024 * 8;
+const FLUSH_THRESHOLD = 1024 * 32;
 
 export const INFO = /^INFO\s+([^\r\n]+)\r\n/i;
 

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -104,7 +104,7 @@ export class DenoTransport implements Transport {
         // EOF
         throw new Error("socket closed while expecting INFO");
       } else if (c) {
-        const frame = this.buf.slice(0, c);
+        const frame = this.buf.subarray(0, c);
         if (this.options.debug) {
           console.info(`> ${render(frame)}`);
         }
@@ -142,15 +142,15 @@ export class DenoTransport implements Transport {
     // yield what we initially read
     yield this.buf;
 
-    this.buf = new Uint8Array(64 * 1024);
     while (!this.done) {
       try {
+        this.buf = new Uint8Array(64 * 1024);
         let c = await this.conn.read(this.buf);
         if (c === null) {
           break;
         }
         if (c) {
-          const frame = this.buf.slice(0, c);
+          const frame = this.buf.subarray(0, c);
           if (this.options.debug) {
             console.info(`> ${render(frame)}`);
           }

--- a/tests/clobber_test.ts
+++ b/tests/clobber_test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NatsServer } from "./helpers/launcher.ts";
+import {
+  createInbox,
+  DataBuffer,
+} from "../nats-base-client/internal_mod.ts";
+import { connect } from "../src/mod.ts";
+import {
+  assertEquals,
+} from "https://deno.land/std@0.63.0/testing/asserts.ts";
+
+function makeBuffer(N: number): Uint8Array {
+  const buf = new Uint8Array(N);
+  for (let i = 0; i < N; i++) {
+    buf[i] = "a".charCodeAt(0) + (i % 26);
+  }
+  return buf;
+}
+
+Deno.test("clobber - buffers don't clobber", async () => {
+  let iters = 250 * 1024;
+  const data = makeBuffer(iters * 1024);
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+  const subj = createInbox();
+  const sub = nc.subscribe(subj, { max: iters });
+  const payloads = new DataBuffer();
+  const iter = (async () => {
+    for await (const m of sub) {
+      payloads.fill(m.data);
+    }
+  })();
+
+  let bytes = 0;
+  for (let i = 0; i < iters; i++) {
+    bytes += 1024;
+    const start = i * 1024;
+    nc.publish(subj, data.subarray(start, start + 1024));
+  }
+
+  await iter;
+
+  const td = new TextDecoder();
+  for (let i = 0; i < iters; i++) {
+    const start = i * 1024;
+    const r = td.decode(payloads.drain(1024));
+    const w = td.decode(data.subarray(start, start + 1024));
+    assertEquals(r, w);
+  }
+
+  await nc.close();
+  await ns.stop();
+});


### PR DESCRIPTION
- increased default flush threshold to 32K
- changed to create a buffer before a read, and eliminate copies
- added clobber test to verify client data is not overwritten by reuse