### PR TITLE
[FIX] added constraint to reject options when both servers and port are specified.

### DIFF
--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -54,6 +54,14 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
   if (typeof opts.servers === "string") {
     opts.servers = [opts.servers];
   }
+
+  if (opts.servers.length > 0 && opts.port) {
+    throw new NatsError(
+      "port and servers options are mutually exclusive",
+      ErrorCode.InvalidOption,
+    );
+  }
+
   if (opts.servers.length === 0 && opts.port) {
     opts.servers = [`${DEFAULT_HOST}:${opts.port}`];
   }

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -865,3 +865,13 @@ Deno.test("basics - resolve", async () => {
   assert(srv.resolves && srv.resolves.length > 1);
   await nci.close();
 });
+
+Deno.test("basics - port and server are mutually exclusive", async () => {
+  await assertThrowsAsync(
+    async () => {
+      await connect({ servers: "localhost", port: 4222 });
+    },
+    NatsError,
+    "port and servers options are mutually exclusive",
+  );
+});

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -127,18 +127,6 @@ Deno.test("properties - port is only honored if no servers provided", () => {
   buf.push({ expected: "127.0.0.1:4222" });
   buf.push({ opts: {}, expected: "127.0.0.1:4222" });
   buf.push({ opts: { port: 9999 }, expected: "127.0.0.1:9999" });
-  buf.push({
-    opts: { port: 9999, servers: "myhost" },
-    expected: "myhost:4222",
-  });
-  buf.push({
-    opts: { port: 9999, servers: "myhost:4333" },
-    expected: "myhost:4333",
-  });
-  buf.push({
-    opts: { port: 9999, servers: ["myhost:4444"] },
-    expected: "myhost:4444",
-  });
 
   buf.forEach((t) => {
     const opts = parseOptions(t.opts);


### PR DESCRIPTION
[FIX] added check that either servers or port was provided - if both options are provided the client will throw an error, as that creates ambiguity on the purpose of `port` - `port` is only allowed if no servers are specified.

FIX https://github.com/nats-io/nats.js/issues/479