### PR TITLE
[FIX] node v17.5.0 seems to go in a loop, suspect some internal patch of subarray to slice

### DIFF
--- a/nats-base-client/parser.ts
+++ b/nats-base-client/parser.ts
@@ -101,12 +101,6 @@ export class Parser {
   }
 
   parse(buf: Uint8Array): void {
-    // @ts-ignore: on node.js module is a global
-    if (typeof module !== "undefined" && module.exports) {
-      // Uint8Array.slice() copies in node it doesn't and it is faster
-      buf.subarray = buf.slice;
-    }
-
     let i: number;
     for (i = 0; i < buf.length; i++) {
       const b = buf[i];


### PR DESCRIPTION
In node, the nbc library conditionally patched buf.subarray as buf.slice because in node, subarray performed copies of the data. This change removes this optimization (as node 17.5.0 seems to internally alias it and thus create an allocation loop which exhausts the stack space).

FIX https://github.com/nats-io/nats.js/issues/483