### PR TITLE
JS add support for `domain`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.2.2" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.3.1" >> $GITHUB_ENV
 
       - name: Get nats-server
         run: |

--- a/nats-base-client/jsbaseclient_api.ts
+++ b/nats-base-client/jsbaseclient_api.ts
@@ -33,6 +33,10 @@ const defaultTimeout = 5000;
 
 export function defaultJsOptions(opts?: JetStreamOptions): JetStreamOptions {
   opts = opts || {} as JetStreamOptions;
+  if (opts.domain) {
+    opts.apiPrefix = `$JS.${opts.domain}.API`;
+    delete opts.domain;
+  }
   return extend({ apiPrefix: defaultPrefix, timeout: defaultTimeout }, opts);
 }
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -226,6 +226,7 @@ export interface URLParseFn {
 export interface JetStreamOptions {
   apiPrefix?: string;
   timeout?: number;
+  domain?: string;
 }
 
 export interface JetStreamManager {
@@ -659,6 +660,7 @@ export interface JetStreamAccountStats {
   consumers: number;
   api: JetStreamApiStats;
   limits: AccountLimits;
+  domain?: string;
 }
 
 export interface JetStreamApiStats {

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -1649,3 +1649,45 @@ Deno.test("jetstream - flow control", async () => {
   assertEquals(sub.getProcessed(), 10000 + fc + 1);
   await cleanup(ns, nc);
 });
+
+Deno.test("jetstream - domain", async () => {
+  const { ns, nc } = await setup(
+    jetstreamServerConf({
+      jetstream: {
+        domain: "afton",
+      },
+    }, true),
+  );
+
+  const jsm = await nc.jetstreamManager({ domain: "afton" });
+  const ai = await jsm.getAccountInfo();
+  assert(ai.domain, "afton");
+  //@ts-ignore: internal use
+  assertEquals(jsm.prefix, `$JS.afton.API`);
+  await cleanup(ns, nc);
+});
+
+Deno.test("jetstream - account domain", async () => {
+  const conf = jetstreamServerConf({
+    jetstream: {
+      domain: "A",
+    },
+    accounts: {
+      A: {
+        users: [
+          { user: "a", password: "a" },
+        ],
+        jetstream: { max_memory: 10000, max_file: 10000 },
+      },
+    },
+  }, true);
+
+  const { ns, nc } = await setup(conf, { user: "a", pass: "a" });
+
+  const jsm = await nc.jetstreamManager({ domain: "A" });
+  const ai = await jsm.getAccountInfo();
+  assert(ai.domain, "A");
+  //@ts-ignore: internal use
+  assertEquals(jsm.prefix, `$JS.A.API`);
+  await cleanup(ns, nc);
+});

--- a/tests/jstest_util.ts
+++ b/tests/jstest_util.ts
@@ -54,12 +54,12 @@ export function jetstreamServerConf(
   opts: unknown = {},
   randomStoreDir = true,
 ): Record<string, unknown> {
-  const conf = Object.assign(opts, jsopts());
+  const conf = Object.assign(jsopts(), opts);
   if (randomStoreDir) {
     conf.jetstream.store_dir = path.join("/tmp", "jetstream", nuid.next());
   }
   Deno.mkdirSync(conf.jetstream.store_dir, { recursive: true });
-  return opts as Record<string, unknown>;
+  return conf as Record<string, unknown>;
 }
 export async function setup(
   serverConf?: Record<string, unknown>,


### PR DESCRIPTION
[FEAT] added `domain` to `JetStreamOptions`, when set a prefix `$JS.${domain}.API` is set.

[FEAT] `domain` is reported by `JetStreamAccountStats`