### PR TITLE
last_by_subject JSM.streams.getMessage()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.2.2" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.3.1" >> $GITHUB_ENV
 
       - name: Get nats-server
         run: |

--- a/examples/jetstream/js_readme_publish_examples.ts
+++ b/examples/jetstream/js_readme_publish_examples.ts
@@ -1,20 +1,21 @@
 import { connect, Empty } from "../../src/mod.ts";
+import { PubAck } from "../../nats-base-client/types.ts";
 
 const nc = await connect();
 const jsm = await nc.jetstreamManager();
-await jsm.streams.add({ name: "a", subjects: ["a.b"] });
+await jsm.streams.add({ name: "a", subjects: ["a.*"] });
 
 // create a jetstream client:
 const js = nc.jetstream();
 
 // to publish messages to a stream:
-const pa = await js.publish("a.b");
+let pa = await js.publish("a.b");
 // the jetstream returns an acknowledgement with the
 // stream that captured the message, it's assigned sequence
 // and whether the message is a duplicate.
-const stream = pa.stream;
-const seq = pa.seq;
-const duplicate = pa.duplicate;
+console.log(
+  `stored in ${pa.stream} with sequence ${pa.seq} and is a duplicate? ${pa.duplicate}`,
+);
 
 // More interesting is the ability to prevent duplicates
 // on messages that are stored in the server. If
@@ -28,5 +29,17 @@ await js.publish("a.b", Empty, { msgID: "a" });
 // last sequence before accepting the new message:
 await js.publish("a.b", Empty, { expect: { lastMsgID: "a" } });
 await js.publish("a.b", Empty, { expect: { lastSequence: 3 } });
-await js.publish("a.b", Empty, { expect: { streamName: "a" } });
+// save the last sequence for this publish
+pa = await js.publish("a.b", Empty, { expect: { streamName: "a" } });
 // you can also mix the above combinations
+
+// now if you have a stream with different subjects, you can also
+// assert that the last recorded sequence on subject on the stream matches
+const buf: Promise<PubAck>[] = [];
+for (let i = 0; i < 100; i++) {
+  buf.push(js.publish("a.a", Empty));
+}
+await Promise.all(buf);
+// if additional "a.b" has been recorded, this will fail
+await js.publish("a.b", Empty, { expect: { lastSubjectSequence: pa.seq } });
+await nc.drain();

--- a/examples/jetstream/js_readme_push_example.ts
+++ b/examples/jetstream/js_readme_push_example.ts
@@ -1,4 +1,4 @@
-import { connect, consumerOpts, createInbox, Empty } from "../../src/mod.ts";
+import { connect, consumerOpts, createInbox } from "../../src/mod.ts";
 import { nuid } from "../../nats-base-client/nuid.ts";
 
 // HIDE THIS
@@ -17,7 +17,7 @@ opts.manualAck();
 opts.ackExplicit();
 opts.deliverTo(createInbox());
 
