### PR TITLE
process error enhancements and fix

### DIFF
--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -44,6 +44,7 @@ export enum ErrorCode {
 
   // emitted by the server
   AUTHORIZATION_VIOLATION = "AUTHORIZATION_VIOLATION",
+  AUTHENTICATION_EXPIRED = "AUTHENTICATION_EXPIRED",
   NATS_PROTOCOL_ERR = "NATS_PROTOCOL_ERR",
   PERMISSIONS_VIOLATION = "PERMISSIONS_VIOLATION",
 }
@@ -101,5 +102,18 @@ export class NatsError extends Error {
   static errorForCode(code: string, chainedError?: Error): NatsError {
     const m = Messages.getMessage(code);
     return new NatsError(m, code, chainedError);
+  }
+
+  isAuthError(): boolean {
+    return this.code === ErrorCode.AUTHENTICATION_EXPIRED ||
+      this.code === ErrorCode.AUTHORIZATION_VIOLATION;
+  }
+
+  isPermissionError(): boolean {
+    return this.code === ErrorCode.PERMISSIONS_VIOLATION;
+  }
+
+  isProtocolError(): boolean {
+    return this.code === ErrorCode.NATS_PROTOCOL_ERR;
   }
 }

--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -65,7 +65,8 @@ export class Subscriptions {
     }
   }
 
-  handleError(err?: NatsError) {
+  handleError(err?: NatsError): boolean {
+    let handled = false;
     if (err) {
       const re = /^'Permissions Violation for Subscription to "(\S+)"'/i;
       const ma = re.exec(err.message);
@@ -75,10 +76,12 @@ export class Subscriptions {
           if (subj == sub.subject) {
             sub.callback(err, {} as Msg);
             sub.close();
+            handled = sub !== this.mux;
           }
         });
       }
     }
+    return handled;
   }
 
   close() {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -23,6 +23,7 @@ export enum Events {
   RECONNECT = "reconnect",
   UPDATE = "update",
   LDM = "ldm",
+  ERROR = "error",
 }
 
 export interface Status {


### PR DESCRIPTION
- [NEW] Added support for authentication expired.
- [NEW] Added Events.Error to provide a mechanism to listen for errors
- [CHANGED] 2 auth errors in a row now correctly closes the client
- [FIX] Process error was calling close, but in the context of connecting if the connection wasn't resolved, it would continue to try to connect after the close.