### PR TITLE
Added ConsumerConfig idle_heartbeat and flow_control options

### DIFF
--- a/examples/jetstream/09_flowcontrol.ts
+++ b/examples/jetstream/09_flowcontrol.ts
@@ -1,0 +1,48 @@
+import { AckPolicy, connect, toJsMsg } from "../../src/mod.ts";
+import { nuid } from "../../nats-base-client/nuid.ts";
+import { isFlowControlMsg } from "../../nats-base-client/jsutil.ts";
+
+const nc = await connect();
+const jsm = await nc.jetstreamManager();
+
+const N = 10000;
+const stream = nuid.next();
+const subj = nuid.next();
+await jsm.streams.add({ name: stream, subjects: [`${subj}.>`] });
+
+// create a regular subscription (this is an ephemeral consumer, so start the sub)
+let data = 0;
+let fc = 0;
+const sub = nc.subscribe("my.messages", {
+  callback: (_err, msg) => {
+    // simply checking if has headers and code === 100
+    if (isFlowControlMsg(msg)) {
+      fc++;
+      msg.respond();
+      return;
+    }
+    // do something with the message
+    data++;
+    const m = toJsMsg(msg);
+    m.ack();
+    if (data === N) {
+      console.log(`processed ${data} msgs and ${fc} flow control messages`);
+      sub.drain();
+    }
+  },
+});
+
+// create a consumer that delivers to the subscription
+await jsm.consumers.add(stream, {
+  ack_policy: AckPolicy.Explicit,
+  deliver_subject: "my.messages",
+  flow_control: true,
+});
+
+// publish some old nats messages
+for (let i = 0; i < N; i++) {
+  nc.publish(`${subj}.${i}`);
+}
+
+await sub.closed;
+await nc.close();

--- a/examples/jetstream/10_heartbeats.ts
+++ b/examples/jetstream/10_heartbeats.ts
@@ -1,0 +1,44 @@
+import { AckPolicy, connect, nanos, toJsMsg } from "../../src/mod.ts";
+import { nuid } from "../../nats-base-client/nuid.ts";
+import { isHeartbeatMsg } from "../../nats-base-client/jsutil.ts";
+
+const nc = await connect();
+const jsm = await nc.jetstreamManager();
+
+const stream = nuid.next();
+const subj = nuid.next();
+await jsm.streams.add({ name: stream, subjects: [`${subj}.>`] });
+
+// create a regular subscription (this is an ephemeral consumer, so start the sub)
+let missed = 0;
+const sub = nc.subscribe("my.messages", {
+  callback: (_err, msg) => {
+    missed = 0;
+    // simply checking if has headers and code === 100, with no reply
+    // subject set. if it has a reply it would be a flow control message
+    // which will get acknowledged at the end.
+    if (isHeartbeatMsg(msg)) {
+      console.log("alive");
+      return;
+    }
+    // do something with the message
+    const m = toJsMsg(msg);
+    m.ack();
+  },
+});
+
+setInterval(() => {
+  missed++;
+  if (missed > 3) {
+    console.error("JetStream stopped sending heartbeats!");
+  }
+}, 30000);
+
+// create a consumer that delivers to the subscription
+await jsm.consumers.add(stream, {
+  ack_policy: AckPolicy.Explicit,
+  deliver_subject: "my.messages",
+  idle_heartbeat: nanos(10000),
+});
+
+await sub.closed;

--- a/nats-base-client/jsconsumeropts.ts
+++ b/nats-base-client/jsconsumeropts.ts
@@ -21,7 +21,7 @@ import {
   DeliverPolicy,
   JsMsgCallback,
 } from "./types.ts";
-import { defaultConsumer, validateDurableName } from "./jsutil.ts";
+import { defaultConsumer, nanos, validateDurableName } from "./jsutil.ts";
 
 export function consumerOpts(
   opts?: Partial<ConsumerConfig>,
@@ -134,6 +134,14 @@ export class ConsumerOptsBuilderImpl implements ConsumerOptsBuilder {
 
   queue(n: string) {
     this.qname = n;
+  }
+
+  idleHeartbeat(millis: number) {
+    this.config.idle_heartbeat = nanos(millis);
+  }
+
+  flowControl() {
+    this.config.flow_control = true;
   }
 }
 

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -73,6 +73,10 @@ export function isFlowControlMsg(msg: Msg): boolean {
   return h.code >= 100 && h.code < 200;
 }
 
+export function isHeartbeatMsg(msg: Msg): boolean {
+  return isFlowControlMsg(msg) && msg.reply === "";
+}
+
 export function checkJsError(msg: Msg): NatsError | null {
   const h = msg.headers;
   if (!h) {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -183,6 +183,7 @@ export interface ServersChanged {
 }
 
 export interface Sub<T> extends AsyncIterable<T> {
+  closed: Promise<void>;
   unsubscribe(max?: number): void;
   drain(): Promise<void>;
   isDraining(): boolean;
@@ -360,6 +361,10 @@ export interface ConsumerOptsBuilder {
   queue(n: string): void;
   // callback to process messages (or iterator is returned)
   callback(fn: JsMsgCallback): void;
+  // idle heartbeats - server sends a status code 100 if idle longer than specified, these messages have no reply
+  idleHeartbeat(millis: number): void;
+  // flow control - server sends a status code 100 and uses the delay in response to throttle inbound messages for a client and prevent slow consumer.
+  flowControl(): void;
 }
 
 export interface Lister<T> {
@@ -687,6 +692,8 @@ export interface ConsumerConfig {
   "sample_freq"?: string;
   "max_waiting"?: number;
   "max_ack_pending"?: number;
+  "idle_heartbeat"?: Nanos; // send empty message when idle longer than this
+  "flow_control"?: boolean; // send message with status of 100 and reply subject
 }
 
 export interface Consumer {

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -59,7 +59,7 @@ Deno.test("jsm - account info", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
   const jsm = await nc.jetstreamManager();
   const ai = await jsm.getAccountInfo();
-  assert(ai.limits.max_memory === -1);
+  assert(ai.limits.max_memory === -1 || ai.limits.max_memory > 0);
   await cleanup(ns, nc);
 });
 

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -59,7 +59,7 @@ Deno.test("jsm - account info", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
   const jsm = await nc.jetstreamManager();
   const ai = await jsm.getAccountInfo();
-  assert(ai.limits.max_memory > 0);
+  assert(ai.limits.max_memory === -1);
   await cleanup(ns, nc);
 });
 


### PR DESCRIPTION
[FEAT] options `idle_heartbeat` and `flow_control` to `ConsumerConfig`
[FEAT] added `idleHeartbeat(millis)` and `flowControl()` to `ConsumerOptsBuilder`
[FEAT] added `isHeartbeatMsg()` to simplify checking if a raw message sent to a NATS subscription is a JetStream heartbeat message.
[FEAT] added examples for idle_heartbeat and flow_control
[FEAT] exposed `closed` property on subscription objects - this is a promise that is resolved when a subscription is finished.