### PR TITLE
The status can now have a description.

### DIFF
--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -19,6 +19,8 @@ import { ErrorCode, NatsError } from "./error.ts";
 import { TD, TE } from "./encoders.ts";
 
 export interface MsgHdrs extends Iterable<[string, string[]]> {
+  hasError: boolean;
+  status: string;
   get(k: string): string;
   set(k: string, v: string): void;
   append(k: string, v: string): void;
@@ -35,7 +37,8 @@ export class MsgHdrsImpl implements MsgHdrs {
   static CRLF = "\r\n";
   static SEP = ": ";
   static HEADER = "NATS/1.0";
-  error?: number;
+  code?: number;
+  description = "";
   headers: Map<string, string[]> = new Map();
 
   constructor() {}
@@ -55,7 +58,7 @@ export class MsgHdrsImpl implements MsgHdrs {
   equals(mh: MsgHdrsImpl) {
     if (
       mh && this.headers.size === mh.headers.size &&
-      this.error === mh.error
+      this.code === mh.code
     ) {
       for (const [k, v] of this.headers) {
         const a = mh.values(k);
@@ -81,8 +84,13 @@ export class MsgHdrsImpl implements MsgHdrs {
     const lines = s.split(MsgHdrsImpl.CRLF);
     const h = lines[0];
     if (h !== MsgHdrsImpl.HEADER) {
-      const str = h.replace(MsgHdrsImpl.HEADER, "");
-      mh.error = parseInt(str, 10);
+      let str = h.replace(MsgHdrsImpl.HEADER, "");
+      mh.code = parseInt(str, 10);
+      const scode = mh.status.toString();
+      mh.set("Status", scode);
+      str = str.replace(mh.status.toString(), "");
+      mh.description = str.trim();
+      mh.set("Description", mh.description);
     } else {
       lines.slice(1).map((s) => {
         if (s) {
@@ -203,5 +211,16 @@ export class MsgHdrsImpl implements MsgHdrs {
   delete(k: string): void {
     const key = MsgHdrsImpl.canonicalMIMEHeaderKey(k);
     this.headers.delete(key);
+  }
+
+  get hasError() {
+    if (this.code) {
+      return this.code > 0 && this.code < 200 && this.code >= 300;
+    }
+    return false;
+  }
+
+  get status(): string {
+    return `${this.code} ${this.description}`.trim();
   }
 }

--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -21,6 +21,7 @@ import { TD, TE } from "./encoders.ts";
 export interface MsgHdrs extends Iterable<[string, string[]]> {
   hasError: boolean;
   status: string;
+  code?: number
   get(k: string): string;
   set(k: string, v: string): void;
   append(k: string, v: string): void;

--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -87,11 +87,13 @@ export class MsgHdrsImpl implements MsgHdrs {
     if (h !== MsgHdrsImpl.HEADER) {
       let str = h.replace(MsgHdrsImpl.HEADER, "");
       mh.code = parseInt(str, 10);
-      const scode = mh.status.toString();
+      const scode = mh.code.toString();
       mh.set("Status", scode);
-      str = str.replace(mh.status.toString(), "");
+      str = str.replace(scode, "");
       mh.description = str.trim();
-      mh.set("Description", mh.description);
+      if (mh.description) {
+        mh.set("Description", mh.description);
+      }
     } else {
       lines.slice(1).map((s) => {
         if (s) {

--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -21,7 +21,7 @@ import { TD, TE } from "./encoders.ts";
 export interface MsgHdrs extends Iterable<[string, string[]]> {
   hasError: boolean;
   status: string;
-  code?: number
+  code?: number;
   get(k: string): string;
   set(k: string, v: string): void;
   append(k: string, v: string): void;
@@ -216,7 +216,7 @@ export class MsgHdrsImpl implements MsgHdrs {
 
   get hasError() {
     if (this.code) {
-      return this.code > 0 && this.code < 200 && this.code >= 300;
+      return this.code > 0 && (this.code < 200 || this.code >= 300);
     }
     return false;
   }

--- a/nats-base-client/muxsubscription.ts
+++ b/nats-base-client/muxsubscription.ts
@@ -62,9 +62,9 @@ export class MuxSubscription {
         if (r) {
           if (err === null && m.headers) {
             const headers = m.headers as MsgHdrsImpl;
-            if (headers.error) {
+            if (headers.hasError) {
               err = new NatsError(
-                headers.error.toString(),
+                headers.status,
                 ErrorCode.REQUEST_ERROR,
               );
             }

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -129,7 +129,7 @@ function status(code: number, description: string): Uint8Array {
 
 function checkStatus(code = 200, description = "") {
   const h = MsgHdrsImpl.decode(status(code, description));
-  const isErrorCode = code > 0 && code < 200 && code >= 300;
+  const isErrorCode = code > 0 && (code < 200 || code >= 300);
   assertEquals(h.hasError, isErrorCode);
 
   if (code > 0) {


### PR DESCRIPTION
Added internal property `description`.
Changed internal `error` property to be `code`.
Added computed property `hasError` to return true if code is not 2xx.
Added computed property `status` that returns a formatted string with code/status.

FIX #79 