### PR TITLE
support an inboxPrefix in the options of connect()

### DIFF
--- a/nats-base-client/muxsubscription.ts
+++ b/nats-base-client/muxsubscription.ts
@@ -30,8 +30,8 @@ export class MuxSubscription {
     return this.reqs.size;
   }
 
-  init(): string {
-    this.baseInbox = `${createInbox()}.`;
+  init(inboxPrefix?: string): string {
+    this.baseInbox = `${createInbox(inboxPrefix)}.`;
     return this.baseInbox;
   }
 

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -54,8 +54,13 @@ const FLUSH_THRESHOLD = 1024 * 32;
 
 export const INFO = /^INFO\s+([^\r\n]+)\r\n/i;
 
-export function createInbox(): string {
-  return `_INBOX.${nuid.next()}`;
+export function createInbox(inboxPrefix?: string): string {
+  if (typeof inboxPrefix === "string") {
+    inboxPrefix = inboxPrefix + ".";
+  } else {
+    inboxPrefix = "";
+  }
+  return `${inboxPrefix}_INBOX.${nuid.next()}`;
 }
 
 const PONG_CMD = fastEncoder("PONG\r\n");
@@ -684,7 +689,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   private initMux(): void {
     const mux = this.subscriptions.getMux();
     if (!mux) {
-      const inbox = this.muxSubscriptions.init();
+      const inbox = this.muxSubscriptions.init(this.options.inboxPrefix);
       // dot is already part of mux
       const sub = new SubscriptionImpl(this, `${inbox}*`);
       sub.callback = this.muxSubscriptions.dispatcher();

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -15,6 +15,7 @@
 import {
   ConnectionOptions,
   DebugEvents,
+  DEFAULT_INBOX_PREFIX,
   DEFAULT_MAX_PING_OUT,
   DEFAULT_PING_INTERVAL,
   DEFAULT_RECONNECT_TIME_WAIT,
@@ -55,12 +56,10 @@ const FLUSH_THRESHOLD = 1024 * 32;
 export const INFO = /^INFO\s+([^\r\n]+)\r\n/i;
 
 export function createInbox(inboxPrefix?: string): string {
-  if (typeof inboxPrefix === "string") {
-    inboxPrefix = inboxPrefix + ".";
-  } else {
-    inboxPrefix = "";
+  if (typeof inboxPrefix !== "string") {
+    inboxPrefix = DEFAULT_INBOX_PREFIX;
   }
-  return `${inboxPrefix}_INBOX.${nuid.next()}`;
+  return `${inboxPrefix}${nuid.next()}`;
 }
 
 const PONG_CMD = fastEncoder("PONG\r\n");

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -100,6 +100,7 @@ export interface ConnectionOptions {
   verbose?: boolean;
   waitOnFirstConnect?: boolean;
   ignoreClusterUpdates?: boolean;
+  inboxPrefix?: string;
 }
 
 // these may not be supported on all environments

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -40,6 +40,7 @@ export enum DebugEvents {
 export const DEFAULT_PORT = 4222;
 export const DEFAULT_HOST = "127.0.0.1";
 export const DEFAULT_HOSTPORT = `${DEFAULT_HOST}:${DEFAULT_PORT}`;
+export const DEFAULT_INBOX_PREFIX = "_INBOX.";
 
 // DISCONNECT Parameters, 2 sec wait, 10 tries
 export const DEFAULT_RECONNECT_TIME_WAIT = 2 * 1000;

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -16,6 +16,7 @@ import {
   assert,
   assertEquals,
   assertMatch,
+  assertNotMatch,
   fail,
 } from "https://deno.land/std@0.83.0/testing/asserts.ts";
 import {
@@ -348,6 +349,8 @@ Deno.test("basics - request", async () => {
     }
   })().then();
   const msg = await nc.request(s);
+  // ensure default prefix is used.
+  assertMatch(msg.subject, /^_INBOX[.]/)
   await nc.close();
   assertEquals(sc.decode(msg.data), "foo");
 });
@@ -438,7 +441,7 @@ Deno.test("basics - request with custom subject", async () => {
 
 Deno.test("basics - request with inbox prefix", async () => {
   const sc = StringCodec();
-  const nc = await connect({ servers: u, inboxPrefix: "apple" });
+  const nc = await connect({ servers: u, inboxPrefix: "apple." });
   nc.subscribe("q", {
     callback: (err, msg) => {
       msg.respond(sc.encode("hello"));
@@ -450,7 +453,7 @@ Deno.test("basics - request with inbox prefix", async () => {
     Empty,
   );
   assertMatch(reply.subject, /^apple[.]/);
-
+  assertNotMatch(reply.subject, /^apple[.]_INBOX/);
   await nc.close();
 });
 

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -15,6 +15,7 @@
 import {
   assert,
   assertEquals,
+  assertMatch,
   fail,
 } from "https://deno.land/std@0.83.0/testing/asserts.ts";
 import {
@@ -431,6 +432,24 @@ Deno.test("basics - request with custom subject", async () => {
     const nerr = err as NatsError;
     assertEquals(ErrorCode.INVALID_OPTION, nerr.code);
   }
+
+  await nc.close();
+});
+
+Deno.test("basics - request with inbox prefix", async () => {
+  const sc = StringCodec();
+  const nc = await connect({ servers: u, inboxPrefix: "apple" });
+  nc.subscribe("q", {
+    callback: (err, msg) => {
+      msg.respond(sc.encode("hello"));
+    },
+  });
+
+  const reply = await nc.request(
+    "q",
+    Empty,
+  );
+  assertMatch(reply.subject, /^apple[.]/);
 
   await nc.close();
 });


### PR DESCRIPTION
This is needed so that JWT tokens can enforce per-user _INBOX prefixes which can only be subscribed to by the individual user, but all other users can publish to that per-user _INBOX prefix. Note that the Java client also supports this option:

https://javadoc.io/doc/io.nats/jnats/latest/io/nats/client/Options.Builder.html#inboxPrefix-java.lang.String-
