### PR TITLE
JSM consumer `update`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.6.3" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.6.5" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
       - name: Add hosts to /etc/hosts

--- a/nats-base-client/jsmconsumer_api.ts
+++ b/nats-base-client/jsmconsumer_api.ts
@@ -17,6 +17,7 @@ import {
   ConsumerConfig,
   ConsumerInfo,
   ConsumerListResponse,
+  ConsumerUpdateConfig,
   CreateConsumerRequest,
   JetStreamOptions,
   Lister,
@@ -62,6 +63,16 @@ export class ConsumerAPIImpl extends BaseApiClient implements ConsumerAPI {
       : `${this.prefix}.CONSUMER.CREATE.${stream}`;
     const r = await this._request(subj, cr);
     return r as ConsumerInfo;
+  }
+
+  async update(
+    stream: string,
+    durable: string,
+    cfg: ConsumerUpdateConfig,
+  ): Promise<ConsumerInfo> {
+    const ci = await this.info(stream, durable);
+    const changable = cfg as ConsumerConfig;
+    return this.add(stream, Object.assign(ci.config, changable));
   }
 
   async info(stream: string, name: string): Promise<ConsumerInfo> {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -417,6 +417,11 @@ export interface Lister<T> {
 export interface ConsumerAPI {
   info(stream: string, consumer: string): Promise<ConsumerInfo>;
   add(stream: string, cfg: Partial<ConsumerConfig>): Promise<ConsumerInfo>;
+  update(
+    stream: string,
+    durable: string,
+    cfg: ConsumerUpdateConfig,
+  ): Promise<ConsumerInfo>;
   delete(stream: string, consumer: string): Promise<boolean>;
   list(stream: string): Lister<ConsumerInfo>;
 }
@@ -757,10 +762,8 @@ export interface AccountLimits {
   "max_consumers": number;
 }
 
-export interface ConsumerConfig {
-  description?: string;
+export interface ConsumerConfig extends ConsumerUpdateConfig {
   "ack_policy": AckPolicy;
-  "ack_wait"?: Nanos;
   "deliver_policy": DeliverPolicy;
   "deliver_subject"?: string;
   "deliver_group"?: string;
@@ -768,14 +771,19 @@ export interface ConsumerConfig {
   "filter_subject"?: string;
   "flow_control"?: boolean; // send message with status of 100 and reply subject
   "idle_heartbeat"?: Nanos; // send empty message when idle longer than this
-  "max_ack_pending"?: number;
-  "max_deliver"?: number;
-  "max_waiting"?: number;
   "opt_start_seq"?: number;
   "opt_start_time"?: string;
   "rate_limit_bps"?: number;
   "replay_policy": ReplayPolicy;
+}
+
+export interface ConsumerUpdateConfig {
+  description?: string;
+  "ack_wait"?: Nanos;
+  "max_deliver"?: number;
   "sample_freq"?: string;
+  "max_ack_pending"?: number;
+  "max_waiting"?: number;
   "headers_only"?: boolean;
 }
 

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -42,7 +42,7 @@ import {
   setup,
 } from "./jstest_util.ts";
 import { connect } from "../src/mod.ts";
-import { assertThrowsAsyncErrorCode, notCompatible } from './helpers/mod.ts'
+import { assertThrowsAsyncErrorCode, notCompatible } from "./helpers/mod.ts";
 import { validateName } from "../nats-base-client/jsutil.ts";
 
 const StreamNameRequired = "stream name required";


### PR DESCRIPTION
added a typed consumer `update` - while JetStream simply does an `add`, the update api, simply retrieves the consumer, and assigns values present in the update (typed to show what properties are editable) - note that this is only intended for updates to durable consumers.

Modifying a consumer is only supported on nats-server 2.6.4+