### PR TITLE
Fixes to `StreamUpdateConfig`, `StreamConfig` and jsm.streams.update() signature

### DIFF
--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -64,7 +64,7 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
 
   async update(
     name: string,
-    cfg = {} as StreamUpdateConfig,
+    cfg = {} as Partial<StreamUpdateConfig>,
   ): Promise<StreamInfo> {
     if (typeof name === "object") {
       const sc = name as StreamConfig;
@@ -75,9 +75,11 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
       );
     }
     validateStreamName(name);
+    const ncfg = cfg as Partial<StreamUpdateConfig> & { name: string };
+    ncfg.name = name;
     const r = await this._request(
       `${this.prefix}.STREAM.UPDATE.${name}`,
-      cfg,
+      ncfg,
     );
     const si = r as StreamInfo;
     this._fixInfo(si);
@@ -86,7 +88,7 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
 
   async info(
     name: string,
-    data?: StreamInfoRequestOptions,
+    data?: Partial<StreamInfoRequestOptions>,
   ): Promise<StreamInfo> {
     validateStreamName(name);
     const r = await this._request(`${this.prefix}.STREAM.INFO.${name}`, data);

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -437,9 +437,12 @@ export type StreamInfoRequestOptions = {
 };
 
 export interface StreamAPI {
-  info(stream: string, opts?: StreamInfoRequestOptions): Promise<StreamInfo>;
+  info(
+    stream: string,
+    opts?: Partial<StreamInfoRequestOptions>,
+  ): Promise<StreamInfo>;
   add(cfg: Partial<StreamConfig>): Promise<StreamInfo>;
-  update(name: string, cfg: StreamUpdateConfig): Promise<StreamInfo>;
+  update(name: string, cfg: Partial<StreamUpdateConfig>): Promise<StreamInfo>;
   purge(stream: string, opts?: PurgeOpts): Promise<PurgeResponse>;
   delete(stream: string): Promise<boolean>;
   list(): Lister<StreamInfo>;
@@ -544,7 +547,6 @@ export interface StreamInfo {
 
 export interface StreamConfig extends StreamUpdateConfig {
   name: string;
-  subjects?: string[];
   retention: RetentionPolicy;
   storage: StorageType;
   "num_replicas": number;
@@ -558,15 +560,16 @@ export interface StreamConfig extends StreamUpdateConfig {
 }
 
 export interface StreamUpdateConfig {
+  subjects: string[];
   description?: string;
-  "max_msgs_per_subject"?: number;
+  "max_msgs_per_subject": number;
   "max_msgs": number;
   "max_age": Nanos;
   "max_bytes": number;
-  "max_msg_size"?: number;
-  discard?: DiscardPolicy;
+  "max_msg_size": number;
+  discard: DiscardPolicy;
   "no_ack"?: boolean;
-  "duplicate_window"?: Nanos;
+  "duplicate_window": Nanos;
   sources?: StreamSource[];
   "allow_rollup_hdrs": boolean;
 }

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -33,7 +33,7 @@ import {
 } from "../nats-base-client/internal_mod.ts";
 import type { TlsOptions } from "../nats-base-client/types.ts";
 
-const VERSION = "1.5.0";
+const VERSION = "1.6.1";
 const LANG = "nats.deno";
 
 // if trying to simply write to the connection for some reason

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -125,6 +125,21 @@ Deno.test("jsm - empty stream config update fails", async () => {
   await cleanup(ns, nc);
 });
 
+Deno.test("jsm - update stream name is internally added", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const jsm = await nc.jetstreamManager();
+  const name = nuid.next();
+  let ci = await jsm.streams.add({
+    name: name,
+    subjects: [`${name}.>`],
+  });
+  assertEquals(ci!.config!.subjects!.length, 1);
+
+  const si = await jsm.streams.update(name, { subjects: [`${name}.>`, "foo"] });
+  assertEquals(si!.config!.subjects!.length, 2);
+  await cleanup(ns, nc);
+});
+
 Deno.test("jsm - delete empty stream name fails", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
   const jsm = await nc.jetstreamManager();


### PR DESCRIPTION
[FIX] StreamUpdateConfig added `subjects`, also unmarked optional `max_msgs_per_subject`, `max_msg_size`, `discard`, and `duplicate_window` - The update api, makes all these fields optional as it is a partial, but when the StreamConfig is returned, these values will be set to their server default values (thus expected to be set).

[FIX] StreamConfig removes `subjects` as it is provided by the extended interface of StreamUpdateConfig

[CHANGE] jsm.streams.update now takes a Partial<StreamUpdateConfig> - this relaxes all fields to be optional

[FIX] jsm.stream.update(name, Partial<StreamUpdateConfig>) will now set the name field - if the update was done without an initial copy of the stream config, this value might not be set by default and result in the server returning an error