### PR TITLE
JSMsg.next() - pull next message (or batch)

### DIFF
--- a/nats-base-client/jsmsg.ts
+++ b/nats-base-client/jsmsg.ts
@@ -177,9 +177,12 @@ export class JsMsgImpl implements JsMsg {
     this.doAck(WPI);
   }
 
-  next(subj?: string, ro?: Partial<NextRequest>) {
+  next(subj: string, ro?: Partial<NextRequest>) {
     let payload = NXT;
     if (ro) {
+      if (ro.expires && ro.expires > 0) {
+        ro.expires = nanos(ro.expires);
+      }
       const data = JSONCodec().encode(ro);
       payload = DataBuffer.concat(NXT, SPACE, data);
     }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -463,7 +463,17 @@ export interface JsMsg {
   ack(): void;
   nak(millis?: number): void;
   working(): void;
-  // next(subj?: string): void;
+  /**
+   * next() combines ack() and pull(), requires the subject for a
+   * subscription processing to process a message is provided
+   * (can be the same) however, because the ability to specify
+   * how long to keep the request open can be specified, this
+   * functionality doesn't work well with iterators, as an error
+   * (408s) are expected and needed to re-trigger a pull in case
+   * there was a timeout. In an iterator, the error will close
+   * the iterator, requiring a subscription to be reset.
+   */
+  next(subj: string, ro?: Partial<NextRequest>): void;
   term(): void;
   ackAck(): Promise<boolean>;
 }


### PR DESCRIPTION
[FEAT] next() - allows a JetStream pull subscription using a callback to simplify ack'ing and pulling the next message (or batch of messages). This strategy doesn't require timers, as the server returns an error if the request times out.