### PR TITLE
FIX partial frames during connect's peek of the info block

### DIFF
--- a/nats-base-client/util.ts
+++ b/nats-base-client/util.ts
@@ -34,13 +34,13 @@ export function protoLen(ba: Uint8Array): number {
       return n + 1;
     }
   }
-  return -1;
+  return 0;
 }
 
 export function extractProtocolMessage(a: Uint8Array): string {
   // protocol messages are ascii, so Uint8Array
   const len = protoLen(a);
-  if (len) {
+  if (len > 0) {
     const ba = new Uint8Array(a);
     const out = ba.slice(0, len);
     return TD.decode(out);

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -113,7 +113,7 @@ export class DenoTransport implements Transport {
         inbound.fill(frame);
         const raw = inbound.peek();
         pm = extractProtocolMessage(raw);
-        if (pm) {
+        if (pm !== "") {
           break;
         }
       }

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -87,6 +87,6 @@ Deno.test("protocol - cancel unknown sub", () => {
 });
 
 Deno.test("protocol - protolen -1 on empty", () => {
-  assertEquals(protoLen(Empty), -1);
+  assertEquals(protoLen(Empty), 0);
   assertEquals(extractProtocolMessage(Empty), "");
 });


### PR DESCRIPTION
[fix] `extractProtocolMessage`, was loosely testing the result from `protoLen`, which returned -1. In such a case, it was possible to attempt processing a frame that wasn't complete. This only happened during connect.