### PR TITLE
[FEAT] dns resolve of server entries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     name: ${{ matrix.config.kind }} ${{ matrix.config.os }}
     runs-on: ubuntu-latest
-
+    environment: CI
     strategy:
       matrix:
         deno-version: [1.8.3, 1.9.2]
@@ -53,6 +53,7 @@ jobs:
         env:
           TMPDIR: ${{ runner.temp }}
           CI: true
+          NGS_CI_USER: ${{ secrets.NGS_CI_USER }}
         run: deno test --allow-all --unstable --failfast --coverage=./cov
 
       - name: Build nats.js

--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -27,7 +27,7 @@ import {
   ServerInfo,
 } from "./types.ts";
 import { buildAuthenticator } from "./authenticator.ts";
-import { defaultPort } from "./transport.ts";
+import { defaultPort, getResolveFn } from "./transport.ts";
 import { createInbox } from "./mod.ts";
 
 export function defaultOptions(): ConnectionOptions {
@@ -103,6 +103,15 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
       createInbox(options.inboxPrefix);
     } catch (err) {
       throw new NatsError(err.message, ErrorCode.ApiError);
+    }
+  }
+
+  if (options.resolve) {
+    if (typeof getResolveFn() !== "function") {
+      throw new NatsError(
+        `'resolve' is not supported on this client`,
+        ErrorCode.InvalidOption,
+      );
     }
   }
 

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -309,7 +309,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     const alts = await srv.resolve({
       fn: getResolveFn(),
       randomize: !this.options.noRandomize,
-      resolve: this.options.resolve,
+      resolve: !this.options.noResolve,
     });
 
     let lastErr: Error | null = null;

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -21,11 +21,12 @@ import {
   Empty,
   Events,
   PublishOptions,
+  Server,
   ServerInfo,
   Status,
   Subscription,
 } from "./types.ts";
-import { newTransport, Transport } from "./transport.ts";
+import { getResolveFn, newTransport, Transport } from "./transport.ts";
 import { ErrorCode, NatsError } from "./error.ts";
 import {
   CR_LF,
@@ -166,11 +167,14 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.pongs = [];
     //@ts-ignore: options.pendingLimit is hidden
     this.pendingLimit = options.pendingLimit || this.pendingLimit;
-    this.servers = new Servers(
-      !options.noRandomize,
-      //@ts-ignore: servers should be a list
-      options.servers,
-    );
+
+    const servers = typeof options.servers === "string"
+      ? [options.servers]
+      : options.servers;
+
+    this.servers = new Servers(servers, {
+      randomize: !options.noRandomize,
+    });
     this.closed = deferred<Error | void>();
     this.parser = new Parser(this);
 
@@ -259,7 +263,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
   }
 
