### PR TITLE
Remove class field initializers

### DIFF
--- a/nats-base-client/denobuffer.ts
+++ b/nats-base-client/denobuffer.ts
@@ -119,7 +119,7 @@ export class DenoBuffer implements Reader, Writer {
     this._off = 0;
   }
 
-  _tryGrowByReslice = (n: number): number => {
+  _tryGrowByReslice(n: number): number {
     const l = this._buf.byteLength;
     if (n <= this.capacity - l) {
       this._reslice(l + n);
@@ -128,7 +128,7 @@ export class DenoBuffer implements Reader, Writer {
     return -1;
   };
 
-  _reslice = (len: number): void => {
+  _reslice(len: number): void {
     assert(len <= this._buf.buffer.byteLength);
     this._buf = new Uint8Array(this._buf.buffer, 0, len);
   };
@@ -169,7 +169,7 @@ export class DenoBuffer implements Reader, Writer {
     return copy(p, this._buf, m);
   }
 
-  _grow = (n: number): number => {
+  _grow(n: number): number {
     const m = this.length;
     // If buffer is empty, reset to recover space.
     if (m === 0 && this._off !== 0) {

--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -38,11 +38,12 @@ const HEADER = "NATS/1.0";
 
 export class MsgHdrsImpl implements MsgHdrs {
   code?: number;
-  description = "";
   headers: Map<string, string[]>;
+  description: string;
 
   constructor() {
     this.headers = new Map();
+    this.description = "";
   }
 
   [Symbol.iterator]() {


### PR DESCRIPTION
Angular can not use the output because of class field initializers.

This, and the corresponding PR in nats.ws are a work around for https://github.com/nats-io/nats.ws/issues/68