### PR TITLE
removed client options `headers` and `noResponders` - features auto-set if server supports headers.

### DIFF
--- a/examples/nats-pub.ts
+++ b/examples/nats-pub.ts
@@ -29,10 +29,6 @@ const payload = argv._[1] || "";
 const count = (argv.c == -1 ? Number.MAX_SAFE_INTEGER : argv.c) || 1;
 const interval = argv.i || 0;
 
-if (argv.headers) {
-  copts.headers = true;
-}
-
 if (argv.debug) {
   copts.debug = true;
 }

--- a/examples/nats-rep.ts
+++ b/examples/nats-rep.ts
@@ -27,10 +27,6 @@ const sc = StringCodec();
 const ps = argv._[1] || "";
 const payload = sc.encode(String(ps));
 
-if (argv.headers) {
-  opts.headers = true;
-}
-
 if (argv.debug) {
   opts.debug = true;
 }

--- a/examples/nats-req.ts
+++ b/examples/nats-req.ts
@@ -30,10 +30,6 @@ const payload = String(argv._[1]) || "";
 const count = (argv.c == -1 ? Number.MAX_SAFE_INTEGER : argv.c) || 1;
 const interval = argv.i;
 
-if (argv.headers) {
-  opts.headers = true;
-}
-
 if (argv.debug) {
   opts.debug = true;
 }

--- a/examples/nats-sub.ts
+++ b/examples/nats-sub.ts
@@ -26,10 +26,6 @@ if (argv.debug) {
   opts.debug = true;
 }
 