-  async dial(srv: ServerImpl): Promise<void> {
+  async dial(srv: Server): Promise<void> {
     const pong = this.prepare();
     let timer;
     try {
@@ -301,6 +305,32 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
   }
 
+  async _doDial(srv: Server): Promise<void> {
+    const alts = await srv.resolve({
+      fn: getResolveFn(),
+      randomize: !this.options.noRandomize,
+      resolve: this.options.resolve,
+    });
+
+    let lastErr: Error | null = null;
+    for (const a of alts) {
+      try {
+        lastErr = null;
+        this.dispatchStatus(
+          { type: DebugEvents.Reconnecting, data: a.toString() },
+        );
+        await this.dial(a);
+        // if here we connected
+        return;
+      } catch (err) {
+        lastErr = err;
+      }
+    }
+    // if we are here, we failed, and we have no additional
+    // alternatives for this server
+    throw lastErr;
+  }
+
   async dialLoop(): Promise<void> {
     let lastError: Error | undefined;
     while (true) {
@@ -316,10 +346,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       if (srv.lastConnect === 0 || srv.lastConnect + wait <= now) {
         srv.lastConnect = Date.now();
         try {
-          this.dispatchStatus(
-            { type: DebugEvents.Reconnecting, data: srv.toString() },
-          );
-          await this.dial(srv);
+          await this._doDial(srv);
           break;
         } catch (err) {
           lastError = err;

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -309,7 +309,6 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     const alts = await srv.resolve({
       fn: getResolveFn(),
       randomize: !this.options.noRandomize,
-      resolve: !this.options.noResolve,
     });
 
     let lastErr: Error | null = null;

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -82,12 +82,14 @@ export class ServerImpl implements Server {
     opts: Partial<{ fn: DnsResolveFn; randomize: boolean; resolve: boolean }>,
   ): Promise<Server[]> {
     if (!opts.fn || !opts.resolve) {
+      // don't add - to resolves or we get a circ reference
       return [this];
     }
 
     const buf: Server[] = [];
     if (isIP(this.hostname)) {
-      buf.push(this);
+      // don't add - to resolves or we get a circ reference
+      return [this];
     } else {
       const ips = await opts.fn(this.hostname);
       for (const ip of ips) {

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -81,7 +81,8 @@ export class ServerImpl implements Server {
   async resolve(
     opts: Partial<{ fn: DnsResolveFn; randomize: boolean; resolve: boolean }>,
   ): Promise<Server[]> {
-    if (!opts.fn || !opts.resolve) {
+    if (!opts.fn) {
+      // we cannot resolve - transport doesn't support it
       // don't add - to resolves or we get a circ reference
       return [this];
     }

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -16,14 +16,35 @@
 import {
   DEFAULT_HOST,
   DEFAULT_PORT,
+  DnsResolveFn,
   Server,
   ServerInfo,
   ServersChanged,
-  URLParseFn,
 } from "./types.ts";
 import { defaultPort, getUrlParseFn } from "./transport.ts";
 import { shuffle } from "./util.ts";
 import { isIP } from "./ipparser.ts";
+
+function hostPort(
+  u: string,
+): { listen: string; hostname: string; port: number } {
+  // remove any protocol that may have been provided
+  if (u.match(/^(.*:\/\/)(.*)/m)) {
+    u = u.replace(/^(.*:\/\/)(.*)/gm, "$2");
+  }
+  // in web environments, URL may not be a living standard
+  // that means that protocols other than HTTP/S are not
+  // parsable correctly.
+  const url = new URL(`http://${u}`);
+  if (!url.port) {
+    url.port = `${DEFAULT_PORT}`;
+  }
+  const listen = url.host;
+  const hostname = url.hostname;
+  const port = parseInt(url.port, 10);
+
+  return { listen, hostname, port };
+}
 
 /**
  * @hidden
@@ -38,25 +59,15 @@ export class ServerImpl implements Server {
   lastConnect: number;
   gossiped: boolean;
   tlsName: string;
+  resolves?: Server[];
 
   constructor(u: string, gossiped = false) {
     this.src = u;
     this.tlsName = "";
-    // remove any protocol that may have been provided
-    if (u.match(/^(.*:\/\/)(.*)/m)) {
-      u = u.replace(/^(.*:\/\/)(.*)/gm, "$2");
-    }
-    // in web environments, URL may not be a living standard
-    // that means that protocols other than HTTP/S are not
-    // parsable correctly.
-    const url = new URL(`http://${u}`);
-    if (!url.port) {
-      url.port = `${DEFAULT_PORT}`;
-    }
-    this.listen = url.host;
-    this.hostname = url.hostname;
-    this.port = parseInt(url.port, 10);
-
+    const v = hostPort(u);
+    this.listen = v.listen;
+    this.hostname = v.hostname;
+    this.port = v.port;
     this.didConnect = false;
     this.reconnects = 0;
     this.lastConnect = 0;
@@ -66,10 +77,37 @@ export class ServerImpl implements Server {
   toString(): string {
     return this.listen;
   }
-}
 
-export interface ServersOptions {
-  urlParseFn?: URLParseFn;
+  async resolve(
+    opts: Partial<{ fn: DnsResolveFn; randomize: boolean; resolve: boolean }>,
+  ): Promise<Server[]> {
+    if (!opts.fn || !opts.resolve) {
+      return [this];
+    }
+
+    const buf: Server[] = [];
+    if (isIP(this.hostname)) {
+      buf.push(this);
+    } else {
+      const ips = await opts.fn(this.hostname);
+      for (const ip of ips) {
+        // letting URL handle the details of representing IPV6 ip with a port, etc
+        const url = new URL(`http://${this.listen}`);
+        if (!url.port) {
+          url.port = `${DEFAULT_PORT}`;
+        }
+        url.hostname = ip;
+        const ss = new ServerImpl(url.host, false);
+        ss.tlsName = this.hostname;
+        buf.push(ss);
+      }
+    }
+    if (opts.randomize) {
+      shuffle(buf);
+    }
+    this.resolves = buf;
+    return buf;
+  }
 }
 
 /**
@@ -80,14 +118,16 @@ export class Servers {
   private readonly servers: ServerImpl[];
   private currentServer: ServerImpl;
   private tlsName: string;
+  private randomize: boolean;
 
   constructor(
-    randomize: boolean,
     listens: string[] = [],
+    opts: Partial<{ randomize: boolean }> = {},
   ) {
     this.firstSelect = true;
     this.servers = [] as ServerImpl[];
     this.tlsName = "";
+    this.randomize = opts.randomize || false;
 
     const urlParseFn = getUrlParseFn();
     if (listens) {
@@ -95,7 +135,7 @@ export class Servers {
         hp = urlParseFn ? urlParseFn(hp) : hp;
         this.servers.push(new ServerImpl(hp));
       });
-      if (randomize) {
+      if (this.randomize) {
         this.servers = shuffle(this.servers);
       }
     }

--- a/nats-base-client/transport.ts
+++ b/nats-base-client/transport.ts
@@ -15,6 +15,7 @@
 import {
   ConnectionOptions,
   DEFAULT_PORT,
+  DnsResolveFn,
   Server,
   URLParseFn,
 } from "./types.ts";
@@ -44,10 +45,17 @@ export function newTransport(): Transport {
   return transportConfig.factory();
 }
 
+export function getResolveFn(): DnsResolveFn | undefined {
+  return transportConfig !== undefined && transportConfig.dnsResolveFn
+    ? transportConfig.dnsResolveFn
+    : undefined;
+}
+
 export interface TransportFactory {
   factory?: () => Transport;
   defaultPort?: number;
   urlParseFn?: URLParseFn;
+  dnsResolveFn?: DnsResolveFn;
 }
 
 export interface Transport extends AsyncIterable<Uint8Array> {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -105,7 +105,7 @@ export interface ConnectionOptions {
   waitOnFirstConnect?: boolean;
   ignoreClusterUpdates?: boolean;
   inboxPrefix?: string;
-  resolve?: boolean;
+  noResolve?: boolean;
 }
 
 // these may not be supported on all environments

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -105,7 +105,6 @@ export interface ConnectionOptions {
   waitOnFirstConnect?: boolean;
   ignoreClusterUpdates?: boolean;
   inboxPrefix?: string;
-  noResolve?: boolean;
 }
 
 // these may not be supported on all environments
@@ -178,7 +177,7 @@ export interface Server {
   tlsName: string;
 
   resolve(
-    opts: Partial<{ fn: DnsResolveFn; randomize: boolean; resolve: boolean }>,
+    opts: Partial<{ fn: DnsResolveFn; randomize: boolean }>,
   ): Promise<Server[]>;
 }
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -105,6 +105,7 @@ export interface ConnectionOptions {
   waitOnFirstConnect?: boolean;
   ignoreClusterUpdates?: boolean;
   inboxPrefix?: string;
+  resolve?: boolean;
 }
 
 // these may not be supported on all environments
@@ -175,6 +176,10 @@ export interface Server {
   listen: string;
   src: string;
   tlsName: string;
+
+  resolve(
+    opts: Partial<{ fn: DnsResolveFn; randomize: boolean; resolve: boolean }>,
+  ): Promise<Server[]>;
 }
 
 export interface ServersChanged {
@@ -220,6 +225,10 @@ export interface Stats {
 
 export interface URLParseFn {
   (u: string): string;
+}
+
+export interface DnsResolveFn {
+  (h: string): Promise<string[]>;
 }
 
 // JetStream

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DenoTransport } from "./deno_transport.ts";
+import { denoResolveHost, DenoTransport } from "./deno_transport.ts";
 import {
   ConnectionOptions,
   NatsConnection,
@@ -27,6 +27,7 @@ export function connect(opts: ConnectionOptions = {}): Promise<NatsConnection> {
     factory: (): Transport => {
       return new DenoTransport();
     },
+    dnsResolveFn: denoResolveHost,
   } as TransportFactory);
 
   return NatsConnectionImpl.connect(opts);

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -259,3 +259,25 @@ export class DenoTransport implements Transport {
     return this.closedNotification;
   }
 }
+
+export async function denoResolveHost(s: string): Promise<string[]> {
+  const a = Deno.resolveDns(s, "A");
+  const aaaa = Deno.resolveDns(s, "AAAA");
+  const ips: string[] = [];
+  const w = await Promise.allSettled([a, aaaa]);
+  if (w[0].status === "fulfilled") {
+    ips.push(...w[0].value);
+  }
+  if (w[1].status === "fulfilled") {
+    ips.push(...w[1].value);
+  }
+
+  if (ips.length === 0 && w[0].status === "rejected") {
+    throw w[0].reason;
+  }
+  if (ips.length === 0 && w[1].status === "rejected") {
+    throw w[1].reason;
+  }
+
+  return ips;
+}

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -278,6 +278,5 @@ export async function denoResolveHost(s: string): Promise<string[]> {
   if (ips.length === 0 && w[1].status === "rejected") {
     throw w[1].reason;
   }
-
   return ips;
 }

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -821,7 +821,6 @@ Deno.test("basics - resolve", async () => {
   const nci = await connect({
     servers: "connect.ngs.global",
     authenticator: jwtAuthenticator(token),
-    resolve: true,
   }) as NatsConnectionImpl;
 
   await nci.flush();

--- a/tests/helpers/mod.ts
+++ b/tests/helpers/mod.ts
@@ -39,9 +39,8 @@ export function compare(a: SemVer, b: SemVer): number {
 }
 
 export function disabled(reason: string): void {
-  console.error(red(
-    `skipping: ${reason}`,
-  ));
+  const m = new TextEncoder().encode(red(`skipping: ${reason} `));
+  Deno.stdout.writeSync(m);
 }
 
 export async function notCompatible(
@@ -53,11 +52,10 @@ export async function notCompatible(
   const varz = await ns.varz() as unknown as Record<string, string>;
   const sv = parseSemVer(varz.version);
   if (compare(sv, parseSemVer(version)) < 0) {
-    console.error(
-      yellow(
-        `skipping test as server (${varz.version}) doesn't implement required feature from ${version}`,
-      ),
-    );
+    const m = new TextEncoder().encode(yellow(
+      `skipping test as server (${varz.version}) doesn't implement required feature from ${version} `,
+    ));
+    await Deno.stdout.write(m);
     await cleanup(ns, nc);
     return true;
   }

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -2156,7 +2156,6 @@ Deno.test("jetstream - source", async () => {
 
   const sub = await js.subscribe(`${stream}.B`, { config: ci.config });
   for await (const m of sub) {
-    console.log(m.seq, m.subject);
     m.ack();
     if (m.info.pending === 0) {
       break;

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -19,7 +19,7 @@ import type { ServerInfo } from "../nats-base-client/internal_mod.ts";
 import { setTransportFactory } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("servers - single", () => {
-  const servers = new Servers(false, ["127.0.0.1:4222"]);
+  const servers = new Servers(["127.0.0.1:4222"], { randomize: false });
   assertEquals(servers.length(), 1);
   assertEquals(servers.getServers().length, 1);
   assertEquals(servers.getCurrentServer().listen, "127.0.0.1:4222");
@@ -33,10 +33,7 @@ Deno.test("servers - single", () => {
 });
 
 Deno.test("servers - multiples", () => {
-  const servers = new Servers(
-    false,
-    ["h:1", "h:2"],
-  );
+  const servers = new Servers(["h:1", "h:2"], { randomize: false });
   assertEquals(servers.length(), 2);
   assertEquals(servers.getServers().length, 2);
   assertEquals(servers.getCurrentServer().listen, "h:1");
@@ -59,7 +56,7 @@ function servInfo(): ServerInfo {
 }
 
 Deno.test("servers - add/delete", () => {
-  const servers = new Servers(false, ["127.0.0.1:4222"]);
+  const servers = new Servers(["127.0.0.1:4222"], { randomize: false });
   assertEquals(servers.length(), 1);
   let ce = servers.update(Object.assign(servInfo(), { connect_urls: ["h:1"] }));
   assertEquals(ce.added.length, 1);
@@ -86,10 +83,7 @@ Deno.test("servers - url parse fn", () => {
     return `x://${s}`;
   };
   setTransportFactory({ urlParseFn: fn });
-  const s = new Servers(
-    false,
-    ["127.0.0.1:4222"],
-  );
+  const s = new Servers(["127.0.0.1:4222"], { randomize: false });
   s.update(Object.assign(servInfo(), { connect_urls: ["h:1", "j:2/path"] }));
 
   const servers = s.getServers();
@@ -100,10 +94,7 @@ Deno.test("servers - url parse fn", () => {
 });
 
 Deno.test("servers - save tls name", () => {
-  const servers = new Servers(
-    false,
-    ["h:1", "h:2"],
-  );
+  const servers = new Servers(["h:1", "h:2"], { randomize: false });
   servers.addServer("127.1.0.0", true);
   servers.addServer("127.1.2.0", true);
   servers.updateTLSName();

--- a/tests/timeout_test.ts
+++ b/tests/timeout_test.ts
@@ -40,7 +40,6 @@ Deno.test("timeout - request stack is useful", async () => {
     fail("request should have failed!");
   } catch (err) {
     assertStringIncludes(err.stack, "timeout_test");
-    console.log(err.stack);
   }
   await nc.close();
 });


### PR DESCRIPTION
Added the ability for client transports to enable dns resolution - currently clients simply pass the server hostname or IP to the network connect function. If specifying `resolve: true` as a connection option, the client will resolve the hostname when attempting to connect to it. If randomize was specified (default), entries are randomized. Note some clients such as nats.ws are unable to resolve, as they WebSocket directly handles the resolution for the connection. If the client fails to resolve any entries, it will throw an error, but the client will attempt to connect to other specified servers if possible.