### PR TITLE
support test harness --jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.8.3, 1.9.2]
+        deno-version: [1.8.3, 1.9.2, 1.13.2]
 
     steps:
       - name: Git Checkout Deno Module

--- a/tests/binary_test.ts
+++ b/tests/binary_test.ts
@@ -14,15 +14,14 @@
  */
 
 import { assertEquals } from "https://deno.land/std@0.95.0/testing/asserts.ts";
-import { connect, createInbox, Msg } from "../src/mod.ts";
+import { createInbox, Msg } from "../src/mod.ts";
 import { deferred } from "../nats-base-client/internal_mod.ts";
-
-const u = "demo.nats.io:4222";
+import { cleanup, setup } from "./jstest_util.ts";
 
 function macro(input: Uint8Array) {
   return async () => {
+    const { ns, nc } = await setup();
     const subj = createInbox();
-    const nc = await connect({ servers: u });
     const dm = deferred<Msg>();
     const sub = nc.subscribe(subj, { max: 1 });
     (async () => {
@@ -34,7 +33,7 @@ function macro(input: Uint8Array) {
     nc.publish(subj, input);
     const msg = await dm;
     assertEquals(msg.data, input);
-    await nc.close();
+    await cleanup(ns, nc);
   };
 }
 

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -16,13 +16,11 @@ import { Lock, NatsServer, ServerSignals } from "../tests/helpers/mod.ts";
 import { connect, Events, ServersChanged } from "../src/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import { delay, NatsConnectionImpl } from "../nats-base-client/internal_mod.ts";
+import { setup } from "./jstest_util.ts";
 
 Deno.test("events - close on close", async () => {
-  const ns = await NatsServer.start();
-  const nc = await connect(
-    { port: ns.port },
-  );
-  nc.close().then().catch();
+  const { ns, nc } = await setup();
+  nc.close().then();
   const status = await nc.closed();
   await ns.stop();
   assertEquals(status, undefined);
@@ -30,10 +28,7 @@ Deno.test("events - close on close", async () => {
 
 Deno.test("events - disconnect and close", async () => {
   const lock = Lock(2);
-  const ns = await NatsServer.start();
-  const nc = await connect(
-    { port: ns.port, reconnect: false },
-  );
+  const { ns, nc } = await setup({}, { reconnect: false });
   (async () => {
     for await (const s of nc.status()) {
       switch (s.type) {
@@ -50,7 +45,6 @@ Deno.test("events - disconnect and close", async () => {
   await lock;
 
   const v = await nc.closed();
-
   assertEquals(v, undefined);
 });
 

--- a/tests/queues_test.ts
+++ b/tests/queues_test.ts
@@ -13,13 +13,12 @@
  * limitations under the License.
  */
 
-import { connect, createInbox, Subscription } from "../src/mod.ts";
+import { createInbox, Subscription } from "../src/mod.ts";
 import { assertEquals } from "https://deno.land/std@0.95.0/testing/asserts.ts";
-
-const u = "demo.nats.io:4222";
+import { cleanup, setup } from "./jstest_util.ts";
 
 Deno.test("queues - deliver to single queue", async () => {
-  const nc = await connect({ servers: u });
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const subs = [];
   for (let i = 0; i < 5; i++) {
@@ -31,11 +30,11 @@ Deno.test("queues - deliver to single queue", async () => {
   const received = subs.map((s) => s.getReceived());
   const sum = received.reduce((p, c) => p + c);
   assertEquals(sum, 1);
-  await nc.close();
+  await cleanup(ns, nc);
 });
 
 Deno.test("queues - deliver to multiple queues", async () => {
-  const nc = await connect({ servers: u });
+  const { ns, nc } = await setup();
   const subj = createInbox();
 
   const fn = (queue: string) => {
@@ -60,11 +59,11 @@ Deno.test("queues - deliver to multiple queues", async () => {
 
   assertEquals(mc(subsa), 1);
   assertEquals(mc(subsb), 1);
-  await nc.close();
+  await cleanup(ns, nc);
 });
 
 Deno.test("queues - queues and subs independent", async () => {
-  const nc = await connect({ servers: u });
+  const { ns, nc } = await setup();
   const subj = createInbox();
   const subs = [];
   let queueCount = 0;
@@ -90,5 +89,5 @@ Deno.test("queues - queues and subs independent", async () => {
   await nc.flush();
   assertEquals(queueCount, 1);
   assertEquals(count, 1);
-  await nc.close();
+  await cleanup(ns, nc);
 });

--- a/tests/tls_test.ts
+++ b/tests/tls_test.ts
@@ -17,7 +17,14 @@ import {
   fail,
 } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import { connect, ErrorCode } from "../src/mod.ts";
-import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
+import {
+  assertErrorCode,
+  compare,
+  disabled,
+  Lock,
+  NatsServer,
+  parseSemVer,
+} from "./helpers/mod.ts";
 
 import { join, resolve } from "https://deno.land/std@0.95.0/path/mod.ts";
 
@@ -41,6 +48,13 @@ Deno.test("tls - connects to tls without option", async () => {
 });
 
 Deno.test("tls - custom ca fails without root", async () => {
+  if (compare(parseSemVer(Deno.version.deno), parseSemVer("1.9.2")) > 0) {
+    disabled(
+      `deno version ${Deno.version.deno} doesn't reject certificates correctly`,
+    );
+    return;
+  }
+
   const cwd = Deno.cwd();
   const config = {
     host: "0.0.0.0",


### PR DESCRIPTION
[chore] replaced remote connects to demo.nats.io in tests to use a test server launched for the test instead - newer versions of deno seem to have a flappier runner when invoked with `--jobs` that increases latency in some unknown way creating timeouts for remote tests. Same tests with 1.9.2 work correctly.