### PR TITLE
fix: export Debug Events

### DIFF
--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -2,6 +2,7 @@ export {
   Bench,
   createInbox,
   credsAuthenticator,
+  DebugEvents,
   Empty,
   ErrorCode,
   Events,


### PR DESCRIPTION
exports Debug Events enums so developers can use them