-if (argv.headers) {
-  opts.headers = true;
-}
-
 if (argv.h || argv.help || !subject) {
   console.log("Usage: nats-sub [-s server] [-q queue] [--headers] subject");
   Deno.exit(1);

--- a/nats-base-client/msg.ts
+++ b/nats-base-client/msg.ts
@@ -17,6 +17,26 @@ import { MsgHdrs, MsgHdrsImpl } from "./headers.ts";
 import type { Publisher } from "./protocol.ts";
 import type { MsgArg } from "./parser.ts";
 import { TD } from "./encoders.ts";
+import { ErrorCode, NatsError } from "./error.ts";
+
+const noResponders = "503";
+
+export function isRequestError(msg: Msg): (NatsError | null) {
+  if (msg && msg.headers) {
+    const headers = msg.headers as MsgHdrsImpl;
+    if (headers.hasError) {
+      if (headers.status === noResponders) {
+        return NatsError.errorForCode(ErrorCode.NO_RESPONDERS);
+      } else {
+        return new NatsError(
+          headers.status,
+          ErrorCode.REQUEST_ERROR,
+        );
+      }
+    }
+  }
+  return null;
+}
 
 export class MsgImpl implements Msg {
   _headers?: MsgHdrs;

--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -100,25 +100,9 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
 }
 
 export function checkOptions(info: ServerInfo, options: ConnectionOptions) {
-  const { proto, headers, tls_required: tlsRequired } = info;
+  const { proto, tls_required: tlsRequired } = info;
   if ((proto === undefined || proto < 1) && options.noEcho) {
     throw new NatsError("noEcho", ErrorCode.SERVER_OPTION_NA);
-  }
-  if ((proto === undefined || proto < 1) && options.headers) {
-    throw new NatsError("headers", ErrorCode.SERVER_OPTION_NA);
-  }
-  if (options.headers && headers !== true) {
-    throw new NatsError("headers", ErrorCode.SERVER_OPTION_NA);
-  }
-
-  if ((proto === undefined || proto < 1) && options.noResponders) {
-    throw new NatsError("noResponders", ErrorCode.SERVER_OPTION_NA);
-  }
-  if ((!headers) && options.noResponders) {
-    throw new NatsError(
-      "noResponders - requires headers",
-      ErrorCode.SERVER_OPTION_NA,
-    );
   }
   if (options.tls && !tlsRequired) {
     throw new NatsError("tls", ErrorCode.SERVER_OPTION_NA);

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -88,12 +88,10 @@ export class Connect {
     this.version = transport.version;
     this.lang = transport.lang;
     this.echo = opts.noEcho ? false : undefined;
-    this.no_responders = opts.noResponders ? true : undefined;
     this.verbose = opts.verbose;
     this.pedantic = opts.pedantic;
     this.tls_required = opts.tls ? true : undefined;
     this.name = opts.name;
-    this.headers = opts.headers;
 
     const creds =
       (opts && opts.authenticator ? opts.authenticator(nonce) : {}) || {};
@@ -442,6 +440,10 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
           info.nonce,
         );
 
+        if (info.headers) {
+          c.headers = true;
+          c.no_responders = true;
+        }
         const cs = JSON.stringify(c);
         this.transport.send(
           fastEncoder(`CONNECT ${cs}${CR_LF}`),
@@ -529,7 +531,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     let headers = Empty;
     let hlen = 0;
     if (options.headers) {
-      if (!this.options.headers) {
+      if (this.info && !this.info.headers) {
         throw new NatsError("headers", ErrorCode.SERVER_OPTION_NA);
       }
       const hdrs = options.headers as MsgHdrsImpl;

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -78,13 +78,11 @@ export interface NatsConnection {
 export interface ConnectionOptions {
   authenticator?: Authenticator;
   debug?: boolean;
-  headers?: boolean;
   maxPingOut?: number;
   maxReconnectAttempts?: number;
   name?: string;
   noEcho?: boolean;
   noRandomize?: boolean;
-  noResponders?: boolean;
   pass?: string;
   pedantic?: boolean;
   pingInterval?: number;

--- a/tests/autounsub_test.ts
+++ b/tests/autounsub_test.ts
@@ -202,7 +202,7 @@ Deno.test("autounsub - check cancelled request leaks", async () => {
   // the rejection should be timeout
   const lock = Lock();
   rp.catch((rej) => {
-    assertEquals(rej?.code, ErrorCode.TIMEOUT);
+    assertEquals(rej?.code, ErrorCode.NO_RESPONDERS);
     lock.unlock();
   });
 

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -361,7 +361,7 @@ Deno.test("basics - request timeout", async () => {
       fail();
     })
     .catch((err) => {
-      assertEquals(err.code, ErrorCode.TIMEOUT);
+      assertEquals(err.code, ErrorCode.NO_RESPONDERS);
       lock.unlock();
     });
 
@@ -546,9 +546,13 @@ Deno.test("basics - no mux requests create normal subs", async () => {
 Deno.test("basics - no mux requests timeout", async () => {
   const nc = await connect({ servers: u }) as NatsConnectionImpl;
   const lock = Lock();
-  nc.request(createInbox(), Empty, { timeout: 250, noMux: true })
+  await nc.request(
+    createInbox(),
+    Empty,
+    { timeout: 1000, noMux: true },
+  )
     .catch((err) => {
-      assertErrorCode(err, ErrorCode.TIMEOUT);
+      assertErrorCode(err, ErrorCode.NO_RESPONDERS);
       lock.unlock();
     });
   await lock;

--- a/tests/noresponders_test.ts
+++ b/tests/noresponders_test.ts
@@ -26,8 +26,6 @@ Deno.test("noresponders - option", async () => {
   const nc = await connect(
     {
       servers: `127.0.0.1:${srv.port}`,
-      headers: true,
-      noResponders: true,
     },
   );
 
@@ -51,8 +49,6 @@ Deno.test("noresponders - list", async () => {
   const nc = await connect(
     {
       servers: `nats://127.0.0.1:${srv.port}`,
-      headers: true,
-      noResponders: true,
     },
   );
 


### PR DESCRIPTION
javascript clients were exposing `headers` and `noResponder` optionsto enable/disable these features.
Go client simply keys from server support. Changed to match.