### PR TITLE
KV prefix handling

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -398,7 +398,7 @@ export class JetStreamClientImpl extends BaseApiClient
           ErrorCode.ApiError,
         );
       }
-      jsi.config.deliver_subject = createInbox();
+      jsi.config.deliver_subject = createInbox(this.nc.options.inboxPrefix);
       jsi.config.ack_policy = AckPolicy.None;
       jsi.config.max_deliver = 1;
       jsi.config.flow_control = true;
@@ -560,7 +560,7 @@ class JetStreamSubscriptionImpl extends TypedSubscription<JsMsg>
     if (this.info === null || this.sub.isClosed()) {
       return;
     }
-    const newDeliver = createInbox(this.js.opts.apiPrefix);
+    const newDeliver = createInbox(this.js.nc.options.inboxPrefix);
     const nci = this.js.nc;
     nci._resub(this.sub, newDeliver);
     const info = this.info;

--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -89,8 +89,8 @@ class ViewsImpl implements Views {
     this.js = js;
     jetstreamPreview(this.js.nc);
   }
-  async kv(name: string, opts: Partial<KvOptions> = {}): Promise<KV> {
-    return Bucket.create(this.js.nc, name, opts);
+  kv(name: string, opts: Partial<KvOptions> = {}): Promise<KV> {
+    return Bucket.create(this.js, name, opts);
   }
 }
 

--- a/nats-base-client/kv.ts
+++ b/nats-base-client/kv.ts
@@ -228,7 +228,7 @@ export class Bucket implements KV, KvRemove {
     return `${this.subjPrefix}.${this.bucket}.${k}`;
   }
 
-  getSubjectForKey(k: string): string {
+  fullKeyName(k: string): string {
     return `${kvSubjectPrefix}.${this.bucket}.${k}`;
   }
 
@@ -350,7 +350,7 @@ export class Bucket implements KV, KvRemove {
     this.validateKey(ek);
     try {
       const sm = await this.jsm.streams.getMessage(this.bucketName(), {
-        last_by_subj: this.getSubjectForKey(ek),
+        last_by_subj: this.fullKeyName(ek),
       });
       return this.smToEntry(k, sm);
     } catch (err) {
@@ -411,7 +411,7 @@ export class Bucket implements KV, KvRemove {
         ? DeliverPolicy.All
         : DeliverPolicy.LastPerSubject,
       "ack_policy": AckPolicy.None,
-      "filter_subject": this.getSubjectForKey(ek),
+      "filter_subject": this.fullKeyName(ek),
       "flow_control": true,
       "idle_heartbeat": nanos(5 * 1000),
     }, opts) as Partial<ConsumerConfig>;

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -34,14 +34,13 @@ import { assert } from "../nats-base-client/denobuffer.ts";
 
 const conf = {
   authorization: {
-    PERM: {
-      subscribe: "bar",
-      publish: "foo",
-    },
     users: [{
       user: "derek",
       password: "foobar",
-      permission: "$PERM",
+      permission: {
+        subscribe: "bar",
+        publish: "foo",
+      },
     }],
   },
 };

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -594,7 +594,7 @@ export function toConf(o: any, indent?: string): string {
       } else {
         if (!Array.isArray(o)) {
           if (
-            typeof v === "string" && v.startsWith("$JS.")
+            typeof v === "string" && v.startsWith("$")
           ) {
             buf.push(`${pad}${k}: "${v}"`);
           } else if (

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -59,14 +59,13 @@ Deno.test("iterators - autounsub breaks and closes", async () => {
 Deno.test("iterators - permission error breaks and closes", async () => {
   const conf = {
     authorization: {
-      PERM: {
-        subscribe: "bar",
-        publish: "foo",
-      },
       users: [{
         user: "derek",
         password: "foobar",
-        permission: "$PERM",
+        permission: {
+          subscribe: "bar",
+          publish: "foo",
+        },
       }],
     },
   };


### PR DESCRIPTION
[FEAT] Properly support KV across accounts:

a sample server configuration:

```javascript
accounts: {
      A: {
        jetstream: true,
        users: [{ user: "a", password: "a" }],
        exports: [
          { service: "$JS.API.>" },
          { service: "$KV.>" },
          { stream: "forb.>" },
        ],
      },
      B: {
        users: [{ user: "b", password: "b" }],
        imports: [
          { service: { subject: "$JS.API.>", account: "A" }, to: "froma.>" },
          { service: { subject: "$KV.>", account: "A" }, to: "froma.$KV.>" },
          { stream: { subject: "forb.>", account: "A" } },
        ],
      },
    },
```
In the above:

- A exports:
  -  Its JetStream API  - required to use KV
  - A service all subjects relating to KV
  - A stream
- B imports:
  - The JetStream API
  - The KV subjects, using a prefix
  - The prefixed stream

In ordered to access the KV, the client in `B`:
- Creates a connection setting the `inboxPrefix` to `forb` (this will force NATS to know that subscription interest on `forb.>` is required by account `B` and allow the ordered push consumer to work for watches and history.
- Using the same connection, the client creates a `JetStreamClient`, setting the option `apiPrefix` to `froma`, `JetStreamManager` requests to setup the KV, etc, will now flow to the account's `A` JetStream.
- KVs created with that JetStream will now properly target buckets in `A`.

[CHANGE] internal Bucket.create now requires a JetStreamClient instead of a NatsConnection - this allows propagation of the JetStream options to the KV, which enables prefixes (from the NatsConnection) and `apiPrefix` from the `JetStreamClient` to be properly honored by the Kv.

[FIX] consumer options ignored `inboxPrefix` connection option when auto-generating an inbox for a `deliverTo`, this, in turn, prevented things like watch/history from working on across accounts because in order to circumvent consumer issues across accounts a stream must be exported, and subscriber must use this prefix in order to receive messages. Possibly this is incorrect but requires current consumer across account strategy to be changed to pull (or at least support ordered pull consumers) 

[FIX] when re-creating an ordered consumer, the API prefix was incorrectly used as an inbox prefix.


