### PR TITLE
implements AsyncIterable<T> for Lister<T>

### DIFF
--- a/nats-base-client/jslister.ts
+++ b/nats-base-client/jslister.ts
@@ -17,7 +17,7 @@ import { BaseApiClient } from "./jsbaseclient_api.ts";
 
 export type ListerFieldFilter<T> = (v: unknown) => T[];
 
-export class ListerImpl<T> implements Lister<T> {
+export class ListerImpl<T> implements Lister<T>, AsyncIterable<T> {
   err?: Error;
   offset: number;
   pageInfo: ApiPaged;
@@ -62,6 +62,16 @@ export class ListerImpl<T> implements Lister<T> {
     } catch (err) {
       this.err = err;
       throw err;
+    }
+  }
+
+  async *[Symbol.asyncIterator]() {
+    let page = await this.next();
+    while (page.length > 0) {
+      for (const item of page) {
+        yield item;
+      }
+      page = await this.next();
     }
   }
 }


### PR DESCRIPTION
When needed to retrieve all streams or consumers instead of a paged list, this simple change makes possible to do something like:
```javascript
for await(const info of jsm.streams.list()) {
  console.log(info.config.name); // do whatever you want with the info
}
```
It doesn't break the actual API: `jsm.streams.list().next()` still returns a list for the paged result.