### PR TITLE
Make JSONCodec generic to allow overriding the returned Codec type

### DIFF
--- a/nats-base-client/codec.ts
+++ b/nats-base-client/codec.ts
@@ -32,7 +32,7 @@ export function StringCodec(): Codec<string> {
   };
 }
 
-export function JSONCodec(): Codec<unknown> {
+export function JSONCodec<T = unknown>(): Codec<T> {
   return {
     encode(d: unknown): Uint8Array {
       try {


### PR DESCRIPTION
`Codec` was already generic but `JSONCodec` was not which was preventing us from overriding the `unknown` type.

Now, we can do:
```ts
const jc = JSONCodec<MyType>()
const result = jc.decode(data)
// result type is MyType
```