### PR TITLE
fix jestream readme examples and expose jsm.deleteMessage() `erase` argument

### DIFF
--- a/examples/jetstream/js_readme_publish_examples.ts
+++ b/examples/jetstream/js_readme_publish_examples.ts
@@ -1,0 +1,32 @@
+import { connect, Empty } from "../../src/mod.ts";
+
+const nc = await connect();
+const jsm = await nc.jetstreamManager();
+await jsm.streams.add({ name: "a", subjects: ["a.b"] });
+
+// create a jetstream client:
+const js = nc.jetstream();
+
+// to publish messages to a stream:
+const pa = await js.publish("a.b");
+// the jetstream returns an acknowledgement with the
+// stream that captured the message, it's assigned sequence
+// and whether the message is a duplicate.
+const stream = pa.stream;
+const seq = pa.seq;
+const duplicate = pa.duplicate;
+
+// More interesting is the ability to prevent duplicates
+// on messages that are stored in the server. If
+// you assign a message ID, the server will keep looking
+// for the same ID for a configured amount of time, and
+// reject messages that sport the same ID:
+await js.publish("a.b", Empty, { msgID: "a" });
+
+// you can also specify constraints that should be satisfied.
+// For example, you can request the message to have as its
+// last sequence before accepting the new message:
+await js.publish("a.b", Empty, { expect: { lastMsgID: "a" } });
+await js.publish("a.b", Empty, { expect: { lastSequence: 3 } });
+await js.publish("a.b", Empty, { expect: { streamName: "a" } });
+// you can also mix the above combinations

--- a/examples/jetstream/js_readme_push_example.ts
+++ b/examples/jetstream/js_readme_push_example.ts
@@ -1,0 +1,39 @@
+import { connect, consumerOpts, createInbox, Empty } from "../../src/mod.ts";
+import { nuid } from "../../nats-base-client/nuid.ts";
+
+// HIDE THIS
+const nc = await connect();
+const jsm = await nc.jetstreamManager();
+const stream = nuid.next();
+const subj = `${stream}.b`;
+await jsm.streams.add({ name: stream, subjects: [subj] });
+const js = nc.jetstream();
+await js.publish(subj);
+// END HIDE THIS
+
+const opts = consumerOpts();
+opts.durable("me");
+opts.manualAck();
+opts.ackExplicit();
+opts.deliverTo(createInbox());
+
+let sub = await js.subscribe(subj, opts);
+const done = (async () => {
+  for await (const m of sub) {
+    m.ack();
+  }
+})();
+
+// HIDE THIS
+sub.unsubscribe();
+await done;
+// END HIDE THIS
+
+// when done (by some logic not shown here), you can delete
+// the consumer by simply calling `destroy()`. Destroying
+// a consumer removes all its state information.
+await sub.destroy();
+
+// HIDE THIS
+await nc.close();
+// END HIDE THIS

--- a/examples/jetstream/jsm_readme_jsm_example.ts
+++ b/examples/jetstream/jsm_readme_jsm_example.ts
@@ -1,0 +1,54 @@
+import { AckPolicy, connect, Empty } from "../../src/mod.ts";
+
+const nc = await connect();
+const jsm = await nc.jetstreamManager();
+
+// list all the streams, the `next()` function
+// retrieves a paged result.
+const streams = await jsm.streams.list().next();
+
+// add a stream
+const stream = "mystream";
+const subj = `mystream.A`;
+await jsm.streams.add({ name: stream, subjects: [subj] });
+
+// publish a reg nats message directly to the stream
+for (let i = 0; i < 10; i++) {
+  nc.publish(subj, Empty);
+}
+
+// find a stream that stores a specific subject:
+const name = await jsm.streams.find("mystream.A");
+
+// retrieve info about the stream by its name
+const si = await jsm.streams.info(name);
+
+// update a stream configuration
+si.config.subjects?.push("a.b");
+await jsm.streams.update(si.config);
+
+// get a particular stored message in the stream by sequence
+// this is not associated with a consumer
+let sm = await jsm.streams.getMessage(stream, 1);
+
+// delete the 5th message in the stream, securely erasing it
+await jsm.streams.deleteMessage(stream, 5);
+
+// purge all messages in the stream, the stream itself
+// remains.
+await jsm.streams.purge(stream);
+
+// list all consumers for a stream:
+const consumers = await jsm.consumers.list(stream).next();
+
+// add a new durable pull consumer
+await jsm.consumers.add(stream, {
+  durable_name: "me",
+  ack_policy: AckPolicy.Explicit,
+});
+
+// retrieve a consumer's configuration
+const ci = await jsm.consumers.info(stream, "me");
+
+// delete a particular consumer
+await jsm.consumers.delete(stream, "me");

