### PR TITLE
[feat] expose `PubAck#domain`- where server can distinguish between two same name streams but in different domains.

### DIFF
--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -244,6 +244,7 @@ export interface PullOptions {
 
 export interface PubAck {
   stream: string;
+  domain?: string;
   seq: number;
   duplicate: boolean;
 


### PR DESCRIPTION
https://github.com/nats-io/nats-architecture-and-design/issues/44