### PR TITLE
added `max_msgs_per_subject` to `StreamConfig`

### DIFF
--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -497,6 +497,7 @@ export interface StreamConfig {
   placement?: Placement;
   mirror?: StreamSource; // same as a source
   sources?: StreamSource[];
+  "max_msgs_per_subject"?: number;
 }
 
 export interface StreamSource {


### PR DESCRIPTION
[FEAT] added `max_msgs_per_subject` option to `StreamConfig`, this option specifies on wildcard streams how many messages to keep per subject.