### PR TITLE
exposed and enabled queue option for consumer opts

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -369,6 +369,7 @@ export class JetStreamClientImpl extends BaseApiClient
       so.dispatchedFn = autoAckJsMsg;
     }
     so.max = jsi.max || 0;
+    so.queue = jsi.queue;
     return so;
   }
 

--- a/nats-base-client/jsconsumeropts.ts
+++ b/nats-base-client/jsconsumeropts.ts
@@ -42,6 +42,7 @@ export class ConsumerOptsBuilderImpl implements ConsumerOptsBuilder {
   stream: string;
   callbackFn?: JsMsgCallback;
   max?: number;
+  qname?: string;
 
   constructor(opts?: Partial<ConsumerConfig>) {
     this.stream = "";
@@ -58,6 +59,7 @@ export class ConsumerOptsBuilderImpl implements ConsumerOptsBuilder {
     o.stream = this.stream;
     o.callbackFn = this.callbackFn;
     o.max = this.max;
+    o.queue = this.qname;
     return o;
   }
 
@@ -128,6 +130,10 @@ export class ConsumerOptsBuilderImpl implements ConsumerOptsBuilder {
 
   callback(fn: JsMsgCallback) {
     this.callbackFn = fn;
+  }
+
+  queue(n: string) {
+    this.qname = n;
   }
 }
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -321,6 +321,7 @@ export interface ConsumerOpts {
 
   // standard
   max?: number;
+  queue?: string;
   debug?: boolean;
 }
 
@@ -355,6 +356,8 @@ export interface ConsumerOptsBuilder {
   maxWaiting(max: number): void;
   // standard nats subscribe option for the maximum number of messages to receive on the subscription
   maxMessages(max: number): void;
+  // standard nats queue group option
+  queue(n: string): void;
   // callback to process messages (or iterator is returned)
   callback(fn: JsMsgCallback): void;
 }


### PR DESCRIPTION
[FIX] js.subscribe followed nats.go, and option for queue was not exposed, it seems this is now supported.

FIX #nats-io/nats.js/issues/432