### PR TITLE
Better trace on timeout

### DIFF
--- a/nats-base-client/util.ts
+++ b/nats-base-client/util.ts
@@ -82,6 +82,8 @@ export interface Timeout<T> extends Promise<T> {
 }
 
 export function timeout<T>(ms: number): Timeout<T> {
+  // by generating the stack here to help identify what timed out
+  const err = NatsError.errorForCode(ErrorCode.Timeout);
   let methods;
   let timer: number;
   const p = new Promise((_resolve, reject) => {
@@ -93,7 +95,7 @@ export function timeout<T>(ms: number): Timeout<T> {
     methods = { cancel };
     // @ts-ignore: node is not a number
     timer = setTimeout(() => {
-      reject(NatsError.errorForCode(ErrorCode.Timeout));
+      reject(err);
     }, ms);
   });
   // noinspection JSUnusedAssignment


### PR DESCRIPTION
changed timeout to pre-generate a stack - in the case of a timeout, the stack will have a context to the operation that failed