### PR TITLE
KV watch notifications and discard policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.7.1" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.7.2" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
       - name: Add hosts to /etc/hosts

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -893,7 +893,9 @@ export interface KvRemove {
 export interface RoKV {
   get(k: string): Promise<KvEntry | null>;
   history(opts?: { key?: string }): Promise<QueuedIterator<KvEntry>>;
-  watch(opts?: { key?: string }): Promise<QueuedIterator<KvEntry>>;
+  watch(
+    opts?: { key?: string; headers_only?: boolean; initializedFn?: callbackFn },
+  ): Promise<QueuedIterator<KvEntry>>;
   close(): Promise<void>;
   status(): Promise<KvStatus>;
   keys(k?: string): Promise<QueuedIterator<string>>;
@@ -915,3 +917,5 @@ export interface KV extends RoKV {
 export interface KvPutOptions {
   previousSeq: number;
 }
+
+export type callbackFn = () => void;


### PR DESCRIPTION
[FEAT] kv watch now takes a callback that will get called once the entries existing in the kv have been received, this allows for the client to get a notification of when the existing values have been loaded (watch will continue to run, notifying of other changes)

[CHANGE] kv will now use DiscardPolicy.New when creating kvs on servers 2.7.2 or better

Fixes https://github.com/nats-io/nats-architecture-and-design/issues/94