### PR TITLE
hostPort fixes for http/s protocol default parsing

### DIFF
--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -25,13 +25,14 @@ import { defaultPort, getUrlParseFn } from "./transport.ts";
 import { shuffle } from "./util.ts";
 import { isIP } from "./ipparser.ts";
 
-function isIPV4OrHostname(hp: string): boolean {
+export function isIPV4OrHostname(hp: string): boolean {
   if (hp.indexOf(".") !== -1) {
     return true;
   }
   if (hp.indexOf("[") !== -1 || hp.indexOf("::") !== -1) {
     return false;
   }
+  // if we have a plain hostname or host:port
   if (hp.split(":").length <= 2) {
     return true;
   }

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -28,6 +28,7 @@ import { isIP } from "./ipparser.ts";
 function hostPort(
   u: string,
 ): { listen: string; hostname: string; port: number } {
+  u = u.trim();
   // remove any protocol that may have been provided
   if (u.match(/^(.*:\/\/)(.*)/m)) {
     u = u.replace(/^(.*:\/\/)(.*)/gm, "$2");
@@ -36,12 +37,20 @@ function hostPort(
   // that means that protocols other than HTTP/S are not
   // parsable correctly.
   const url = new URL(`http://${u}`);
+
+  let sport = "";
   if (!url.port) {
-    url.port = `${DEFAULT_PORT}`;
+    if (u.endsWith(":80")) {
+      sport = "80";
+    } else if (u.endsWith(":443")) {
+      sport = "443";
+    } else {
+      url.port = `${DEFAULT_PORT}`;
+    }
   }
   const listen = url.host;
   const hostname = url.hostname;
-  const port = parseInt(url.port, 10);
+  const port = sport !== "" ? parseInt(sport, 10) : parseInt(url.port, 10);
 
   return { listen, hostname, port };
 }

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -44,6 +44,7 @@ import {
 import { connect } from "../src/mod.ts";
 import { assertThrowsAsyncErrorCode, notCompatible } from "./helpers/mod.ts";
 import { validateName } from "../nats-base-client/jsutil.ts";
+import { JsMsgImpl } from "../nats-base-client/jsmsg.ts";
 
 const StreamNameRequired = "stream name required";
 const ConsumerNameRequired = "durable name required";

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -114,10 +114,15 @@ Deno.test("servers - save tls name", () => {
 Deno.test("servers - port 80", () => {
   function t(hp: string, port: number) {
     let servers = new Servers([hp]);
-    assertEquals(servers.getCurrentServer().port, port);
+    const s = servers.getCurrentServer();
+    assertEquals(s.port, port);
   }
   t("localhost:80", 80);
   t("localhost:443", 443);
   t("localhost:201", 201);
   t("localhost", 4222);
+  t("localhost/foo", 4222);
+  t("localhost:2342/foo", 2342);
+  t("[2001:db8:4006:812::200e]:8080", 8080);
+  t("::1", 4222);
 });

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  *
  */
-import { Servers } from "../nats-base-client/servers.ts";
+import { isIPV4OrHostname, Servers } from "../nats-base-client/servers.ts";
 import { assertEquals } from "https://deno.land/std@0.95.0/testing/asserts.ts";
 import type { ServerInfo } from "../nats-base-client/types.ts";
 import { setTransportFactory } from "../nats-base-client/internal_mod.ts";
@@ -125,4 +125,9 @@ Deno.test("servers - port 80", () => {
   t("localhost:2342/foo", 2342);
   t("[2001:db8:4006:812::200e]:8080", 8080);
   t("::1", 4222);
+});
+
+Deno.test("servers - hostname only", () => {
+  assertEquals(isIPV4OrHostname("hostname"), true);
+  assertEquals(isIPV4OrHostname("hostname:40"), true);
 });

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -15,7 +15,7 @@
  */
 import { Servers } from "../nats-base-client/servers.ts";
 import { assertEquals } from "https://deno.land/std@0.95.0/testing/asserts.ts";
-import type { ServerInfo } from "../nats-base-client/internal_mod.ts";
+import type { ServerInfo } from "../nats-base-client/types.ts";
 import { setTransportFactory } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("servers - single", () => {
@@ -109,4 +109,15 @@ Deno.test("servers - save tls name", () => {
   gossiped.forEach((sn) => {
     assertEquals(sn.tlsName, "h");
   });
+});
+
+Deno.test("servers - port 80", () => {
+  function t(hp: string, port: number) {
+    let servers = new Servers([hp]);
+    assertEquals(servers.getCurrentServer().port, port);
+  }
+  t("localhost:80", 80);
+  t("localhost:443", 443);
+  t("localhost:201", 201);
+  t("localhost", 4222);
 });


### PR DESCRIPTION
parsing the hostPort will default the port to 4222 if the platform's URL#port doesn't report default ports for a protocol even if specified in the URL (like 80 or 443).

FIX https://github.com/nats-io/nats.js/issues/478