### PR TITLE
request validation doesn't reject properly in downstream

### DIFF
--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -145,7 +145,11 @@ export class NatsConnectionImpl implements NatsConnection {
     data: Uint8Array = Empty,
     opts: RequestOptions = { timeout: 1000, noMux: false },
   ): Promise<Msg> {
-    this._check(subject, true, true);
+    try {
+      this._check(subject, true, true);
+    } catch (err) {
+      return Promise.reject(err);
+    }
     opts.timeout = opts.timeout || 1000;
     if (opts.timeout < 1) {
       return Promise.reject(new NatsError("timeout", ErrorCode.InvalidOption));

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -32,7 +32,7 @@ import {
 } from "../nats-base-client/internal_mod.ts";
 import type { TlsOptions } from "../nats-base-client/types.ts";
 
-const VERSION = "1.3.0";
+const VERSION = "1.3.1";
 const LANG = "nats.deno";
 
 // if trying to simply write to the connection for some reason

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -447,6 +447,19 @@ Deno.test("basics - request with custom subject", async () => {
   await cleanup(ns, nc);
 });
 
+Deno.test("basics - request requires a subject", async () => {
+  const { ns, nc } = await setup();
+  await assertThrowsAsync(
+    async () => {
+      //@ts-ignore: subject missing on purpose
+      await nc.request();
+    },
+    NatsError,
+    "BAD_SUBJECT",
+  );
+  await cleanup(ns, nc);
+});
+
 Deno.test("basics - close promise resolves", async () => {
   const lock = Lock();
   const cs = new TestServer(false, (ca: Connection) => {


### PR DESCRIPTION
[FIX] in some downstream environments the assertion for the subject doesn't seem to auto-reject properly even if there's a handler associated with the promise.