-let sub = await js.subscribe(subj, opts);
+const sub = await js.subscribe(subj, opts);
 const done = (async () => {
   for await (const m of sub) {
     m.ack();

--- a/examples/jetstream/jsm_readme_jsm_example.ts
+++ b/examples/jetstream/jsm_readme_jsm_example.ts
@@ -6,6 +6,9 @@ const jsm = await nc.jetstreamManager();
 // list all the streams, the `next()` function
 // retrieves a paged result.
 const streams = await jsm.streams.list().next();
+streams.forEach((si) => {
+  console.log(si);
+});
 
 // add a stream
 const stream = "mystream";
@@ -29,7 +32,8 @@ await jsm.streams.update(si.config);
 
 // get a particular stored message in the stream by sequence
 // this is not associated with a consumer
-let sm = await jsm.streams.getMessage(stream, 1);
+const sm = await jsm.streams.getMessage(stream, { seq: 1 });
+console.log(sm.seq);
 
 // delete the 5th message in the stream, securely erasing it
 await jsm.streams.deleteMessage(stream, 5);
@@ -40,6 +44,9 @@ await jsm.streams.purge(stream);
 
 // list all consumers for a stream:
 const consumers = await jsm.consumers.list(stream).next();
+consumers.forEach((ci) => {
+  console.log(ci);
+});
 
 // add a new durable pull consumer
 await jsm.consumers.add(stream, {
@@ -49,6 +56,7 @@ await jsm.consumers.add(stream, {
 
 // retrieve a consumer's configuration
 const ci = await jsm.consumers.info(stream, "me");
+console.log(ci);
 
 // delete a particular consumer
 await jsm.consumers.delete(stream, "me");

--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -71,6 +71,7 @@ enum PubHeaders {
   ExpectedStreamHdr = "Nats-Expected-Stream",
   ExpectedLastSeqHdr = "Nats-Expected-Last-Sequence",
   ExpectedLastMsgIdHdr = "Nats-Expected-Last-Msg-Id",
+  ExpectedLastSubjectSequenceHdr = "Nats-Expected-Last-Subject-Sequence",
 }
 
 export class JetStreamClientImpl extends BaseApiClient
@@ -101,6 +102,12 @@ export class JetStreamClientImpl extends BaseApiClient
       }
       if (opts.expect.lastSequence) {
         mh.set(PubHeaders.ExpectedLastSeqHdr, `${opts.expect.lastSequence}`);
+      }
+      if (opts.expect.lastSubjectSequence) {
+        mh.set(
+          PubHeaders.ExpectedLastSubjectSequenceHdr,
+          `${opts.expect.lastSubjectSequence}`,
+        );
       }
     }
 

--- a/nats-base-client/jsstream_api.ts
+++ b/nats-base-client/jsstream_api.ts
@@ -109,12 +109,11 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     return cr.success;
   }
 
-  async getMessage(stream: string, seq: number): Promise<StoredMsg> {
+  async getMessage(stream: string, query: MsgRequest): Promise<StoredMsg> {
     validateStreamName(stream);
-    const dr = { seq } as MsgRequest;
     const r = await this._request(
       `${this.prefix}.STREAM.MSG.GET.${stream}`,
-      dr,
+      query,
     );
     const sm = r as StreamMsgResponse;
     return new StoredMsgImpl(sm);

--- a/nats-base-client/jsstream_api.ts
+++ b/nats-base-client/jsstream_api.ts
@@ -110,6 +110,13 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
   }
 
   async getMessage(stream: string, query: MsgRequest): Promise<StoredMsg> {
+    // FIXME: remove this shim
+    if (typeof query === "number") {
+      console.log(
+        `\u001B[33m [WARN] jsm.getMessage(number) is deprecated and will be removed on release - use \`{seq: number}\` as an argument \u001B[0m`,
+      );
+      query = { seq: query };
+    }
     validateStreamName(stream);
     const r = await this._request(
       `${this.prefix}.STREAM.MSG.GET.${stream}`,

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -389,7 +389,7 @@ export interface StreamAPI {
   delete(stream: string): Promise<boolean>;
   list(): Lister<StreamInfo>;
   deleteMessage(stream: string, seq: number, erase?: boolean): Promise<boolean>;
-  getMessage(stream: string, seq: number): Promise<StoredMsg>;
+  getMessage(stream: string, query: MsgRequest): Promise<StoredMsg>;
   find(subject: string): Promise<string>;
 }
 
@@ -644,11 +644,17 @@ export interface Success {
 
 export type SuccessResponse = ApiResponse & Success;
 
-export interface MsgRequest {
+export interface LastForMsgRequest {
+  "last_by_subj": string;
+}
+
+export interface SeqMsgRequest {
   seq: number;
 }
 
-export interface MsgDeleteRequest extends MsgRequest {
+export type MsgRequest = SeqMsgRequest | LastForMsgRequest;
+
+export interface MsgDeleteRequest extends SeqMsgRequest {
   "no_erase"?: boolean;
 }
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -258,6 +258,7 @@ export interface JetStreamPublishOptions {
     lastMsgID: string;
     streamName: string;
     lastSequence: number;
+    lastSubjectSequence: number;
   }>;
 }
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -653,7 +653,8 @@ export interface SeqMsgRequest {
   seq: number;
 }
 
-export type MsgRequest = SeqMsgRequest | LastForMsgRequest;
+// FIXME: remove number as it is deprecated
+export type MsgRequest = SeqMsgRequest | LastForMsgRequest | number;
 
 export interface MsgDeleteRequest extends SeqMsgRequest {
   "no_erase"?: boolean;

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -245,48 +245,20 @@ Deno.test("jetstream - publish require last message id", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("jetstream - publish require last by subject", async () => {
+Deno.test("jetstream - get message last by subject", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
-  const { stream, subj } = await initStream(nc);
 
   const jsm = await nc.jetstreamManager();
-  const si = await jsm.streams.info(stream);
-  si.config.subjects?.push(`${stream}.B`);
-  // @ts-ignore
-  si.config.max_msgs_per_subject = 100;
-  console.log(si.config);
-  await jsm.streams.update(si.config);
+  const stream = nuid.next();
+  await jsm.streams.add({ name: stream, subjects: [`${stream}.*`] });
 
   const js = nc.jetstream();
   const sc = StringCodec();
   await js.publish(`${stream}.A`, sc.encode("a"));
-  await js.publish(`${stream}.A`, sc.encode("aa"), {
-    expect: {
-      lastSequence: 1,
-    },
-  });
-  await js.publish(`${stream}.B`, sc.encode("b"), {
-    expect: {
-      lastSequence: 2,
-    },
-  });
-  await js.publish(`${stream}.B`, sc.encode("bb"), {
-    expect: {
-      lastSequence: 3,
-    },
-  });
+  await js.publish(`${stream}.A`, sc.encode("aa"));
+  await js.publish(`${stream}.B`, sc.encode("b"));
+  await js.publish(`${stream}.B`, sc.encode("bb"));
 
-  const a = await jsm.streams.getMessage(stream, {seq: 1})
-  assertEquals(sc.decode(a.data), "a");
-  const aa = await jsm.streams.getMessage(stream, {seq: 2})
-  assertEquals(sc.decode(aa.data), "aa");
-  const b = await jsm.streams.getMessage(stream, {seq: 3})
-  assertEquals(sc.decode(b.data), "b");
-  const bb = await jsm.streams.getMessage(stream, {seq: 4})
-  assertEquals(sc.decode(bb.data), "bb");
-
-  //@ts-ignore
-  nc.options.debug = true;
   const sm = await jsm.streams.getMessage(stream, {
     last_by_subj: `${stream}.A`,
   });

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -646,6 +646,17 @@ Deno.test("jsm - cross account streams", async () => {
   await cleanup(ns, nc, admin);
 });
 
+Deno.test("jsm - getMessage() takes a number", async () => {
+  // get message
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const { stream, subj } = await initStream(nc);
+  nc.publish(subj);
+  const jsm = await nc.jetstreamManager();
+  const sm = await jsm.streams.getMessage(stream, 1);
+  assertEquals(sm.seq, 1);
+  await cleanup(ns, nc);
+});
+
 Deno.test("jsm - cross account consumers", async () => {
   const { ns, nc } = await setup(
     jetstreamExportServerConf(),

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -470,19 +470,19 @@ Deno.test("jsm - get message", async () => {
   nc.publish(subj, jc.encode(2));
 
   const jsm = await nc.jetstreamManager();
-  let sm = await jsm.streams.getMessage(stream, 1);
+  let sm = await jsm.streams.getMessage(stream, { seq: 1 });
   assertEquals(sm.subject, subj);
   assertEquals(sm.seq, 1);
   assertEquals(jc.decode(sm.data), 1);
 
-  sm = await jsm.streams.getMessage(stream, 2);
+  sm = await jsm.streams.getMessage(stream, { seq: 2 });
   assertEquals(sm.subject, subj);
   assertEquals(sm.seq, 2);
   assertEquals(jc.decode(sm.data), 2);
 
   const err = await assertThrowsAsync(
     async () => {
-      await jsm.streams.getMessage(stream, 3);
+      await jsm.streams.getMessage(stream, { seq: 3 });
     },
     Error,
   );
@@ -504,12 +504,12 @@ Deno.test("jsm - get message payload", async () => {
   await js.publish(subj, sc.encode(""), { msgID: "empty2" });
 
   const jsm = await nc.jetstreamManager();
-  let sm = await jsm.streams.getMessage(stream, 1);
+  let sm = await jsm.streams.getMessage(stream, { seq: 1 });
   assertEquals(sm.subject, subj);
   assertEquals(sm.seq, 1);
   assertEquals(sm.data, Empty);
 
-  sm = await jsm.streams.getMessage(stream, 2);
+  sm = await jsm.streams.getMessage(stream, { seq: 2 });
   assertEquals(sm.subject, subj);
   assertEquals(sm.seq, 2);
   assertEquals(sm.data, Empty);
@@ -610,7 +610,7 @@ Deno.test("jsm - cross account streams", async () => {
   assertEquals(si.state.messages, 2);
 
   // get message
-  const sm = await jsm.streams.getMessage(stream, 1);
+  const sm = await jsm.streams.getMessage(stream, { seq: 1 });
   assertEquals(sm.seq, 1);
 
   // delete message


### PR DESCRIPTION
[FEAT] [BREAKING] Slight change to JSM streams `getMessage()` the API the second argument changed from a sequence number to be either `{seq: #}` or `last_by_subject: "my.subject"`, this enables the feature for retrieving the last message in a stream with the specified subject.

The JetStream features in the JavaScript clients are pre-release and subject to changes.