### PR TITLE
connect sends extraneous options

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -69,21 +69,38 @@ export class Connect {
   echo?: boolean;
   no_responders?: boolean;
   protocol: number = 1;
+  verbose?: boolean;
+  pedantic?: boolean;
+  jwt?: string;
+  nkey?: string;
+  sig?: string;
+  user?: string;
+  pass?: string;
+  auth_token?: string;
+  tls_required?: boolean;
+  name?: string;
+  lang: string;
+  version: string;
+  headers?: boolean;
 
   constructor(
     transport: { version: string; lang: string },
     opts: ConnectionOptions,
     nonce?: string,
   ) {
-    if (opts.noEcho) {
-      this.echo = false;
-    }
-    if (opts.noResponders) {
-      this.no_responders = true;
-    }
+    this.version = transport.version;
+    this.lang = transport.lang;
+    this.echo = opts.noEcho ? false : undefined;
+    this.no_responders = opts.noResponders ? true : undefined;
+    this.verbose = opts.verbose;
+    this.pedantic = opts.pedantic;
+    this.tls_required = opts.tls ? true : undefined;
+    this.name = opts.name;
+    this.headers = opts.headers;
+
     const creds =
       (opts && opts.authenticator ? opts.authenticator(nonce) : {}) || {};
-    extend(this, opts, transport, creds);
+    extend(this, creds);
   }
 }
 

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -57,12 +57,10 @@ Deno.test("properties - default connect properties", () => {
   assertEquals(cc.name, undefined, "name");
 });
 
-Deno.test("properties - configured options", async () => {
+Deno.test("properties - configured token options", async () => {
   let opts = defaultOptions();
   opts.servers = "127.0.0.1:4222";
   opts.name = "test";
-  opts.pass = "secret";
-  opts.user = "me";
   opts.token = "abc";
   opts.pedantic = true;
   opts.verbose = true;
@@ -77,7 +75,25 @@ Deno.test("properties - configured options", async () => {
   assertEquals(cc.verbose, opts.verbose);
   assertEquals(cc.pedantic, opts.pedantic);
   assertEquals(cc.name, opts.name);
+  assertEquals(cc.user, undefined);
+  assertEquals(cc.pass, undefined);
+  assertEquals(cc.auth_token, opts.token);
+});
+
+Deno.test("properties - configured user/pass options", async () => {
+  let opts = defaultOptions();
+  opts.servers = "127.0.0.1:4222";
+  opts.user = "test";
+  opts.pass = "secret";
+  // simulate the autheticator
+  opts.authenticator = buildAuthenticator(opts);
+  const auth = await opts.authenticator();
+  opts = extend(opts, auth);
+
+  const c = new Connect({ version, lang }, opts);
+  const cc = JSON.parse(JSON.stringify(c));
+
   assertEquals(cc.user, opts.user);
   assertEquals(cc.pass, opts.pass);
-  assertEquals(cc.auth_token, opts.token);
+  assertEquals(cc.auth_token, undefined);
 });


### PR DESCRIPTION
the `Connect` object was extended with all connection options rather than just the ones expected by the server,