### PR TITLE
[feat] added `reply` option to RequestOptions 

### DIFF
--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -132,9 +132,17 @@ export class NatsConnectionImpl implements NatsConnection {
     if (opts.timeout < 1) {
       return Promise.reject(new NatsError("timeout", ErrorCode.INVALID_OPTION));
     }
+    if (!opts.noMux && opts.reply) {
+      return Promise.reject(
+        new NatsError(
+          "reply can only be used with noMux",
+          ErrorCode.INVALID_OPTION,
+        ),
+      );
+    }
 
     if (opts.noMux) {
-      const inbox = createInbox();
+      const inbox = opts.reply ? opts.reply : createInbox();
       const sub = this.subscribe(inbox, { max: 1, timeout: opts.timeout });
       this.publish(subject, data, { reply: inbox });
       const d = deferred<Msg>();

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -191,6 +191,7 @@ export interface RequestOptions {
   timeout: number;
   headers?: MsgHdrs;
   noMux?: boolean;
+  reply?: string;
 }
 
 export interface PublishOptions {

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -30,7 +30,7 @@ import {
 } from "../nats-base-client/internal_mod.ts";
 import type { TlsOptions } from "../nats-base-client/types.ts";
 
-const VERSION = "1.0.0-12";
+const VERSION = "1.0.0-13";
 const LANG = "nats.deno";
 
 // if trying to simply write to the connection for some reason


### PR DESCRIPTION
This change makes it easy to `request()` while specifying a reply subject that is in the client's subscribe permission set.