--- a/jetstream.md
+++ b/jetstream.md
@@ -45,22 +45,27 @@ const stream = "mystream";
 const subj = `mystream.A`;
 await jsm.streams.add({ name: stream, subjects: [subj] });
 
+// publish a reg nats message directly to the stream
+for (let i = 0; i < 10; i++) {
+  nc.publish(subj, Empty);
+}
+
 // find a stream that stores a specific subject:
-const name = await jsm.find("mystream.A");
+const name = await jsm.streams.find("mystream.A");
 
 // retrieve info about the stream by its name
 const si = await jsm.streams.info(name);
 
 // update a stream configuration
-si.subjects.push("mystream.B");
-await jsm.streams.update(si);
+si.config.subjects?.push("mystream.B");
+await jsm.streams.update(si.config);
 
 // get a particular stored message in the stream by sequence
 // this is not associated with a consumer
 let sm = await jsm.streams.getMessage(stream, 1);
 
 // delete the 5th message in the stream, securely erasing it
-await jsm.streams.deleteMessage(stream, 5, true);
+await jsm.streams.deleteMessage(stream, 5);
 
 // purge all messages in the stream, the stream itself
 // remains.
@@ -112,7 +117,7 @@ await js.publish("a.b", Empty, { msgID: "a" });
 // For example, you can request the message to have as its
 // last sequence before accepting the new message:
 await js.publish("a.b", Empty, { expect: { lastMsgID: "a" } });
-await js.publish("a.b", Empty, { expect: { lastSequence: 2 } });
+await js.publish("a.b", Empty, { expect: { lastSequence: 3 } });
 await js.publish("a.b", Empty, { expect: { streamName: "a" } });
 // you can also mix the above combinations
 ```

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -314,7 +314,6 @@ export interface JetStreamClient {
 export interface ConsumerOpts {
   config: Partial<ConsumerConfig>;
   mack: boolean;
-  subQueue: string;
   stream: string;
   callbackFn?: JsMsgCallback;
   name?: string;
@@ -384,7 +383,7 @@ export interface StreamAPI {
   purge(stream: string): Promise<PurgeResponse>;
   delete(stream: string): Promise<boolean>;
   list(): Lister<StreamInfo>;
-  deleteMessage(stream: string, seq: number): Promise<boolean>;
+  deleteMessage(stream: string, seq: number, erase?: boolean): Promise<boolean>;
   getMessage(stream: string, seq: number): Promise<StoredMsg>;
   find(subject: string): Promise<string>;
 }
@@ -494,7 +493,7 @@ export interface StreamConfig {
   "num_replicas": number;
   "no_ack"?: boolean;
   "template_owner"?: string;
-  "duplicate_window"?: number; // duration
+  "duplicate_window"?: number; // nanos
   placement?: Placement;
   mirror?: StreamSource; // same as a source
   sources?: StreamSource[];

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -493,7 +493,7 @@ export interface StreamConfig {
   "num_replicas": number;
   "no_ack"?: boolean;
   "template_owner"?: string;
-  "duplicate_window"?: number; // nanos
+  "duplicate_window"?: Nanos;
   placement?: Placement;
   mirror?: StreamSource; // same as a source
   sources?: StreamSource[];


### PR DESCRIPTION
[FIX] jetstream readme examples
[FIX] expose jetstreamManagers deleteMessage 'erase' argument