### PR TITLE
[feat] allow non-file tls certificate configuration

### DIFF
--- a/doc/snippets/headers.ts
+++ b/doc/snippets/headers.ts
@@ -19,7 +19,6 @@ import { nuid } from "../../nats-base-client/nuid.ts";
 const nc = await connect(
   {
     servers: `demo.nats.io`,
-    headers: true,
   },
 );
 

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -36,7 +36,7 @@ export { Heartbeat } from "./heartbeats.ts";
 export type { PH } from "./heartbeats.ts";
 export { MuxSubscription } from "./muxsubscription.ts";
 export { DataBuffer } from "./databuffer.ts";
-export { checkOptions } from "./options.ts";
+export { checkOptions, checkUnsupportedOption } from "./options.ts";
 export { Request } from "./request.ts";
 export type { Authenticator } from "./authenticator.ts";
 export {

--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -109,3 +109,9 @@ export function checkOptions(info: ServerInfo, options: ConnectionOptions) {
     throw new NatsError("tls", ErrorCode.SERVER_OPTION_NA);
   }
 }
+
+export function checkUnsupportedOption(prop: string, v?: string) {
+  if (v) {
+    throw new NatsError(prop, ErrorCode.INVALID_OPTION);
+  }
+}

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -104,8 +104,11 @@ export interface ConnectionOptions {
 // these may not be supported on all environments
 export interface TlsOptions {
   certFile?: string;
+  cert?: string;
   caFile?: string;
+  ca?: string;
   keyFile?: string;
+  key?: string;
 }
 
 export interface Msg {

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -18,6 +18,7 @@ import { Deferred, deferred } from "https://deno.land/std@0.83.0/async/mod.ts";
 import Conn = Deno.Conn;
 import {
   checkOptions,
+  checkUnsupportedOption,
   ConnectionOptions,
   DataBuffer,
   ErrorCode,
@@ -131,6 +132,14 @@ export class DenoTransport implements Transport {
     const tls = this.options && this.options.tls
       ? this.options.tls
       : {} as TlsOptions;
+
+    // these options are not available in Deno
+    checkUnsupportedOption("tls.ca", tls.ca);
+    checkUnsupportedOption("tls.cert", tls.cert);
+    checkUnsupportedOption("tls.certFile", tls.certFile);
+    checkUnsupportedOption("tls.key", tls.key);
+    checkUnsupportedOption("tls.keyFile", tls.keyFile);
+
     this.conn = await Deno.startTls(
       this.conn,
       { hostname, certFile: tls.caFile },


### PR DESCRIPTION
- [feat] added `tls.cert`, `tls.key`, `tls.ca` to make it possible to specify certificate as a string on clients that would allow that (node).
- FIX https://github.com/nats-io/nats.js/issues/395