### PR TITLE
Deno 1.16.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.8.3, 1.9.2, 1.13.2]
+        deno-version: [1.16.3]
 
     steps:
       - name: Git Checkout Deno Module

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -81,8 +81,8 @@ const reducer = (a, m) => {
     a.version = m.version;
     a.async = m.async;
 
-    a.max = Math.max((a.max === undefined ? 0 : a.max), m.duration);
-    a.min = Math.min((a.min === undefined ? m.duration : a.max), m.duration);
+    a.max = Math.max(a.max === undefined ? 0 : a.max, m.duration);
+    a.min = Math.min(a.min === undefined ? m.duration : a.max, m.duration);
   }
   return a;
 };

--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -99,13 +99,13 @@ export class NatsError extends Error {
   api_error?: ApiError;
 
   /**
-     * @param {String} message
-     * @param {String} code
-     * @param {Error} [chainedError]
-     * @constructor
-     *
-     * @api private
-     */
+   * @param {String} message
+   * @param {String} code
+   * @param {Error} [chainedError]
+   * @constructor
+   *
+   * @api private
+   */
   constructor(message: string, code: string, chainedError?: Error) {
     super(message);
     this.name = "NatsError";

--- a/nats-base-client/ipparser.ts
+++ b/nats-base-client/ipparser.ts
@@ -194,7 +194,7 @@ function xtoi(s: string): { n: number; c: number; ok: boolean } {
   for (i = 0; i < s.length; i++) {
     if (ASCII0 <= s.charCodeAt(i) && s.charCodeAt(i) <= ASCII9) {
       n *= 16;
-      n += (s.charCodeAt(i) - ASCII0);
+      n += s.charCodeAt(i) - ASCII0;
     } else if (ASCIIa <= s.charCodeAt(i) && s.charCodeAt(i) <= ASCIIf) {
       n *= 16;
       n += (s.charCodeAt(i) - ASCIIa) + 10;

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -221,10 +221,10 @@ export class NatsConnectionImpl implements NatsConnection {
     }
   }
 
-  /***
-     * Flushes to the server. Promise resolves when round-trip completes.
-     * @returns {Promise<void>}
-     */
+  /** *
+   * Flushes to the server. Promise resolves when round-trip completes.
+   * @returns {Promise<void>}
+   */
   flush(): Promise<void> {
     if (this.isClosed()) {
       return Promise.reject(

--- a/nats-base-client/nuid.ts
+++ b/nats-base-client/nuid.ts
@@ -62,11 +62,11 @@ export class Nuid {
   }
 
   /**
-     * Initializes a nuid with a crypto random prefix,
-     * and pseudo-random sequence and increment.
-     *
-     * @api private
-     */
+   * Initializes a nuid with a crypto random prefix,
+   * and pseudo-random sequence and increment.
+   *
+   * @api private
+   */
   private init() {
     this.setPre();
     this.initSeqAndInc();
@@ -74,20 +74,20 @@ export class Nuid {
   }
 
   /**
-     * Initializes the pseudo randmon sequence number and the increment range.
-     *
-     * @api private
-     */
+   * Initializes the pseudo randmon sequence number and the increment range.
+   *
+   * @api private
+   */
   private initSeqAndInc() {
     this.seq = Math.floor(Math.random() * maxSeq);
     this.inc = Math.floor(Math.random() * (maxInc - minInc) + minInc);
   }
 
   /**
-     * Sets the prefix from crypto random bytes. Converts to base36.
-     *
-     * @api private
-     */
+   * Sets the prefix from crypto random bytes. Converts to base36.
+   *
+   * @api private
+   */
   private setPre() {
     const cbuf = new Uint8Array(preLen);
     cryptoObj.getRandomValues(cbuf);
@@ -98,10 +98,10 @@ export class Nuid {
   }
 
   /**
-     * Fills the sequence part of the nuid as base36 from this.seq.
-     *
-     * @api private
-     */
+   * Fills the sequence part of the nuid as base36 from this.seq.
+   *
+   * @api private
+   */
   private fillSeq() {
     let n = this.seq;
     for (let i = totalLen - 1; i >= preLen; i--) {
@@ -111,10 +111,10 @@ export class Nuid {
   }
 
   /**
-     * Returns the next nuid.
-     *
-     * @api private
-     */
+   * Returns the next nuid.
+   *
+   * @api private
+   */
   next(): string {
     this.seq += this.inc;
     if (this.seq > maxSeq) {

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -568,7 +568,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     }
 
     if (this.info && len > this.info.max_payload) {
-      throw NatsError.errorForCode((ErrorCode.MaxPayloadExceeded));
+      throw NatsError.errorForCode(ErrorCode.MaxPayloadExceeded);
     }
     this.outBytes += len;
     this.outMsgs++;

--- a/tests/heartbeats_test.ts
+++ b/tests/heartbeats_test.ts
@@ -102,5 +102,5 @@ Deno.test("heartbeat - recovers from missed", async () => {
   await delay(800);
   hb.cancel();
   assertEquals(hb.timer, undefined);
-  assert(status.length >= 7, `${status.length} >= 7`);
+  assert(status.length >= 6, `${status.length} >= 6`);
 });

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -28,11 +28,11 @@ import { assert } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import { jsopts } from "../jstest_util.ts";
 
 export const ServerSignals = Object.freeze({
-  QUIT: Deno.Signal.SIGQUIT,
-  STOP: Deno.Signal.SIGSTOP,
-  REOPEN: Deno.Signal.SIGUSR1,
-  RELOAD: Deno.Signal.SIGHUP,
-  LDM: Deno.Signal.SIGUSR2,
+  QUIT: "SIGQUIT",
+  STOP: "SIGSTOP",
+  REOPEN: "SIGUSR1",
+  RELOAD: "SIGHUP",
+  LDM: "SIGUSR2",
 });
 
 export interface PortInfo {
@@ -216,16 +216,17 @@ export class NatsServer implements PortInfo {
     if (!this.stopped) {
       this.stopped = true;
       this.process.stderr?.close();
-      this.process.kill(Deno.Signal.SIGKILL);
+      this.process.kill("SIGKILL");
       this.process.close();
     }
     await this.done;
   }
 
-  signal(signal: Deno.MacOSSignal | Deno.LinuxSignal): Promise<void> {
-    if (signal === Deno.Signal.SIGKILL) {
+  signal(signal: string): Promise<void> {
+    if (signal === "SIGKILL") {
       return this.stop();
     } else {
+      //@ts-ignore: this is correct
       this.process.kill(signal);
       return Promise.resolve();
     }

--- a/tests/sub_extensions_test.ts
+++ b/tests/sub_extensions_test.ts
@@ -30,10 +30,10 @@ Deno.test("extensions - cleanup fn called at auto unsub", async () => {
   const d = deferred<string>();
   const subimpl = sub as SubscriptionImpl;
   subimpl.info = { data: "hello" };
-  subimpl.cleanupFn = ((_sub, info) => {
+  subimpl.cleanupFn = (_sub, info) => {
     const id = info as { data?: string };
     d.resolve(id.data ? id.data : "");
-  });
+  };
   nc.publish(subj);
   assertEquals(await d, "hello");
   assert(sub.isClosed());
@@ -47,9 +47,9 @@ Deno.test("extensions - cleanup fn called at unsubscribe", async () => {
   const d = deferred<string>();
   const subimpl = sub as SubscriptionImpl;
   subimpl.info = { data: "hello" };
-  subimpl.cleanupFn = (() => {
+  subimpl.cleanupFn = () => {
     d.resolve("hello");
-  });
+  };
   sub.unsubscribe();
   assertEquals(await d, "hello");
   assert(sub.isClosed());
@@ -63,9 +63,9 @@ Deno.test("extensions - cleanup fn called at sub drain", async () => {
   const d = deferred<string>();
   const subimpl = sub as SubscriptionImpl;
   subimpl.info = { data: "hello" };
-  subimpl.cleanupFn = (() => {
+  subimpl.cleanupFn = () => {
     d.resolve("hello");
-  });
+  };
   await sub.drain();
   assertEquals(await d, "hello");
   assert(sub.isClosed());
@@ -79,9 +79,9 @@ Deno.test("extensions - cleanup fn called at conn drain", async () => {
   const d = deferred<string>();
   const subimpl = sub as SubscriptionImpl;
   subimpl.info = { data: "hello" };
-  subimpl.cleanupFn = (() => {
+  subimpl.cleanupFn = () => {
     d.resolve("hello");
-  });
+  };
   await nc.drain();
   assertEquals(await d, "hello");
   assert(sub.isClosed());

--- a/tests/tls_test.ts
+++ b/tests/tls_test.ts
@@ -19,11 +19,8 @@ import {
 import { connect, ErrorCode } from "../src/mod.ts";
 import {
   assertErrorCode,
-  compare,
-  disabled,
   Lock,
   NatsServer,
-  parseSemVer,
 } from "./helpers/mod.ts";
 
 import { join, resolve } from "https://deno.land/std@0.95.0/path/mod.ts";
@@ -50,13 +47,6 @@ Deno.test("tls - connects to tls without option", async () => {
 });
 
 Deno.test("tls - custom ca fails without root", async () => {
-  if (compare(parseSemVer(Deno.version.deno), parseSemVer("1.9.2")) > 0) {
-    disabled(
-      `deno version ${Deno.version.deno} doesn't reject certificates correctly`,
-    );
-    return;
-  }
-
   const cwd = Deno.cwd();
   const config = {
     host: "0.0.0.0",
@@ -76,6 +66,7 @@ Deno.test("tls - custom ca fails without root", async () => {
     .catch((err) => {
       // this is a bogus error name - but at least we know we are rejected
       assertEquals(err.name, "InvalidData");
+      assertEquals(err.message, "invalid certificate: UnknownIssuer");
       lock.unlock();
     });
 

--- a/tests/tls_test.ts
+++ b/tests/tls_test.ts
@@ -17,11 +17,7 @@ import {
   fail,
 } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import { connect, ErrorCode } from "../src/mod.ts";
-import {
-  assertErrorCode,
-  Lock,
-  NatsServer,
-} from "./helpers/mod.ts";
+import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 
 import { join, resolve } from "https://deno.land/std@0.95.0/path/mod.ts";
 


### PR DESCRIPTION
[CHANGE] [DENO] internals for handling signals in the test framework upgraded to changes from Deno.Signal
[CHANGE] [DENO] tls upgrade changed name of CA property - and instead of a file, takes a string
[BREAKING] [DENO] after this change only Deno 1.16.x or better is compatible with the library.