### PR TITLE
FIX nats-io/nats.ws/issues/80

### DIFF
--- a/nats-base-client/authenticator.ts
+++ b/nats-base-client/authenticator.ts
@@ -20,7 +20,7 @@ import { TD, TE } from "./encoders.ts";
 export type NoAuth = void;
 
 export interface TokenAuth {
-  auth_token: string;
+  "auth_token": string;
 }
 
 export interface UserPass {

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -18,8 +18,8 @@ export { DebugEvents, Empty, Events } from "./types.ts";
 export { MsgImpl } from "./msg.ts";
 export { SubscriptionImpl } from "./subscription.ts";
 export { Subscriptions } from "./subscriptions.ts";
-export { setTransportFactory, setUrlParseFn } from "./transport.ts";
-export type { Transport } from "./transport.ts";
+export { setTransportFactory } from "./transport.ts";
+export type { Transport, TransportFactory } from "./transport.ts";
 export { Connect, createInbox, INFO, ProtocolHandler } from "./protocol.ts";
 export type { Deferred, Timeout } from "./util.ts";
 export {

--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -18,7 +18,6 @@ import { ErrorCode, NatsError } from "./error.ts";
 import {
   ConnectionOptions,
   DEFAULT_HOST,
-  DEFAULT_HOSTPORT,
   DEFAULT_JITTER,
   DEFAULT_JITTER_TLS,
   DEFAULT_MAX_PING_OUT,
@@ -28,6 +27,7 @@ import {
   ServerInfo,
 } from "./types.ts";
 import { buildAuthenticator } from "./authenticator.ts";
+import { defaultPort } from "./transport.ts";
 
 export function defaultOptions(): ConnectionOptions {
   return {
@@ -47,7 +47,8 @@ export function defaultOptions(): ConnectionOptions {
 }
 
 export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
-  opts = opts || { servers: [DEFAULT_HOSTPORT] };
+  const dhp = `${DEFAULT_HOST}:${defaultPort()}`;
+  opts = opts || { servers: [dhp] };
   if (opts.port) {
     opts.servers = [`${DEFAULT_HOST}:${opts.port}`];
   }
@@ -55,7 +56,7 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
     opts.servers = [opts.servers];
   }
   if (opts.servers && opts.servers.length === 0) {
-    opts.servers = [DEFAULT_HOSTPORT];
+    opts.servers = [dhp];
   }
   const options = extend(defaultOptions(), opts);
 

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -14,14 +14,14 @@
  *
  */
 import {
-  DEFAULT_HOSTPORT,
+  DEFAULT_HOST,
   DEFAULT_PORT,
   Server,
   ServerInfo,
   ServersChanged,
   URLParseFn,
 } from "./types.ts";
-import { urlParseFn } from "./transport.ts";
+import { defaultPort, getUrlParseFn } from "./transport.ts";
 import { shuffle } from "./util.ts";
 import { isIP } from "./ipparser.ts";
 
@@ -89,6 +89,8 @@ export class Servers {
     this.firstSelect = true;
     this.servers = [] as ServerImpl[];
     this.tlsName = "";
+
+    const urlParseFn = getUrlParseFn();
     if (listens) {
       listens.forEach((hp) => {
         hp = urlParseFn ? urlParseFn(hp) : hp;
@@ -99,7 +101,7 @@ export class Servers {
       }
     }
     if (this.servers.length === 0) {
-      this.addServer(DEFAULT_HOSTPORT, false);
+      this.addServer(`${DEFAULT_HOST}:${defaultPort()}`, false);
     }
     this.currentServer = this.servers[0];
   }
@@ -121,6 +123,7 @@ export class Servers {
   }
 
   addServer(u: string, implicit = false): void {
+    const urlParseFn = getUrlParseFn();
     u = urlParseFn ? urlParseFn(u) : u;
     const s = new ServerImpl(u, implicit);
     if (isIP(s.hostname)) {
@@ -170,6 +173,7 @@ export class Servers {
     const added: string[] = [];
     let deleted: string[] = [];
 
+    const urlParseFn = getUrlParseFn();
     const discovered = new Map<string, ServerImpl>();
     if (info.connect_urls && info.connect_urls.length > 0) {
       info.connect_urls.forEach((hp) => {

--- a/nats-base-client/transport.ts
+++ b/nats-base-client/transport.ts
@@ -12,27 +12,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConnectionOptions, Server, URLParseFn } from "./types.ts";
+import {
+  ConnectionOptions,
+  DEFAULT_PORT,
+  Server,
+  URLParseFn,
+} from "./types.ts";
 
-export let urlParseFn: URLParseFn | undefined;
-export function setUrlParseFn(fn?: URLParseFn): void {
-  urlParseFn = fn;
+let transportConfig: TransportFactory;
+export function setTransportFactory(config: TransportFactory): void {
+  transportConfig = config;
 }
 
-let transportFactory: TransportFactory;
-export function setTransportFactory(fn: TransportFactory): void {
-  transportFactory = fn;
+export function defaultPort(): number {
+  return transportConfig !== undefined &&
+      transportConfig.defaultPort !== undefined
+    ? transportConfig.defaultPort
+    : DEFAULT_PORT;
+}
+
+export function getUrlParseFn(): URLParseFn | undefined {
+  return transportConfig !== undefined && transportConfig.urlParseFn
+    ? transportConfig.urlParseFn
+    : undefined;
 }
 
 export function newTransport(): Transport {
-  if (typeof transportFactory !== "function") {
-    throw new Error("transport is not set");
+  if (!transportConfig || typeof transportConfig.factory !== "function") {
+    throw new Error("transport fn is not set");
   }
-  return transportFactory();
+  return transportConfig.factory();
 }
 
 export interface TransportFactory {
-  (): Transport;
+  factory?: () => Transport;
+  defaultPort?: number;
+  urlParseFn?: URLParseFn;
 }
 
 export interface Transport extends AsyncIterable<Uint8Array> {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -39,7 +39,6 @@ export enum DebugEvents {
 
 export const DEFAULT_PORT = 4222;
 export const DEFAULT_HOST = "127.0.0.1";
-export const DEFAULT_HOSTPORT = `${DEFAULT_HOST}:${DEFAULT_PORT}`;
 
 // DISCONNECT Parameters, 2 sec wait, 10 tries
 export const DEFAULT_RECONNECT_TIME_WAIT = 2 * 1000;
@@ -136,25 +135,25 @@ export interface Base {
 }
 
 export interface ServerInfo {
-  auth_required?: boolean;
-  client_id: number;
-  client_ip?: string;
-  connect_urls?: string[];
-  git_commit?: string;
+  "auth_required"?: boolean;
+  "client_id": number;
+  "client_ip"?: string;
+  "connect_urls"?: string[];
+  "git_commit"?: string;
   go: string;
   headers?: boolean;
   host: string;
   jetstream?: boolean;
   ldm?: boolean;
-  max_payload: number;
+  "max_payload": number;
   nonce?: string;
   port: number;
   proto: number;
-  server_id: string;
-  server_name: string;
-  tls_available?: boolean;
-  tls_required?: boolean;
-  tls_verify?: boolean;
+  "server_id": string;
+  "server_name": string;
+  "tls_available"?: boolean;
+  "tls_required"?: boolean;
+  "tls_verify"?: boolean;
   version: string;
 }
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -20,11 +20,14 @@ import {
   setTransportFactory,
   Transport,
 } from "../nats-base-client/internal_mod.ts";
+import { TransportFactory } from "../nats-base-client/transport.ts";
 
 export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
-  setTransportFactory((): Transport => {
-    return new DenoTransport();
-  });
+  setTransportFactory({
+    factory: (): Transport => {
+      return new DenoTransport();
+    },
+  } as TransportFactory);
 
   return NatsConnectionImpl.connect(opts);
 }

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -48,7 +48,7 @@ export interface Ports {
 }
 
 export interface VarZ {
-  connect_urls: string[];
+  "connect_urls": string[];
 }
 
 function parseHostport(s?: string) {

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -16,7 +16,7 @@
 import { Servers } from "../nats-base-client/servers.ts";
 import { assertEquals } from "https://deno.land/std@0.83.0/testing/asserts.ts";
 import type { ServerInfo } from "../nats-base-client/internal_mod.ts";
-import { setUrlParseFn } from "../nats-base-client/internal_mod.ts";
+import { setTransportFactory } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("servers - single", () => {
   const servers = new Servers(false, ["127.0.0.1:4222"]);
@@ -85,7 +85,7 @@ Deno.test("servers - url parse fn", () => {
   const fn = (s: string): string => {
     return `x://${s}`;
   };
-  setUrlParseFn(fn);
+  setTransportFactory({ urlParseFn: fn });
   const s = new Servers(
     false,
     ["127.0.0.1:4222"],
@@ -96,7 +96,7 @@ Deno.test("servers - url parse fn", () => {
   assertEquals(servers[0].src, "x://127.0.0.1:4222");
   assertEquals(servers[1].src, "x://h:1");
   assertEquals(servers[2].src, "x://j:2/path");
-  setUrlParseFn(undefined);
+  setTransportFactory({ urlParseFn: undefined });
 });
 
 Deno.test("servers - save tls name", () => {


### PR DESCRIPTION
- [change] refactored transport factory to also provide `defaultPort`, `urlParseFn`, and `factory` - `defaultPort` and `urlParseFn` are transport specific (ie websockets)

- [change] made default hostport calculated from the transport information.
- [removed] default hostport constant
- [fix] lint warnings for snake case json fields

FIXES https://github.com/nats-io/nats.ws/issues/80