### PR TITLE
api safety for callback based susbscriptions

### DIFF
--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -15,6 +15,7 @@
 
 export enum ErrorCode {
   // emitted by the client
+  API_ERROR = "BAD API",
   BAD_AUTHENTICATION = "BAD_AUTHENTICATION",
   BAD_CREDS = "BAD_CREDS",
   BAD_HEADER = "BAD_HEADER",

--- a/nats-base-client/subscription.ts
+++ b/nats-base-client/subscription.ts
@@ -38,6 +38,8 @@ export class SubscriptionImpl extends QueuedIterator<Msg>
     extend(this, opts);
     this.protocol = protocol;
     this.subject = subject;
+    this.noIterator = typeof opts.callback === "function";
+
     if (opts.timeout) {
       this.timer = timeout<void>(opts.timeout);
       this.timer

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -164,6 +164,7 @@ export interface Subscription extends AsyncIterable<Msg> {
   getSubject(): string;
   getReceived(): number;
   getProcessed(): number;
+  getPending(): number;
   getID(): number;
   getMax(): number | undefined;
 }


### PR DESCRIPTION
[feat] callback-based subscriptions, invoking the iterator throws an error
[fix] subscription exposes `getPending()`
fixes #42 