### PR TITLE
deno bundler safari compatibility

### DIFF
--- a/nats-base-client/bench.ts
+++ b/nats-base-client/bench.ts
@@ -23,11 +23,11 @@ export class Metric {
   name: string;
   duration: number;
   date: number;
-  payload = 0;
-  msgs = 0;
+  payload: number;
+  msgs: number;
   lang!: string;
   version!: string;
-  bytes = 0;
+  bytes: number;
   asyncRequests?: boolean;
   min?: number;
   max?: number;
@@ -36,6 +36,9 @@ export class Metric {
     this.name = name;
     this.duration = duration;
     this.date = Date.now();
+    this.payload = 0;
+    this.msgs = 0;
+    this.bytes = 0;
   }
 
   toString(): string {
@@ -81,7 +84,7 @@ export interface BenchOpts {
 
 export class Bench {
   nc: NatsConnection;
-  callbacks = false;
+  callbacks: boolean;
   msgs: number;
   size: number;
   subject: string;

--- a/nats-base-client/databuffer.ts
+++ b/nats-base-client/databuffer.ts
@@ -16,8 +16,13 @@
 import { TD, TE } from "./encoders.ts";
 
 export class DataBuffer {
-  buffers: Uint8Array[] = [];
-  byteLength = 0;
+  buffers: Uint8Array[];
+  byteLength: number;
+
+  constructor() {
+    this.buffers = [];
+    this.byteLength = 0;
+  }
 
   static concat(...bufs: Uint8Array[]): Uint8Array {
     let max = 0;

--- a/nats-base-client/denobuffer.ts
+++ b/nats-base-client/denobuffer.ts
@@ -1,4 +1,4 @@
-// Copyright 2018-2020 the Deno authors. All rights reserved. MIT license.
+// Copyright 2018-2021 the Deno authors. All rights reserved. MIT license.
 
 // This code has been ported almost directly from Go's src/bytes/buffer.go
 // Copyright 2009 The Go Authors. All rights reserved. BSD license.
@@ -74,9 +74,10 @@ export function append(origin: Uint8Array, b: number): Uint8Array {
 
 export class DenoBuffer implements Reader, Writer {
   _buf: Uint8Array; // contents are the bytes _buf[off : len(_buf)]
-  _off = 0; // read at _buf[off], write at _buf[_buf.byteLength]
+  _off: number; // read at _buf[off], write at _buf[_buf.byteLength]
 
   constructor(ab?: ArrayBuffer) {
+    this._off = 0;
     if (ab == null) {
       this._buf = new Uint8Array(0);
       return;

--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -47,7 +47,6 @@ export enum ErrorCode {
   PERMISSIONS_VIOLATION = "PERMISSIONS_VIOLATION",
 }
 
-
 export class Messages {
   messages: Map<string, string>;
 
@@ -77,7 +76,6 @@ export class Messages {
 
 // safari doesn't support static class members
 const messages: Messages = new Messages();
-
 
 export class NatsError extends Error {
   name: string;

--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -47,8 +47,8 @@ export enum ErrorCode {
   PERMISSIONS_VIOLATION = "PERMISSIONS_VIOLATION",
 }
 
+
 export class Messages {
-  static messages = new Messages();
   messages: Map<string, string>;
 
   constructor() {
@@ -67,13 +67,17 @@ export class Messages {
   }
 
   static getMessage(s: string): string {
-    return Messages.messages.getMessage(s);
+    return messages.getMessage(s);
   }
 
   getMessage(s: string): string {
     return this.messages.get(s) || s;
   }
 }
+
+// safari doesn't support static class members
+const messages: Messages = new Messages();
+
 
 export class NatsError extends Error {
   name: string;

--- a/nats-base-client/heartbeats.ts
+++ b/nats-base-client/heartbeats.ts
@@ -26,12 +26,13 @@ export class Heartbeat {
   interval: number;
   maxOut: number;
   timer?: number;
-  pendings: Promise<void>[] = [];
+  pendings: Promise<void>[];
 
   constructor(ph: PH, interval: number, maxOut: number) {
     this.ph = ph;
     this.interval = interval;
     this.maxOut = maxOut;
+    this.pendings = [];
   }
 
   // api to start the heartbeats, since this can be

--- a/nats-base-client/muxsubscription.ts
+++ b/nats-base-client/muxsubscription.ts
@@ -20,7 +20,11 @@ import { createInbox } from "./protocol.ts";
 
 export class MuxSubscription {
   baseInbox!: string;
-  reqs: Map<string, Request> = new Map<string, Request>();
+  reqs: Map<string, Request>;
+
+  constructor() {
+    this.reqs = new Map<string, Request>();
+  }
 
   size(): number {
     return this.reqs.size;

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -37,11 +37,13 @@ import { Request } from "./request.ts";
 export class NatsConnectionImpl implements NatsConnection {
   options: ConnectionOptions;
   protocol!: ProtocolHandler;
-  draining = false;
-  listeners: QueuedIterator<Status>[] = [];
+  draining: boolean;
+  listeners: QueuedIterator<Status>[];
 
   private constructor(opts: ConnectionOptions) {
+    this.draining = false;
     this.options = parseOptions(opts);
+    this.listeners = [];
   }
 
   public static connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {

--- a/nats-base-client/nkeys.ts
+++ b/nats-base-client/nkeys.ts
@@ -1,1 +1,1 @@
-export * as nkeys from "https://raw.githubusercontent.com/nats-io/nkeys.js/v1.0.0-7/modules/esm/mod.ts";
+export * as nkeys from "https://raw.githubusercontent.com/nats-io/nkeys.js/v1.0.0-9/modules/esm/mod.ts";

--- a/nats-base-client/parser.ts
+++ b/nats-base-client/parser.ts
@@ -83,10 +83,10 @@ const ASCII_9 = 57;
 // https://github.com/nats-io/nats.go/blob/master/parser.go
 export class Parser {
   dispatcher: Dispatcher<ParserEvent>;
-  state = State.OP_START;
-  as = 0;
-  drop = 0;
-  hdr = 0;
+  state: State;
+  as: number;
+  drop: number;
+  hdr: number;
   ma!: MsgArg;
   argBuf?: DenoBuffer;
   msgBuf?: DenoBuffer;
@@ -94,6 +94,9 @@ export class Parser {
   constructor(dispatcher: Dispatcher<ParserEvent>) {
     this.dispatcher = dispatcher;
     this.state = State.OP_START;
+    this.as = 0;
+    this.drop = 0;
+    this.hdr = 0;
   }
 
   parse(buf: Uint8Array): void {

--- a/nats-base-client/queued_iterator.ts
+++ b/nats-base-client/queued_iterator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The NATS Authors
+ * Copyright 2020-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { deferred } from "./util.ts";
+import { Deferred, deferred } from "./util.ts";
 import { ErrorCode, NatsError } from "./error.ts";
 
 export interface Dispatcher<T> {
@@ -20,14 +20,24 @@ export interface Dispatcher<T> {
 }
 
 export class QueuedIterator<T> implements Dispatcher<T> {
-  inflight = 0;
-  processed = 0;
-  received = 0; // this is updated by the protocol
-  protected noIterator = false;
-  protected done = false;
-  private signal = deferred<void>();
-  private yields: T[] = [];
+  inflight: number;
+  processed: number;
+  received: number; // this is updated by the protocol
+  protected noIterator: boolean;
+  protected done: boolean;
+  private signal: Deferred<void>;
+  private yields: T[];
   private err?: Error;
+
+  constructor() {
+    this.inflight = 0;
+    this.processed = 0;
+    this.received = 0;
+    this.noIterator = false;
+    this.done = false;
+    this.signal = deferred<void>();
+    this.yields = [];
+  }
 
   [Symbol.asyncIterator]() {
     return this.iterate();

--- a/nats-base-client/request.ts
+++ b/nats-base-client/request.ts
@@ -20,8 +20,8 @@ import { nuid } from "./nuid.ts";
 
 export class Request {
   token: string;
-  received = 0;
-  deferred: Deferred<Msg> = deferred();
+  received: number;
+  deferred: Deferred<Msg>;
   timer: Timeout<Msg>;
   private mux: MuxSubscription;
 
@@ -30,6 +30,8 @@ export class Request {
     opts: RequestOptions = { timeout: 1000 },
   ) {
     this.mux = mux;
+    this.received = 0;
+    this.deferred = deferred();
     this.token = nuid.next();
     extend(this, opts);
     this.timer = timeout<Msg>(opts.timeout);

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -37,10 +37,11 @@ export class ServerImpl implements Server {
   reconnects: number;
   lastConnect: number;
   gossiped: boolean;
-  tlsName = "";
+  tlsName: string;
 
   constructor(u: string, gossiped = false) {
     this.src = u;
+    this.tlsName = "";
     // remove any protocol that may have been provided
     if (u.match(/^(.*:\/\/)(.*)/m)) {
       u = u.replace(/^(.*:\/\/)(.*)/gm, "$2");
@@ -75,17 +76,19 @@ export interface ServersOptions {
  * @hidden
  */
 export class Servers {
-  private firstSelect = true;
+  private firstSelect: boolean;
   private readonly servers: ServerImpl[];
   private currentServer: ServerImpl;
-  private tlsName = "";
+  private tlsName: string;
 
   constructor(
     randomize: boolean,
     listens: string[] = [],
     opts: ServersOptions = {},
   ) {
+    this.firstSelect = true;
     this.servers = [] as ServerImpl[];
+    this.tlsName = "";
     if (listens) {
       listens.forEach((hp) => {
         hp = urlParseFn ? urlParseFn(hp) : hp;

--- a/nats-base-client/subscription.ts
+++ b/nats-base-client/subscription.ts
@@ -22,7 +22,7 @@ export class SubscriptionImpl extends QueuedIterator<Msg>
   implements Base, Subscription {
   sid!: number;
   queue?: string;
-  draining = false;
+  draining: boolean;
   max?: number;
   subject: string;
   drained?: Promise<void>;
@@ -38,6 +38,7 @@ export class SubscriptionImpl extends QueuedIterator<Msg>
     extend(this, opts);
     this.protocol = protocol;
     this.subject = subject;
+    this.draining = false;
     this.noIterator = typeof opts.callback === "function";
 
     if (opts.timeout) {

--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -18,8 +18,13 @@ import type { Msg } from "./types.ts";
 
 export class Subscriptions {
   mux!: SubscriptionImpl;
-  subs: Map<number, SubscriptionImpl> = new Map<number, SubscriptionImpl>();
-  sidCounter = 0;
+  subs: Map<number, SubscriptionImpl>;
+  sidCounter: number;
+
+  constructor() {
+    this.sidCounter = 0;
+    this.subs = new Map<number, SubscriptionImpl>();
+  }
 
   size(): number {
     return this.subs.size;

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -134,8 +134,8 @@ Deno.test("headers - request headers", async () => {
 
 function status(code: number, description: string): Uint8Array {
   const status = code
-    ? `${MsgHdrsImpl.HEADER} ${code.toString()} ${description}`.trim()
-    : MsgHdrsImpl.HEADER;
+    ? `NATS/1.0 ${code.toString()} ${description}`.trim()
+    : "NATS/1.0";
   const line = `${status}\r\n\r\n\r\n`;
   return StringCodec().encode(line);
 }


### PR DESCRIPTION
[fix] removed class field initializers and static fields as the current deno bundler doesn't polyfill.