### PR TITLE
[FIX] processOptions processed `port` property before `servers`

### DIFF
--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -50,11 +50,12 @@ export function defaultOptions(): ConnectionOptions {
 export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
   const dhp = `${DEFAULT_HOST}:${defaultPort()}`;
   opts = opts || { servers: [dhp] };
-  if (opts.port) {
-    opts.servers = [`${DEFAULT_HOST}:${opts.port}`];
-  }
+  opts.servers = opts.servers || [];
   if (typeof opts.servers === "string") {
     opts.servers = [opts.servers];
+  }
+  if (opts.servers.length === 0 && opts.port) {
+    opts.servers = [`${DEFAULT_HOST}:${opts.port}`];
   }
   if (opts.servers && opts.servers.length === 0) {
     opts.servers = [dhp];


### PR DESCRIPTION
If an ambiguous configuration was provided (one that specified `port` and `servers`), the `port` option would be selected, discarding the specified `servers`. The documentation for the JavaScript clients specifies that port is only processed if no servers are specified.

FIX #247