### PR TITLE
[change] [breaking] event names now follow ES5 naming

### DIFF
--- a/nats-base-client/heartbeats.ts
+++ b/nats-base-client/heartbeats.ts
@@ -60,7 +60,7 @@ export class Heartbeat {
     // @ts-ignore: node is not a number - we treat this opaquely
     this.timer = setTimeout(() => {
       this.ph.dispatchStatus(
-        { type: DebugEvents.PING_TIMER, data: `${this.pendings.length + 1}` },
+        { type: DebugEvents.PingTimer, data: `${this.pendings.length + 1}` },
       );
       if (this.pendings.length === this.maxOut) {
         this.cancel(true);

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -226,14 +226,14 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   }
 
   public disconnect(): void {
-    this.dispatchStatus({ type: DebugEvents.STALE_CONNECTION, data: "" });
+    this.dispatchStatus({ type: DebugEvents.StaleConnection, data: "" });
     this.transport.disconnect();
   }
 
   async disconnected(err?: Error): Promise<void> {
     this.dispatchStatus(
       {
-        type: Events.DISCONNECT,
+        type: Events.Disconnect,
         data: this.servers.getCurrentServer().toString(),
       },
     );
@@ -242,7 +242,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
         .then(() => {
           this.dispatchStatus(
             {
-              type: Events.RECONNECT,
+              type: Events.Reconnect,
               data: this.servers.getCurrentServer().toString(),
             },
           );
@@ -313,7 +313,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
         srv.lastConnect = Date.now();
         try {
           this.dispatchStatus(
-            { type: DebugEvents.RECONNECTING, data: srv.toString() },
+            { type: DebugEvents.Reconnecting, data: srv.toString() },
           );
           await this.dial(srv);
           break;
@@ -387,7 +387,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     const err = ProtocolHandler.toError(s);
     const handled = this.subscriptions.handleError(err);
     if (!handled) {
-      this.dispatchStatus({ type: Events.ERROR, data: err.code });
+      this.dispatchStatus({ type: Events.Error, data: err.code });
     }
     await this.handleError(err);
   }
@@ -460,7 +460,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       }
     }
     if (updates) {
-      this.dispatchStatus({ type: Events.UPDATE, data: updates });
+      this.dispatchStatus({ type: Events.Update, data: updates });
     }
     const ldm = info.ldm !== undefined ? info.ldm : false;
     if (ldm) {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -19,22 +19,22 @@ import type { Authenticator } from "./authenticator.ts";
 export const Empty = new Uint8Array(0);
 
 export enum Events {
-  DISCONNECT = "disconnect",
-  RECONNECT = "reconnect",
-  UPDATE = "update",
+  Disconnect = "disconnect",
+  Reconnect = "reconnect",
+  Update = "update",
   LDM = "ldm",
-  ERROR = "error",
+  Error = "error",
 }
 
 export interface Status {
   type: Events | DebugEvents;
-  data: string | ServersChanged;
+  data: string | ServersChanged | number;
 }
 
 export enum DebugEvents {
-  RECONNECTING = "reconnecting",
-  PING_TIMER = "pingTimer",
-  STALE_CONNECTION = "staleConnection",
+  Reconnecting = "reconnecting",
+  PingTimer = "pingTimer",
+  StaleConnection = "staleConnection",
 }
 
 export const DEFAULT_PORT = 4222;

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -149,7 +149,7 @@ Deno.test("auth - pub perm", async () => {
   await lock;
   await iter;
   const es = await errStatus;
-  assertEquals(es.type, Events.ERROR);
+  assertEquals(es.type, Events.Error);
   assertEquals(es.data, ErrorCode.PERMISSIONS_VIOLATION);
   await ns.stop();
 });

--- a/tests/doublesubs_test.ts
+++ b/tests/doublesubs_test.ts
@@ -70,10 +70,10 @@ async function runDoubleSubsTest(tls: boolean) {
   (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           disconnected.resolve();
           break;
-        case Events.RECONNECT:
+        case Events.Reconnect:
           reconnected.resolve();
           break;
       }

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -16,7 +16,6 @@ import { Lock, NatsServer, ServerSignals } from "../tests/helpers/mod.ts";
 import { connect, Events, ServersChanged } from "../src/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.83.0/testing/asserts.ts";
 import { delay, NatsConnectionImpl } from "../nats-base-client/internal_mod.ts";
-import { assert } from "../nats-base-client/denobuffer.ts";
 
 Deno.test("events - close on close", async () => {
   const ns = await NatsServer.start();
@@ -38,7 +37,7 @@ Deno.test("events - disconnect and close", async () => {
   (async () => {
     for await (const s of nc.status()) {
       switch (s.type) {
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           lock.unlock();
           break;
       }
@@ -70,10 +69,10 @@ Deno.test("events - disconnect, reconnect", async () => {
   (async () => {
     for await (const s of nc.status()) {
       switch (s.type) {
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           disconnect.unlock();
           break;
-        case Events.RECONNECT:
+        case Events.Reconnect:
           reconnect.unlock();
           break;
       }
@@ -97,7 +96,7 @@ Deno.test("events - update", async () => {
   (async () => {
     for await (const s of nc.status()) {
       switch (s.type) {
-        case Events.UPDATE: {
+        case Events.Update: {
           const u = s.data as ServersChanged;
           assertEquals(u.added.length, 1);
           lock.unlock();

--- a/tests/heartbeats_test.ts
+++ b/tests/heartbeats_test.ts
@@ -68,7 +68,7 @@ Deno.test("heartbeat - timers fire", async () => {
   hb.cancel();
   assertEquals(hb.timer, undefined);
   assert(status.length >= 3);
-  assertEquals(status[0].type, DebugEvents.PING_TIMER);
+  assertEquals(status[0].type, DebugEvents.PingTimer);
 });
 
 Deno.test("heartbeat - errors fire on missed maxOut", async () => {
@@ -86,7 +86,7 @@ Deno.test("heartbeat - errors fire on missed maxOut", async () => {
   await disconnect;
   assertEquals(hb.timer, undefined);
   assert(status.length >= 7, `${status.length} >= 7`);
-  assertEquals(status[0].type, DebugEvents.PING_TIMER);
+  assertEquals(status[0].type, DebugEvents.PingTimer);
 });
 
 Deno.test("heartbeat - recovers from missed", async () => {

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -69,10 +69,10 @@ Deno.test("reconnect - events", async () => {
   (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           disconnects++;
           break;
-        case DebugEvents.RECONNECTING:
+        case DebugEvents.Reconnecting:
           reconnecting++;
           break;
       }
@@ -99,10 +99,10 @@ Deno.test("reconnect - reconnect not emitted if suppressed", async () => {
   (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           disconnects++;
           break;
-        case DebugEvents.RECONNECTING:
+        case DebugEvents.Reconnecting:
           fail("shouldn't have emitted reconnecting");
           break;
       }
@@ -126,7 +126,7 @@ Deno.test("reconnect - reconnecting after proper delay", async () => {
   (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
-        case DebugEvents.RECONNECTING: {
+        case DebugEvents.Reconnecting: {
           const elapsed = Date.now() - serverLastConnect;
           dt.resolve(elapsed);
           break;
@@ -155,14 +155,14 @@ Deno.test("reconnect - indefinite reconnects", async () => {
   (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           disconnects++;
           break;
-        case Events.RECONNECT:
+        case Events.Reconnect:
           reconnect = true;
           nc.close();
           break;
-        case DebugEvents.RECONNECTING:
+        case DebugEvents.Reconnecting:
           reconnects++;
           break;
       }
@@ -228,13 +228,13 @@ Deno.test("reconnect - internal disconnect forces reconnect", async () => {
   (async () => {
     for await (const e of nc.status()) {
       switch (e.type) {
-        case DebugEvents.STALE_CONNECTION:
+        case DebugEvents.StaleConnection:
           stale = true;
           break;
-        case Events.DISCONNECT:
+        case Events.Disconnect:
           disconnect = true;
           break;
-        case Events.RECONNECT:
+        case Events.Reconnect:
           lock.unlock();
           break;
       }


### PR DESCRIPTION
chore to cleanup event names to be ES5 compliant