### PR TITLE
small fixes to KV

### DIFF
--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -836,6 +836,7 @@ export interface KvEntry {
   revision: number;
   delta?: number;
   operation: "PUT" | "DEL" | "PURGE";
+  length: number;
 }
 
 export interface KvCodec<T> {
@@ -867,6 +868,7 @@ export interface KvOptions {
   ttl: number; // millis
   streamName: string;
   codec: KvCodecs;
+  storage: StorageType;
 }
 
 /**


### PR DESCRIPTION
[FEAT] KvEntry now adds `length` to telegraph the length of the payload - if `headers_only` this value is extracted from the header sent by the server, otherwise, it is calculated from the payload.

[FIX] KvOption didn't expose the storage type for the KV - it is now possible to specify `StorageType.File` (the default) or `StorageType.Memory`.

[FEAT] history() and watch() can now specify `headers_only` as an option.