### PR TITLE
Preparing for JetStream

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,4 @@
 ## Community Code of Conduct
 
-NATS follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+NATS follows the
+[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,4 @@
 # NATS.deno Client Governance
 
-NATS.deno Client is part of the NATS project and is subject to the [NATS Governance](https://github.com/nats-io/nats-general/blob/master/GOVERNANCE.md).
+NATS.deno Client is part of the NATS project and is subject to the
+[NATS Governance](https://github.com/nats-io/nats-general/blob/master/GOVERNANCE.md).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,6 +3,8 @@
 Maintainership is on a per project basis.
 
 ### Maintainers
-  - Alberto Ricart <alberto@nats.io> [@aricart](https://github.com/aricart)
-  - Derek Collison <derek@nats.io> [@derekcollison](https://github.com/derekcollison)
-  - Ivan Kozlovic <ivan@nats.io> [@kozlovic](https://github.com/kozlovic)
+
+- Alberto Ricart <alberto@nats.io> [@aricart](https://github.com/aricart)
+- Derek Collison <derek@nats.io>
+  [@derekcollison](https://github.com/derekcollison)
+- Ivan Kozlovic <ivan@nats.io> [@kozlovic](https://github.com/kozlovic)

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,7 +1,10 @@
 reviewers:
+
 - aricart
 - derekcollison
 - kozlovic
+
 approvers:
+
 - aricart
 - derekcollison

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # NATS.deno - A [NATS](http://nats.io) client for [Deno](https://deno.land)
 
-
 A Deno client for the [NATS messaging system](https://nats.io).
 
 [![License](https://img.shields.io/badge/Licence-Apache%202.0-blue.svg)](./LICENSE)
 ![Test NATS.deno](https://github.com/nats-io/nats.deno/workflows/NATS.deno/badge.svg)
 
-
 # Installation
 
-** :warning: NATS.deno is a release candidate** you can get the current development version by:
+** :warning: NATS.deno is a release candidate** you can get the current
+development version by:
 
 ```bash
 import * as nats from "https://raw.githubusercontent.com/nats-io/nats.deno/main/src/mod.ts"
@@ -17,26 +16,23 @@ import * as nats from "https://raw.githubusercontent.com/nats-io/nats.deno/main/
 
 To see a list of items that are under development see [TODO](TODO.md).
 
-
 ## Basics
-
 
 ### Connecting to a nats-server
 
-To connect to a server you use the `connect()` function. It returns
-a connection that you can use to interact with the server. You can customize
-the behavior of the client by specifying many [`ConnectionOptions`](#Connection_Options).
+To connect to a server you use the `connect()` function. It returns a connection
+that you can use to interact with the server. You can customize the behavior of
+the client by specifying many [`ConnectionOptions`](#Connection_Options).
 
-By default, a connection will attempt a connection on`127.0.0.1:4222`. 
-If the connection is dropped, the client will attempt to reconnect. 
-You can customize the server you want to connect to by specifying `port` 
-(for local connections), or full host port on the `servers` option.
-Note that the `servers` option can be a single hostport (a string) or
-an array of hostports.
+By default, a connection will attempt a connection on`127.0.0.1:4222`. If the
+connection is dropped, the client will attempt to reconnect. You can customize
+the server you want to connect to by specifying `port` (for local connections),
+or full host port on the `servers` option. Note that the `servers` option can be
+a single hostport (a string) or an array of hostports.
 
 The example below will attempt to connect to different servers by specifying
-different `ConnectionOptions`. At least two of them should work if your
-internet is working.
+different `ConnectionOptions`. At least two of them should work if your internet
+is working.
 
 ```typescript
 // import the connect function
@@ -70,43 +66,42 @@ await servers.forEach(async (v) => {
 });
 ```
 
-To disconnect from the nats-server, call `close()` on the connection.
-A connection can also be terminated when an unexpected error happens. 
-For example, the server returns a run-time error. In those cases, 
-the client will re-initiate a connection.
+To disconnect from the nats-server, call `close()` on the connection. A
+connection can also be terminated when an unexpected error happens. For example,
+the server returns a run-time error. In those cases, the client will re-initiate
+a connection.
 
-By default, the client will always attempt to reconnect if the connection
-is closed for a reason other than calling `close()`. To get notified when
-the connection is closed for some reason, await the resolution of the Promise 
-returned by `closed()`. If closed resolves to a value, the value is a `NatsError`
-indicating why the connection closed.
-
+By default, the client will always attempt to reconnect if the connection is
+closed for a reason other than calling `close()`. To get notified when the
+connection is closed for some reason, await the resolution of the Promise
+returned by `closed()`. If closed resolves to a value, the value is a
+`NatsError` indicating why the connection closed.
 
 ### Publish and Subscribe
 
-The basic client operations are `publish` to send messages and
-`subscribe` to receive messages. 
+The basic client operations are `publish` to send messages and `subscribe` to
+receive messages.
 
-Messages are published to a subject. A subject is like an URL with the
-exception that it doesn't specify an actual endpoint. All recipients that
-have expressed interest in a subject will receive messages addressed to that subject
-(provided they have access and permissions to get it). To express interest 
-in a subject, you create a `subscription`.
+Messages are published to a subject. A subject is like an URL with the exception
+that it doesn't specify an actual endpoint. All recipients that have expressed
+interest in a subject will receive messages addressed to that subject (provided
+they have access and permissions to get it). To express interest in a subject,
+you create a `subscription`.
 
-In JavaScript clients (websocket, Deno, or Node) subscriptions work as an
-async iterator - clients simply loop to process messages as they become available.
+In JavaScript clients (websocket, Deno, or Node) subscriptions work as an async
+iterator - clients simply loop to process messages as they become available.
 
-NATS messages are payload agnostic. Payloads are `Uint8Arrays`. You can easily 
-convert to and from JSON or strings by using  `JSONCodec` or `StringCodec`, 
-or a custom `Codec`.
+NATS messages are payload agnostic. Payloads are `Uint8Arrays`. You can easily
+convert to and from JSON or strings by using `JSONCodec` or `StringCodec`, or a
+custom `Codec`.
 
-To cancel a subscription and terminate your interest, you call `unsubscribe()` 
+To cancel a subscription and terminate your interest, you call `unsubscribe()`
 or `drain()` on a subscription. Unsubscribe will typically terminate regardless
-of whether there are messages in flight for the client. Drain ensures
-that all messages that are inflight are processed before canceling the
-subscription. Connections can also be drained as well. Draining a connection
-closes it, after all subscriptions have been drained and all outbound messages
-have been sent to the server.
+of whether there are messages in flight for the client. Drain ensures that all
+messages that are inflight are processed before canceling the subscription.
+Connections can also be drained as well. Draining a connection closes it, after
+all subscriptions have been drained and all outbound messages have been sent to
+the server.
 
 ```typescript
 // import the connect function
@@ -139,22 +134,19 @@ nc.publish("hello", sc.encode("again"));
 await nc.drain();
 ```
 
-
 ### Wildcard Subscriptions
 
-Subjects can be used to organize messages into hierarchies.
-For example, a subject may contain additional information that
-can be useful in providing a context to the message, such as
-the ID of the client that sent the message, or the region where
-a message originated.
+Subjects can be used to organize messages into hierarchies. For example, a
+subject may contain additional information that can be useful in providing a
+context to the message, such as the ID of the client that sent the message, or
+the region where a message originated.
 
-Instead of subscribing to each specific subject, you can create 
-subscriptions that have subjects with wildcards. Wildcards match
-one or more tokens in a subject. A token is a string following a
-period.
+Instead of subscribing to each specific subject, you can create subscriptions
+that have subjects with wildcards. Wildcards match one or more tokens in a
+subject. A token is a string following a period.
 
-All subscriptions are independent. If two different subscriptions
-match a subject, both will get to process the message:
+All subscriptions are independent. If two different subscriptions match a
+subject, both will get to process the message:
 
 ```javascript
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
@@ -189,26 +181,25 @@ printMsgs(s3);
 
 // don't exit until the client closes
 await nc.closed();
-
 ```
 
 ### Services: Request/Reply
 
-Request/Reply is NATS equivalent to an HTTP request. To make requests
-you publish messages as you did before, but also specify a `reply`
-subject. The `reply` subject is where a service will publish your response.
+Request/Reply is NATS equivalent to an HTTP request. To make requests you
+publish messages as you did before, but also specify a `reply` subject. The
+`reply` subject is where a service will publish your response.
 
-NATS provides syntactic sugar, for publishing requests. The `request()` API
-will generate a reply subject and manage the creation of a subscription 
-under the covers. It will also start a timer to ensure that if a response
-is not received within your alloted time, the request fails. The example
-also illustrates a graceful shutdown.
+NATS provides syntactic sugar, for publishing requests. The `request()` API will
+generate a reply subject and manage the creation of a subscription under the
+covers. It will also start a timer to ensure that if a response is not received
+within your alloted time, the request fails. The example also illustrates a
+graceful shutdown.
 
 #### Services
 
 Here's an example of a service. It is a bit more complicated than expected
-simply to illustrate not only how to create responses, but how
-the subject itself is used to dispatch different behaviors.
+simply to illustrate not only how to create responses, but how the subject
+itself is used to dispatch different behaviors.
 
 ```typescript
 import { connect, StringCodec, Subscription } from "../../src/mod.ts";
@@ -278,16 +269,15 @@ await nc.closed().then((err?: void | Error) => {
   }
   console.log(m);
 });
-
 ```
 
 #### Making Requests
 
-Here's a simple example of a client making a simple request
-from the service above:
+Here's a simple example of a client making a simple request from the service
+above:
 
 ```typescript
-import { connect, StringCodec, Empty } from "../../src/mod.ts";
+import { connect, Empty, StringCodec } from "../../src/mod.ts";
 
 // create a connection
 const nc = await connect({ servers: "demo.nats.io:4222" });
@@ -307,17 +297,17 @@ await nc.request("time", Empty, { timeout: 1000 })
   });
 
 await nc.close();
-
 ```
 
 ### Queue Groups
-Queue groups allow scaling of services horizontally. Subscriptions for members of a 
-queue group are treated as a single service. When you send a message to a queue group
-subscription, only a single client in a queue group will receive it. 
 
-There can be any number of queue groups. Each group is treated as its own independent
-unit. Note that non-queue subscriptions are also independent of subscriptions in a queue
-group.
+Queue groups allow scaling of services horizontally. Subscriptions for members
+of a queue group are treated as a single service. When you send a message to a
+queue group subscription, only a single client in a queue group will receive it.
+
+There can be any number of queue groups. Each group is treated as its own
+independent unit. Note that non-queue subscriptions are also independent of
+subscriptions in a queue group.
 
 ```typescript
 import {
@@ -397,11 +387,11 @@ Run it and publish a request to the subject `echo` to see what happens.
 
 ### Headers
 
-NATS headers are similar to HTTP headers. Headers are enabled automatically\
-if the server supports them. Note that if you publish a message using headers
-but the server doesn't support them, an Error is thrown. Also note that
-even if you are publishing a message with a header, it is possible for the
-recipient to not support them.
+NATS headers are similar to HTTP headers. Headers are enabled automatically if
+the server supports them. Note that if you publish a message using headers but
+the server doesn't support them, an Error is thrown. Also note that even if you
+are publishing a message with a header, it is possible for the recipient to not
+support them.
 
 ```typescript
 import { connect, createInbox, Empty, headers } from "../../src/mod.ts";
@@ -438,41 +428,39 @@ nc.publish(subj, Empty, { headers: h });
 
 await nc.flush();
 await nc.close();
-
 ```
 
 ### No Responders
 
-Requests can fail for many reasons. A common reason for a failure is the 
-lack of interest in the subject. Typically these surface as a
-timeout error. If the server is enabled to use headers, it will also
-enable a `no responders` feature. If you send a request for which there's
-no interest, the request will be immediately rejected:
+Requests can fail for many reasons. A common reason for a failure is the lack of
+interest in the subject. Typically these surface as a timeout error. If the
+server is enabled to use headers, it will also enable a `no responders` feature.
+If you send a request for which there's no interest, the request will be
+immediately rejected:
 
 ```typescript
 const nc = await connect({
-    servers: `demo.nats.io` },
-);
+  servers: `demo.nats.io`,
+});
 
 try {
-  const m = await nc.request('hello.world');
+  const m = await nc.request("hello.world");
   console.log(m.data);
-} catch(err) {
-  const nerr = err as NatsError
+} catch (err) {
+  const nerr = err as NatsError;
   switch (nerr.code) {
     case ErrorCode.NO_RESPONDERS:
-      console.log("no one is listening to 'hello.world'")
+      console.log("no one is listening to 'hello.world'");
       break;
     case ErrorCode.TIMEOUT:
-      console.log("someone is listening but didn't respond")
+      console.log("someone is listening but didn't respond");
       break;
     default:
-      console.log("request failed", err)
+      console.log("request failed", err);
   }
 }
 
 await nc.close();
-
 ```
 
 ### Authentication
@@ -485,52 +473,55 @@ NATS supports many different forms of credentials:
 - client certificates
 - JWTs
 
-For user/password and token authentication, you can simply provide them
-as `ConnectionOptions` - see `user`, `pass`, `token`. Internally these
-mechanisms are implemented as an `Authenticator`. An `Authenticator` is
-simply a function that handles the type of authentication specified.
+For user/password and token authentication, you can simply provide them as
+`ConnectionOptions` - see `user`, `pass`, `token`. Internally these mechanisms
+are implemented as an `Authenticator`. An `Authenticator` is simply a function
+that handles the type of authentication specified.
 
-Setting the `user`/`pass` or `token` options, simply initializes an `Authenticator`
-and sets the username/password. 
+Setting the `user`/`pass` or `token` options, simply initializes an
+`Authenticator` and sets the username/password.
 
 ```typescript
-// if the connection requires authentication, provide `user` and `pass` or 
+// if the connection requires authentication, provide `user` and `pass` or
 // `token` options in the NatsConnectionOptions
 import { connect } from "src/mod.ts";
 
-const nc1 = await connect({servers: "127.0.0.1:4222", user: "jenny", pass: "867-5309"});
-const nc2 = await connect({port: 4222, token: "t0pS3cret!"});
+const nc1 = await connect({
+  servers: "127.0.0.1:4222",
+  user: "jenny",
+  pass: "867-5309",
+});
+const nc2 = await connect({ port: 4222, token: "t0pS3cret!" });
 ```
 
 #### Authenticators
 
-NKEYs and JWT authentication are more complex, as they cryptographically 
-respond to a server challenge.
+NKEYs and JWT authentication are more complex, as they cryptographically respond
+to a server challenge.
 
-Because NKEY and JWT authentication may require reading data from a file or
-an HTTP cookie, these forms of authentication will require a bit more from
-the developer to activate them. However, the work is related to accessing
-these resources varies depending on the platform.
+Because NKEY and JWT authentication may require reading data from a file or an
+HTTP cookie, these forms of authentication will require a bit more from the
+developer to activate them. However, the work is related to accessing these
+resources varies depending on the platform.
 
 After the credential artifacts are read, you can use one of these functions to
-create the authenticator. You then simply assign it to the `authenticator` property of
-the `ConnectionOptions`:
+create the authenticator. You then simply assign it to the `authenticator`
+property of the `ConnectionOptions`:
 
 - `nkeyAuthenticator(seed?: Uint8Array | (() => Uint8Array)): Authenticator`
 - `jwtAuthenticator(jwt: string | (() => string), seed?: Uint8Array | (()=> Uint8Array)): Authenticator`
 - `credsAuthenticator(creds: Uint8Array): Authenticator`
 
-The first two options provide the ability to specify functions that return
-the desired value. This enables dynamic environments such as a browser where
-values accessed by fetching a value from a cookie.
-
+The first two options provide the ability to specify functions that return the
+desired value. This enables dynamic environments such as a browser where values
+accessed by fetching a value from a cookie.
 
 Here's an example:
 
 ```javascript
-  // read the creds file as necessary, in the case it
-  // is part of the code for illustration purposes
-  const creds = `-----BEGIN NATS USER JWT-----
+// read the creds file as necessary, in the case it
+// is part of the code for illustration purposes
+const creds = `-----BEGIN NATS USER JWT-----
     eyJ0eXAiOiJqdSDJB....
   ------END NATS USER JWT------
 
@@ -543,25 +534,25 @@ Here's an example:
   ------END USER NKEY SEED------
 `;
 
-  const nc = await connect(
-    {
-      port: 4222,
-      authenticator: credsAuthenticator(new TextEncoder().encode(creds)),
-    },
-  );
+const nc = await connect(
+  {
+    port: 4222,
+    authenticator: credsAuthenticator(new TextEncoder().encode(creds)),
+  },
+);
 ```
 
 ### Flush
 
-Flush sends a PING to the server. When the server responds with PONG
-you are guaranteed that all pending data was sent and received by the server.
-Note `ping()` effectively adds a server round-trip. All NATS clients
-handle their buffering optimally, so `ping(): Promise<void>` shouldn't 
-be used except in cases where you are writing some sort of test.
+Flush sends a PING to the server. When the server responds with PONG you are
+guaranteed that all pending data was sent and received by the server. Note
+`ping()` effectively adds a server round-trip. All NATS clients handle their
+buffering optimally, so `ping(): Promise<void>` shouldn't be used except in
+cases where you are writing some sort of test.
 
 ```javascript
-nc.publish('foo');
-nc.publish('bar');
+nc.publish("foo");
+nc.publish("bar");
 await nc.flush();
 ```
 
@@ -569,24 +560,30 @@ await nc.flush();
 
 When you publish a message you can specify some options:
 
-- `reply` - this is a subject to receive a reply (you must setup a subscription) before you publish.
+- `reply` - this is a subject to receive a reply (you must setup a subscription)
+  before you publish.
 - `headers` - a set of headers to decorate the message.
 
 ### `SubscriptionOptions`
 
 You can specify several options when creating a subscription:
+
 - `max`: maximum number of messages to receive - auto unsubscribe
 - `timeout`: how long to wait for the first message
 - `queue`: the [queue group](#Queue-Groups) name the subscriber belongs to
-- `callback`: a function with the signature `(err: NatsError|null, msg: Msg) => void;` that should be used for handling the message. Subscriptions with callbacks are NOT iterators.
+- `callback`: a function with the signature
+  `(err: NatsError|null, msg: Msg) => void;` that should be used for handling
+  the message. Subscriptions with callbacks are NOT iterators.
 
 #### Auto Unsubscribe
+
 ```javascript
 // subscriptions can auto unsubscribe after a certain number of messages
-nc.subscribe('foo', { max: 10 });
+nc.subscribe("foo", { max: 10 });
 ```
 
 #### Timeout Subscriptions
+
 ```javascript
 // create subscription with a timeout, if no message arrives
 // within the timeout, the function running the iterator with
@@ -611,78 +608,76 @@ When making a request, there are several options you can pass:
 
 - `timeout`: how long to wait for the response
 - `headers`: optional headers to include with the message
-- `noMux`: create a new subscription to handle the request. Normally a shared subscription is used to receive response messages.
+- `noMux`: create a new subscription to handle the request. Normally a shared
+  subscription is used to receive response messages.
 - `reply`: optional subject where the reply should be sent.
 
 #### `noMux` and `reply`
 
-Under the hood the request API simply uses a wildcard subscription
-to handle all requests you send.
+Under the hood the request API simply uses a wildcard subscription to handle all
+requests you send.
 
-In some cases the default subscription strategy doesn't work correctly.
-For example a client may be constrained by the subjects where it can
-receive replies.
+In some cases the default subscription strategy doesn't work correctly. For
+example a client may be constrained by the subjects where it can receive
+replies.
 
 When `noMux` is set to `true`, the client will create a normal subscription for
-receiving the response to a generated inbox subject before the request is published. 
-The `reply` option can be used to override the generated inbox subject with an application
-provided one. Note that setting `reply` requires `noMux` to be `true`:
+receiving the response to a generated inbox subject before the request is
+published. The `reply` option can be used to override the generated inbox
+subject with an application provided one. Note that setting `reply` requires
+`noMux` to be `true`:
 
 ```typescript
-  const m = await nc.request(
-    "q",
-    Empty,
-    { reply: "bar", noMux: true, timeout: 1000 },
-  );
+const m = await nc.request(
+  "q",
+  Empty,
+  { reply: "bar", noMux: true, timeout: 1000 },
+);
 ```
 
 ### Draining Connections and Subscriptions
 
-Draining provides for a graceful way to unsubscribe or 
-close a connection without losing messages that have 
-already been dispatched to the client.
+Draining provides for a graceful way to unsubscribe or close a connection
+without losing messages that have already been dispatched to the client.
 
 You can drain a subscription or all subscriptions in a connection.
 
-When you drain a subscription, the client sends an `unsubscribe`
-protocol message to the server followed by a `flush`. The
-subscription handler is only removed after the server responds. 
-Thus all pending messages for the subscription have been processed.
+When you drain a subscription, the client sends an `unsubscribe` protocol
+message to the server followed by a `flush`. The subscription handler is only
+removed after the server responds. Thus all pending messages for the
+subscription have been processed.
 
-Draining a connection, drains all subscriptions. However
-when you drain the connection it becomes impossible to make
-new subscriptions or send new requests. After the last
-subscription is drained it also becomes impossible to publish
-a message. These restrictions do not exist when just draining
-a subscription.
-
+Draining a connection, drains all subscriptions. However when you drain the
+connection it becomes impossible to make new subscriptions or send new requests.
+After the last subscription is drained it also becomes impossible to publish a
+message. These restrictions do not exist when just draining a subscription.
 
 ### Lifecycle/Informational Events
 
 Clients can get notification on various event types:
+
 - `Events.DISCONNECT`
 - `Events.RECONNECT`
 - `Events.UPDATE`
 - `Events.LDM`
 - `Events.ERROR`
 
-The first two fire when a client disconnects and reconnects respectively.
-The payload will be the server where the event took place.
+The first two fire when a client disconnects and reconnects respectively. The
+payload will be the server where the event took place.
 
 The `UPDATE` event notifies whenever the client receives a cluster configuration
-update. The `ServersChanged` interface provides two arrays: `added` and `deleted`
-listing the servers that were added or removed. 
+update. The `ServersChanged` interface provides two arrays: `added` and
+`deleted` listing the servers that were added or removed.
 
-The `LDM` event notifies that the current server has signaled that it
-is running in _Lame Duck Mode_ and will evict clients. Depending on the server
+The `LDM` event notifies that the current server has signaled that it is running
+in _Lame Duck Mode_ and will evict clients. Depending on the server
 configuration policy, the client may want to initiate an ordered shutdown, and
 initiate a new connection to a different server in the cluster.
 
-The `ERROR` event notifies you of async errors that couldn't be routed
-in a more precise way to your client. For example, permission errors for 
-a subscription or request, will properly be reported by the subscription 
-or request. However, permission errors on publish will be reported via 
-the status mechanism.
+The `ERROR` event notifies you of async errors that couldn't be routed in a more
+precise way to your client. For example, permission errors for a subscription or
+request, will properly be reported by the subscription or request. However,
+permission errors on publish will be reported via the status mechanism.
 
 ```javascript
 const nc = await connect(opts);
@@ -692,99 +687,102 @@ const nc = await connect(opts);
     console.info(`${s.type}: ${s.data}`);
   }
 })().then();
-
 ```
 
-Be aware that when a client closes, you will need to wait for the `closed()` promise to resolve.
-When it resolves, the client is done and will not reconnect.
+Be aware that when a client closes, you will need to wait for the `closed()`
+promise to resolve. When it resolves, the client is done and will not reconnect.
 
 ### Async vs. Callbacks
 
-Previous versions of the JavaScript NATS clients specified callbacks
-for message processing. This required complex handling logic when a
-service required coordination of operations. Callbacks are an
-inversion of control anti-pattern.
+Previous versions of the JavaScript NATS clients specified callbacks for message
+processing. This required complex handling logic when a service required
+coordination of operations. Callbacks are an inversion of control anti-pattern.
 
-The async APIs trivialize complex coordination and makes your code
-easier to maintain. With that said, there are some implications:
+The async APIs trivialize complex coordination and makes your code easier to
+maintain. With that said, there are some implications:
 
 - Async subscriptions buffer inbound messages.
 - Subscription processing delays until the runtime executes the promise related
   microtasks at the end of an event loop.
 
-In a traditional callback-based library, I/O happens after all data yielded by
-a read in the current event loop completes processing. This means that
-callbacks are invoked as part of processing. With async, the processing is queued
-in a microtask queue. At the end of the event loop, the runtime processes
-the microtasks, which in turn resumes your functions. As expected, this
-increases latency, but also provides additional liveliness.
+In a traditional callback-based library, I/O happens after all data yielded by a
+read in the current event loop completes processing. This means that callbacks
+are invoked as part of processing. With async, the processing is queued in a
+microtask queue. At the end of the event loop, the runtime processes the
+microtasks, which in turn resumes your functions. As expected, this increases
+latency, but also provides additional liveliness.
 
-To reduce async latency, the NATS client allows processing a subscription
-in the same event loop that dispatched the message. Simply specify a `callback`
-in the subscription options. The signature for a callback is
+To reduce async latency, the NATS client allows processing a subscription in the
+same event loop that dispatched the message. Simply specify a `callback` in the
+subscription options. The signature for a callback is
 `(err: (NatsError|null), msg: Msg) => void`. When specified, the subscription
-iterator will never yield a message, as the callback will intercept all messages.
+iterator will never yield a message, as the callback will intercept all
+messages.
 
-Note that `callback` likely shouldn't be documented, as it may be a workaround to an underlying application problem where you should be
-considering a different strategy to horizontally scale your application,
-or reduce pressure on the clients, such as using queue workers,
-or more explicitly targeting messages. With that said, there are many situations
-where using callbacks can be more performant or appropriate.
+Note that `callback` likely shouldn't be documented, as it may be a workaround
+to an underlying application problem where you should be considering a different
+strategy to horizontally scale your application, or reduce pressure on the
+clients, such as using queue workers, or more explicitly targeting messages.
+With that said, there are many situations where using callbacks can be more
+performant or appropriate.
 
 ## Connection Options
 
 The following is the list of connection options and default values.
 
-| Option                 | Default                   | Description
-|--------                |---------                  |------------
-| `authenticator`        | none                      | Specifies the authenticator function that sets the client credentials.
-| `debug`                | `false`                   | If `true`, the client prints protocol interactions to the console. Useful for debugging. 
-| `maxPingOut`           | `2`                       | Max number of pings the client will allow unanswered before raising a stale connection error.
-| `maxReconnectAttempts` | `10`                      | Sets the maximum number of reconnect attempts. The value of `-1` specifies no limit.
-| `name`                 |                           | Optional client name - recommended to be set to a unique client name.
-| `noEcho`               | `false`                   | Subscriptions receive messages published by the client. Requires server support (1.2.0). If set to true, and the server does not support the feature, an error with code `NO_ECHO_NOT_SUPPORTED` is emitted, and the connection is aborted. Note that it is possible for this error to be emitted on reconnect when the server reconnects to a server that does not support the feature.
-| `noRandomize`          | `false`                   | If set, the order of user-specified servers is randomized.
-| `pass`                 |                           | Sets the password for a connection.
-| `pedantic`             | `false`                   | Turns on strict subject format checks.
-| `pingInterval`         | `120000`                  | Number of milliseconds between client-sent pings.
-| `port`                 | `4222`                    | Port to connect to (only used if `servers` is not specified).
-| `reconnectTimeWait`    | `2000`                    | If disconnected, the client will wait the specified number of milliseconds between reconnect attempts.
-| `reconnectJitter`      | `100`                     | Number of millis to randomize after `reconnectTimeWait`.
-| `reconnectJitterTLS`   | `1000`                    | Number of millis to randomize after `reconnectTimeWait` when TLS options are specified.
-| `reconnectDelayHandler`| Generated function        | A function that returns the number of millis to wait before the next connection to a server it connected to `()=>number`.
-| `reconnect`            | `true`                    | If false, client will not attempt reconnecting.
-| `servers`              | `"localhost:4222"`        | String or Array of hostport for servers.
-| `timeout`              | 20000                     | Number of milliseconds the client will wait for a connection to be established. If it fails it will emit a `connection_timeout` event with a NatsError that provides the hostport of the server where the connection was attempted.
-| `tls`                  | TlsOptions                | A configuration object for requiring a TLS connection (not applicable to nats.ws).
-| `token`                |                           | Sets a authorization token for a connection.
-| `user`                 |                           | Sets the username for a connection.
-| `verbose`              | `false`                   | Turns on `+OK` protocol acknowledgements.
-| `waitOnFirstConnect`   | `false`                   | If `true` the client will fall back to a reconnect mode if it fails its first connection attempt.
-| `ignoreClusterUpdates` | `false`                   | If `true` the client will ignore any cluster updates provided by the server.
-
+| Option                  | Default            | Description                                                                                                                                                                                                                                                                                                                                                                              |
+| ----------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `authenticator`         | none               | Specifies the authenticator function that sets the client credentials.                                                                                                                                                                                                                                                                                                                   |
+| `debug`                 | `false`            | If `true`, the client prints protocol interactions to the console. Useful for debugging.                                                                                                                                                                                                                                                                                                 |
+| `maxPingOut`            | `2`                | Max number of pings the client will allow unanswered before raising a stale connection error.                                                                                                                                                                                                                                                                                            |
+| `maxReconnectAttempts`  | `10`               | Sets the maximum number of reconnect attempts. The value of `-1` specifies no limit.                                                                                                                                                                                                                                                                                                     |
+| `name`                  |                    | Optional client name - recommended to be set to a unique client name.                                                                                                                                                                                                                                                                                                                    |
+| `noEcho`                | `false`            | Subscriptions receive messages published by the client. Requires server support (1.2.0). If set to true, and the server does not support the feature, an error with code `NO_ECHO_NOT_SUPPORTED` is emitted, and the connection is aborted. Note that it is possible for this error to be emitted on reconnect when the server reconnects to a server that does not support the feature. |
+| `noRandomize`           | `false`            | If set, the order of user-specified servers is randomized.                                                                                                                                                                                                                                                                                                                               |
+| `pass`                  |                    | Sets the password for a connection.                                                                                                                                                                                                                                                                                                                                                      |
+| `pedantic`              | `false`            | Turns on strict subject format checks.                                                                                                                                                                                                                                                                                                                                                   |
+| `pingInterval`          | `120000`           | Number of milliseconds between client-sent pings.                                                                                                                                                                                                                                                                                                                                        |
+| `port`                  | `4222`             | Port to connect to (only used if `servers` is not specified).                                                                                                                                                                                                                                                                                                                            |
+| `reconnectTimeWait`     | `2000`             | If disconnected, the client will wait the specified number of milliseconds between reconnect attempts.                                                                                                                                                                                                                                                                                   |
+| `reconnectJitter`       | `100`              | Number of millis to randomize after `reconnectTimeWait`.                                                                                                                                                                                                                                                                                                                                 |
+| `reconnectJitterTLS`    | `1000`             | Number of millis to randomize after `reconnectTimeWait` when TLS options are specified.                                                                                                                                                                                                                                                                                                  |
+| `reconnectDelayHandler` | Generated function | A function that returns the number of millis to wait before the next connection to a server it connected to `()=>number`.                                                                                                                                                                                                                                                                |
+| `reconnect`             | `true`             | If false, client will not attempt reconnecting.                                                                                                                                                                                                                                                                                                                                          |
+| `servers`               | `"localhost:4222"` | String or Array of hostport for servers.                                                                                                                                                                                                                                                                                                                                                 |
+| `timeout`               | 20000              | Number of milliseconds the client will wait for a connection to be established. If it fails it will emit a `connection_timeout` event with a NatsError that provides the hostport of the server where the connection was attempted.                                                                                                                                                      |
+| `tls`                   | TlsOptions         | A configuration object for requiring a TLS connection (not applicable to nats.ws).                                                                                                                                                                                                                                                                                                       |
+| `token`                 |                    | Sets a authorization token for a connection.                                                                                                                                                                                                                                                                                                                                             |
+| `user`                  |                    | Sets the username for a connection.                                                                                                                                                                                                                                                                                                                                                      |
+| `verbose`               | `false`            | Turns on `+OK` protocol acknowledgements.                                                                                                                                                                                                                                                                                                                                                |
+| `waitOnFirstConnect`    | `false`            | If `true` the client will fall back to a reconnect mode if it fails its first connection attempt.                                                                                                                                                                                                                                                                                        |
+| `ignoreClusterUpdates`  | `false`            | If `true` the client will ignore any cluster updates provided by the server.                                                                                                                                                                                                                                                                                                             |
 
 ### TlsOptions
 
-| Option       | Default | Description
-|--------      |-------- |------------
-|  `caFile`    |         | CA certificate filepath
-|  `certFile`  |         | Client certificate file path - not applicable to Deno clients.
-|  `keyFile`   |         | Client key file path - not applicable to Deno clients.
+| Option     | Default | Description                                                    |
+| ---------- | ------- | -------------------------------------------------------------- |
+| `caFile`   |         | CA certificate filepath                                        |
+| `certFile` |         | Client certificate file path - not applicable to Deno clients. |
+| `keyFile`  |         | Client key file path - not applicable to Deno clients.         |
 
-In some Node and Deno clients, having the option set to an empty option, requires the client have a secured connection.
-
+In some Node and Deno clients, having the option set to an empty option,
+requires the client have a secured connection.
 
 ### Jitter
 
-The settings `reconnectTimeWait`, `reconnectJitter`, `reconnectJitterTLS`, `reconnectDelayHandler` are all related.
-They control how long before the NATS client attempts to reconnect to a server it has previously connected.
+The settings `reconnectTimeWait`, `reconnectJitter`, `reconnectJitterTLS`,
+`reconnectDelayHandler` are all related. They control how long before the NATS
+client attempts to reconnect to a server it has previously connected.
 
-The intention of the settings is to spread out the number of clients attempting to reconnect to a server over a period of time,
-and thus preventing a ["Thundering Herd"](https://docs.nats.io/developing-with-nats/reconnect/random).
+The intention of the settings is to spread out the number of clients attempting
+to reconnect to a server over a period of time, and thus preventing a
+["Thundering Herd"](https://docs.nats.io/developing-with-nats/reconnect/random).
 
 The relationship between these is:
 
-- If `reconnectDelayHandler` is specified, the client will wait the value returned by this function. No other value will be taken into account.
-- If the client specified TLS options, the client will generate a number between 0 and `reconnectJitterTLS` and add it to
-  `reconnectTimeWait`.
-- If the client didn't specify TLS options, the client will generate a number between 0 and `reconnectJitter` and add it to `reconnectTimeWait`.
+- If `reconnectDelayHandler` is specified, the client will wait the value
+  returned by this function. No other value will be taken into account.
+- If the client specified TLS options, the client will generate a number between
+  0 and `reconnectJitterTLS` and add it to `reconnectTimeWait`.
+- If the client didn't specify TLS options, the client will generate a number
+  between 0 and `reconnectJitter` and add it to `reconnectTimeWait`.

--- a/TODO.md
+++ b/TODO.md
@@ -5,5 +5,3 @@
 - [-] Transport send batching (current batching seems to perform best)
 
 ## BUGS
-
-

--- a/dependencies.md
+++ b/dependencies.md
@@ -2,7 +2,7 @@
 
 This file lists the dependencies used in this repository.
 
-| Dependency | License |
-|-|-|
+| Dependency                                | License     |
+| ----------------------------------------- | ----------- |
 | https://deno.land/std@0.83.0/flags/mod.ts | MIT License |
-| http://github.com/nats-io/nkeys.js | Apache-2.0 |
+| http://github.com/nats-io/nkeys.js        | Apache-2.0  |

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -25,6 +25,7 @@ export type { Deferred, Timeout } from "./util.ts";
 export {
   deferred,
   delay,
+  extend,
   extractProtocolMessage,
   render,
   timeout,

--- a/nats-base-client/queued_iterator.ts
+++ b/nats-base-client/queued_iterator.ts
@@ -27,6 +27,7 @@ export class QueuedIterator<T> implements Dispatcher<T> {
   protected done: boolean;
   private signal: Deferred<void>;
   private yields: T[];
+  yieldedCb?: (data: T) => void;
   private err?: Error;
 
   constructor() {
@@ -68,6 +69,9 @@ export class QueuedIterator<T> implements Dispatcher<T> {
       for (let i = 0; i < yields.length; i++) {
         this.processed++;
         yield yields[i];
+        if (this.yieldedCb) {
+          this.yieldedCb(yields[i]);
+        }
         this.inflight--;
       }
       // yielding could have paused and microtask

--- a/nats-base-client/subscription.ts
+++ b/nats-base-client/subscription.ts
@@ -28,6 +28,8 @@ export class SubscriptionImpl extends QueuedIterator<Msg>
   drained?: Promise<void>;
   protocol: ProtocolHandler;
   timer?: Timeout<void>;
+  info?: unknown;
+  cleanupFn?: (sub: Subscription, info?: unknown) => void;
 
   constructor(
     protocol: ProtocolHandler,

--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -64,7 +64,7 @@ export class Subscriptions {
       if (s.cleanupFn) {
         try {
           s.cleanupFn(s, s.info);
-        } catch(err) {
+        } catch (err) {
           // ignoring
         }
       }

--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -61,6 +61,13 @@ export class Subscriptions {
   cancel(s: SubscriptionImpl): void {
     if (s) {
       s.close();
+      if (s.cleanupFn) {
+        try {
+          s.cleanupFn(s, s.info);
+        } catch(err) {
+          // ignoring
+        }
+      }
       this.subs.delete(s.sid);
     }
   }

--- a/tests/sub_extensions_test.ts
+++ b/tests/sub_extensions_test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  assert,
+  assertEquals,
+  fail,
+} from "https://deno.land/std@0.83.0/testing/asserts.ts";
+import { connect, createInbox } from "../src/mod.ts";
+import { NatsServer } from "./helpers/mod.ts";
+import {
+  deferred,
+  SubscriptionImpl,
+} from "../nats-base-client/internal_mod.ts";
+
+const u = "demo.nats.io:4222";
+
+Deno.test("extensions - cleanup fn called at auto unsub", async () => {
+  const nc = await connect({ servers: u });
+  const subj = createInbox();
+  const sub = nc.subscribe(subj, { callback: (err, msg) => {}, max: 1 });
+  const d = deferred<string>();
+  const subimpl = sub as SubscriptionImpl;
+  subimpl.info = { data: "hello" };
+  subimpl.cleanupFn = ((sub, info) => {
+    const id = info as { data?: string };
+    d.resolve(id.data ? id.data : "");
+  });
+  nc.publish(subj);
+  assertEquals(await d, "hello");
+  assert(sub.isClosed());
+  await nc.close();
+});
+
+Deno.test("extensions - cleanup fn called at unsubscribe", async () => {
+  const nc = await connect({ servers: u });
+  const subj = createInbox();
+  const sub = nc.subscribe(subj, { callback: (err, msg) => {} });
+  const d = deferred<string>();
+  const subimpl = sub as SubscriptionImpl;
+  subimpl.info = { data: "hello" };
+  subimpl.cleanupFn = ((sub, info) => {
+    d.resolve("hello");
+  });
+  sub.unsubscribe();
+  assertEquals(await d, "hello");
+  assert(sub.isClosed());
+  await nc.close();
+});
+
+Deno.test("extensions - cleanup fn called at sub drain", async () => {
+  const nc = await connect({ servers: u });
+  const subj = createInbox();
+  const sub = nc.subscribe(subj, { callback: (err, msg) => {} });
+  const d = deferred<string>();
+  const subimpl = sub as SubscriptionImpl;
+  subimpl.info = { data: "hello" };
+  subimpl.cleanupFn = ((sub, info) => {
+    d.resolve("hello");
+  });
+  await sub.drain();
+  assertEquals(await d, "hello");
+  assert(sub.isClosed());
+  await nc.close();
+});
+
+Deno.test("extensions - cleanup fn called at conn drain", async () => {
+  const nc = await connect({ servers: u });
+  const subj = createInbox();
+  const sub = nc.subscribe(subj, { callback: (err, msg) => {} });
+  const d = deferred<string>();
+  const subimpl = sub as SubscriptionImpl;
+  subimpl.info = { data: "hello" };
+  subimpl.cleanupFn = ((sub, info) => {
+    d.resolve("hello");
+  });
+  await nc.drain();
+  assertEquals(await d, "hello");
+  assert(sub.isClosed());
+  await nc.close();
+});


### PR DESCRIPTION
- [feat] added an internal yield callback on the subscription to enable support of auto-acks on JetStream
- [feat] added an internal cleanup function for when a subscription is called (such as removing a consumer)
- [doc] deno now formats markdown :)