### PR TITLE
mark info received right when the first info is processed

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -272,7 +272,6 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       this.connectedOnce = true;
       this.server.didConnect = true;
       this.server.reconnects = 0;
-      this.infoReceived = true;
       this.flushPending();
       this.heartbeats.start();
     } catch (err) {
@@ -390,6 +389,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       ? undefined
       : this.servers.update(this.info);
     if (!this.infoReceived) {
+      this.infoReceived = true;
       // send connect
       const { version, lang } = this.transport;
       try {


### PR DESCRIPTION
The receiving of the info was noted when the PONG for the connection was resolved. If the server sent another info within this timeframe, a double connect is sent resulting in the server disconnecting the client.

FIX #73