### PR TITLE
JetStream API changes

### DIFF
--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -49,7 +49,7 @@ export type {
   Placement,
   PullOptions,
   SeqMsgRequest,
-  SequencePair,
+  SequenceInfo,
   StoredMsg,
   StreamConfig,
   StreamInfo,

--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -119,13 +119,6 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
   }
 
   async getMessage(stream: string, query: MsgRequest): Promise<StoredMsg> {
-    // FIXME: remove this shim
-    if (typeof query === "number") {
-      console.log(
-        `\u001B[33m [WARN] jsm.getMessage(number) is deprecated and will be removed on release - use \`{seq: number}\` as an argument \u001B[0m`,
-      );
-      query = { seq: query };
-    }
     validateStreamName(stream);
     const r = await this._request(
       `${this.prefix}.STREAM.MSG.GET.${stream}`,

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -72,7 +72,7 @@ export type {
   PullOptions,
   RequestOptions,
   SeqMsgRequest,
-  SequencePair,
+  SequenceInfo,
   ServerInfo,
   ServersChanged,
   Stats,

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -639,7 +639,7 @@ export interface StreamMsgResponse extends ApiResponse {
   };
 }
 
-export interface SequencePair {
+export interface SequenceInfo {
   "consumer_seq": number;
   "stream_seq": number;
   "last_active": Nanos;
@@ -650,8 +650,8 @@ export interface ConsumerInfo {
   name: string;
   created: number;
   config: ConsumerConfig;
-  delivered: SequencePair;
-  "ack_floor": SequencePair;
+  delivered: SequenceInfo;
+  "ack_floor": SequenceInfo;
   "num_ack_pending": number;
   "num_redelivered": number;
   "num_waiting": number;

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -821,17 +821,6 @@ Deno.test("jsm - cross account streams", async () => {
   await cleanup(ns, nc, admin);
 });
 
-Deno.test("jsm - getMessage() takes a number", async () => {
-  // get message
-  const { ns, nc } = await setup(jetstreamServerConf({}, true));
-  const { stream, subj } = await initStream(nc);
-  nc.publish(subj);
-  const jsm = await nc.jetstreamManager();
-  const sm = await jsm.streams.getMessage(stream, 1);
-  assertEquals(sm.seq, 1);
-  await cleanup(ns, nc);
-});
-
 Deno.test("jsm - cross account consumers", async () => {
   const { ns, nc } = await setup(
     jetstreamExportServerConf(),


### PR DESCRIPTION
[JS CHANGE] `SequencePair` type used in ConsumerInfo is now called `SequenceInfo`.
[JS CHANGE] deprecated `jsm.streams.getMessage(number)` shim has been removed - instead do `jsm.streams.getMessage({seq: number})`.