### PR TITLE
websocket client urls/updates

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -37,7 +37,7 @@ import {
 } from "./util.ts";
 import { nuid } from "./nuid.ts";
 import { DataBuffer } from "./databuffer.ts";
-import { Server, Servers } from "./servers.ts";
+import { ServerImpl, Servers } from "./servers.ts";
 import { Dispatcher, QueuedIterator } from "./queued_iterator.ts";
 import type { MsgHdrs, MsgHdrsImpl } from "./headers.ts";
 import { SubscriptionImpl } from "./subscription.ts";
@@ -122,7 +122,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   pendingLimit = FLUSH_THRESHOLD;
 
   private servers: Servers;
-  private server!: Server;
+  private server!: ServerImpl;
 
   constructor(options: ConnectionOptions, publisher: Publisher) {
     this.options = options;
@@ -228,11 +228,11 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
   }
 
-  async dial(srv: Server): Promise<void> {
+  async dial(srv: ServerImpl): Promise<void> {
     const pong = this.prepare();
     const timer = timeout(this.options.timeout || 20000);
     try {
-      await this.transport.connect(srv.hostport(), this.options);
+      await this.transport.connect(srv, this.options);
       (async () => {
         try {
           for await (const b of this.transport) {
@@ -627,7 +627,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
   }
 
-  private selectServer(): Server | undefined {
+  private selectServer(): ServerImpl | undefined {
     let server = this.servers.selectServer();
     if (server === undefined) {
       return undefined;
@@ -637,7 +637,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     return this.server;
   }
 
-  getServer(): Server | undefined {
+  getServer(): ServerImpl | undefined {
     return this.server;
   }
 }

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -369,7 +369,9 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
 
   processInfo(m: Uint8Array) {
     this.info = JSON.parse(fastDecoder(m));
-    const updates = this.servers.update(this.info);
+    const updates = this.options && this.options.ignoreClusterUpdates
+      ? undefined
+      : this.servers.update(this.info);
     if (!this.infoReceived) {
       // send connect
       const { version, lang } = this.transport;

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -18,13 +18,15 @@ import {
   DEFAULT_HOSTPORT,
   ServerInfo,
   ServersChanged,
+  Server,
 } from "./types.ts";
 import { shuffle } from "./util.ts";
 
 /**
  * @hidden
  */
-export class Server {
+export class ServerImpl implements Server {
+  src: string;
   listen: string;
   hostname: string;
   port: number;
@@ -34,6 +36,7 @@ export class Server {
   gossiped: boolean;
 
   constructor(u: string, gossiped = false) {
+    this.src = u;
     // remove any protocol that may have been provided
     if (u.match(/^(.*:\/\/)(.*)/m)) {
       u = u.replace(/^(.*:\/\/)(.*)/gm, "$2");
@@ -58,10 +61,6 @@ export class Server {
   toString(): string {
     return this.listen;
   }
-
-  hostport(): { hostname: string; port: number } {
-    return this;
-  }
 }
 
 /**
@@ -69,18 +68,18 @@ export class Server {
  */
 export class Servers {
   private firstSelect: boolean = true;
-  private readonly servers: Server[];
-  private currentServer: Server;
+  private readonly servers: ServerImpl[];
+  private currentServer: ServerImpl;
 
   constructor(
     randomize: boolean,
     listens: string[] = [],
     firstServer?: string,
   ) {
-    this.servers = [] as Server[];
+    this.servers = [] as ServerImpl[];
     if (listens) {
       listens.forEach((hp) => {
-        this.servers.push(new Server(hp));
+        this.servers.push(new ServerImpl(hp));
       });
       if (randomize) {
         this.servers = shuffle(this.servers);
@@ -90,7 +89,7 @@ export class Servers {
     if (firstServer) {
       let index = listens.indexOf(firstServer);
       if (index === -1) {
-        this.servers.unshift(new Server(firstServer));
+        this.servers.unshift(new ServerImpl(firstServer));
       } else {
         let fs = this.servers[index];
         this.servers.splice(index, 1);
@@ -104,15 +103,15 @@ export class Servers {
     this.currentServer = this.servers[0];
   }
 
-  getCurrentServer(): Server {
+  getCurrentServer(): ServerImpl {
     return this.currentServer;
   }
 
   addServer(u: string, implicit = false): void {
-    this.servers.push(new Server(u, implicit));
+    this.servers.push(new ServerImpl(u, implicit));
   }
 
-  selectServer(): Server | undefined {
+  selectServer(): ServerImpl | undefined {
     // allow using select without breaking the order of the servers
     if (this.firstSelect) {
       this.firstSelect = false;
@@ -130,7 +129,7 @@ export class Servers {
     this.removeServer(this.currentServer);
   }
 
-  removeServer(server: Server | undefined): void {
+  removeServer(server: ServerImpl | undefined): void {
     if (server) {
       let index = this.servers.indexOf(server);
       this.servers.splice(index, 1);
@@ -141,11 +140,11 @@ export class Servers {
     return this.servers.length;
   }
 
-  next(): Server | undefined {
+  next(): ServerImpl | undefined {
     return this.servers.length ? this.servers[0] : undefined;
   }
 
-  getServers(): Server[] {
+  getServers(): ServerImpl[] {
     return this.servers;
   }
 
@@ -153,10 +152,10 @@ export class Servers {
     const added: string[] = [];
     let deleted: string[] = [];
 
-    const discovered = new Map<string, Server>();
+    const discovered = new Map<string, ServerImpl>();
     if (info.connect_urls && info.connect_urls.length > 0) {
       info.connect_urls.forEach((hp) => {
-        discovered.set(hp, new Server(hp, true));
+        discovered.set(hp, new ServerImpl(hp, true));
       });
     }
     // remove gossiped servers that are no longer reported

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -65,7 +65,6 @@ export class ServerImpl implements Server {
 }
 
 export interface ServersOptions {
-  firstServer?: string;
   urlParseFn?: URLParseFn;
 }
 
@@ -94,23 +93,8 @@ export class Servers {
         this.servers = shuffle(this.servers);
       }
     }
-
-    if (opts.firstServer) {
-      opts.firstServer = this.urlParseFn
-        ? this.urlParseFn(opts.firstServer)
-        : opts.firstServer;
-      let index = listens.indexOf(opts.firstServer);
-      if (index === -1) {
-        this.servers.unshift(new ServerImpl(opts.firstServer));
-      } else {
-        let fs = this.servers[index];
-        this.servers.splice(index, 1);
-        this.servers.unshift(fs);
-      }
-    } else {
-      if (this.servers.length === 0) {
-        this.addServer(DEFAULT_HOSTPORT, false);
-      }
+    if (this.servers.length === 0) {
+      this.addServer(DEFAULT_HOSTPORT, false);
     }
     this.currentServer = this.servers[0];
   }

--- a/nats-base-client/transport.ts
+++ b/nats-base-client/transport.ts
@@ -13,7 +13,12 @@
  * limitations under the License.
  */
 //@ts-ignore
-import { ConnectionOptions, Server } from "./types.ts";
+import { ConnectionOptions, Server, URLParseFn } from "./types.ts";
+
+let urlParseFn: URLParseFn;
+export function setUrlParseFn(fn: URLParseFn): void {
+  urlParseFn = fn;
+}
 
 let transportFactory: TransportFactory;
 export function setTransportFactory(fn: TransportFactory): void {

--- a/nats-base-client/transport.ts
+++ b/nats-base-client/transport.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 //@ts-ignore
-import { ConnectionOptions } from "./types.ts";
+import { ConnectionOptions, Server } from "./types.ts";
 
 let transportFactory: TransportFactory;
 export function setTransportFactory(fn: TransportFactory): void {
@@ -38,7 +38,7 @@ export interface Transport extends AsyncIterable<Uint8Array> {
   readonly closeError?: Error;
 
   connect(
-    hp: { hostname: string; port: number },
+    server: Server,
     opts: ConnectionOptions,
   ): Promise<void>;
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -203,3 +203,7 @@ export interface Stats {
   inMsgs: number;
   outMsgs: number;
 }
+
+export interface URLParseFn {
+  (u: string): string;
+}

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -101,6 +101,7 @@ export interface ConnectionOptions {
   user?: string;
   verbose?: boolean;
   waitOnFirstConnect?: boolean;
+  ignoreClusterUpdates?: boolean;
 }
 
 // these may not be supported on all environments

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -159,6 +159,13 @@ export interface ServerInfo {
   version: string;
 }
 
+export interface Server {
+  hostname: string;
+  port: number;
+  listen: string;
+  src: string;
+}
+
 export interface ServersChanged {
   readonly added: string[];
   readonly deleted: string[];

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -20,7 +20,7 @@ import {
 import type { ServerInfo } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("servers - single", () => {
-  const servers = new Servers(false, [], { firstServer: "127.0.0.1:4222" });
+  const servers = new Servers(false, ["127.0.0.1:4222"]);
   assertEquals(servers.length(), 1);
   assertEquals(servers.getServers().length, 1);
   assertEquals(servers.getCurrentServer().listen, "127.0.0.1:4222");
@@ -37,11 +37,10 @@ Deno.test("servers - multiples", () => {
   const servers = new Servers(
     false,
     ["h:1", "h:2"],
-    { firstServer: "127.0.0.1:4222" },
   );
-  assertEquals(servers.length(), 3);
-  assertEquals(servers.getServers().length, 3);
-  assertEquals(servers.getCurrentServer().listen, "127.0.0.1:4222");
+  assertEquals(servers.length(), 2);
+  assertEquals(servers.getServers().length, 2);
+  assertEquals(servers.getCurrentServer().listen, "h:1");
   let ni = 0;
   servers.getServers().forEach((s) => {
     if (s.gossiped) {
@@ -61,7 +60,7 @@ function servInfo(): ServerInfo {
 }
 
 Deno.test("servers - add/delete", () => {
-  const servers = new Servers(false, [], { firstServer: "127.0.0.1:4222" });
+  const servers = new Servers(false, ["127.0.0.1:4222"]);
   assertEquals(servers.length(), 1);
   let ce = servers.update(Object.assign(servInfo(), { connect_urls: ["h:1"] }));
   assertEquals(ce.added.length, 1);
@@ -89,8 +88,8 @@ Deno.test("servers - url parse fn", () => {
   };
   const s = new Servers(
     false,
-    [],
-    { firstServer: "127.0.0.1:4222", urlParseFn: fn },
+    ["127.0.0.1:4222"],
+    { urlParseFn: fn },
   );
   s.update(Object.assign(servInfo(), { connect_urls: ["h:1", "j:2/path"] }));
 


### PR DESCRIPTION
By default websocket clients will use the `wss://` protocol and connect to a NATS server. In cases where they are connecting to a proxy, it becomes possible to not only provide the `host:port` portion, but the requirement may be a full URL with a path. The proxy may have some semantic associated with the path portion.

A `URLParseFn` type enables a Transport to pre-process all URLs provided during connect - this allows re-targeting default ports to match for example default `ws://` or `wss://` ports, before the underlying hostport parsing activates.

To capture the initial values specified by a client, such as `ws://server:port/path`, the initial hp specification as modified by `URLParseFn` or not is stored in the `src` property. 

Finally, in cases where they are connecting through a proxy, added option to `ignoreClusterUpdates` to enable the client to specify to ignore them, this can be turned off in the server as well.