### PR TITLE
Fixes associated with NATS server 2.7 behavior changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.6.5" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.7.0" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
       - name: Add hosts to /etc/hosts

--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -160,7 +160,7 @@ export class JetStreamClientImpl extends BaseApiClient
     const msg = await this.nc.request(
       // FIXME: specify expires
       `${this.prefix}.CONSUMER.MSG.NEXT.${stream}.${durable}`,
-      this.jc.encode({ no_wait: true, batch: 1, expires: nanos(this.timeout) }),
+      this.jc.encode({ no_wait: true, batch: 1, expires: 0 }),
       { noMux: true, timeout: this.timeout },
     );
     const err = checkJsError(msg);
@@ -192,6 +192,9 @@ export class JetStreamClientImpl extends BaseApiClient
     const args: Partial<PullOptions> = {};
     args.batch = opts.batch || 1;
     args.no_wait = opts.no_wait || false;
+    if (args.no_wait && args.expires) {
+      args.expires = 0;
+    }
     const expires = opts.expires || 0;
     if (expires) {
       args.expires = nanos(expires);
@@ -649,8 +652,8 @@ class JetStreamPullSubscriptionImpl extends JetStreamSubscriptionImpl
     super(js, subject, opts);
   }
   pull(opts: Partial<PullOptions> = { batch: 1 }): void {
-    const { stream, config } = this.sub.info as JetStreamSubscriptionInfo;
-    const consumer = config.durable_name;
+    const { stream, config, name } = this.sub.info as JetStreamSubscriptionInfo;
+    const consumer = config.durable_name ?? name;
     const args: Partial<PullOptions> = {};
     args.batch = opts.batch || 1;
     args.no_wait = opts.no_wait || false;

--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -238,7 +238,9 @@ export class JetStreamClientImpl extends BaseApiClient
             timer = null;
           }
           if (
-            isNatsError(err) && err.code === ErrorCode.JetStream404NoMessages
+            isNatsError(err) &&
+            (err.code === ErrorCode.JetStream404NoMessages ||
+              err.code === ErrorCode.JetStream408RequestTimeout)
           ) {
             qi.stop();
           } else {

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -96,7 +96,7 @@ export function checkJsErrorCode(
   switch (code) {
     case 408:
       return NatsError.errorForCode(
-        ErrorCode.JetStream404NoMessages,
+        ErrorCode.JetStream408RequestTimeout,
         new Error(description),
       );
     case 503:

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -94,6 +94,11 @@ export function checkJsErrorCode(
   }
   description = description.toLowerCase();
   switch (code) {
+    case 408:
+      return NatsError.errorForCode(
+        ErrorCode.JetStream404NoMessages,
+        new Error(description),
+      );
     case 503:
       return NatsError.errorForCode(
         ErrorCode.JetStreamNotEnabled,


### PR DESCRIPTION
[FIX] nats-server 2.7+ handle mixes of `no_wait` and `expires` are slightly different. Since `no_wait` is exposed, the javascript client handles that option by eliminating any specification of `expires`.

[FIX] nats-server 2.7+ returns a 408 when `expires` triggers - previously it was a NoMessages, the 408 is remapped to the no messages which then is handled properly.

[CHANGE] nats-server 2.7+ allows pull consumers to be ephemeral, added a fix for the determination of the consumer `name`, since previously it was the durable, but now it is the consumer name returned by the create consumer.