### PR TITLE
Fixes related to JetStream errors being prematurely processed by the core request layer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.8.1" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.8.2" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
       - name: Add hosts to /etc/hosts

--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -49,6 +49,7 @@ export enum ErrorCode {
   JetStream404NoMessages = "404",
   JetStream408RequestTimeout = "408",
   JetStream409MaxAckPendingExceeded = "409",
+  JetStream409MaxWaitingExceeded = "409",
   JetStreamNotEnabled = "503",
 
   // emitted by the server

--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -48,8 +48,9 @@ export enum ErrorCode {
   JetStreamInvalidAck = "JESTREAM_INVALID_ACK",
   JetStream404NoMessages = "404",
   JetStream408RequestTimeout = "408",
+  //@deprecated: use JetStream409
   JetStream409MaxAckPendingExceeded = "409",
-  JetStream409MaxWaitingExceeded = "409",
+  JetStream409 = "409",
   JetStreamNotEnabled = "503",
 
   // emitted by the server

--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -744,7 +744,7 @@ function iterMsgAdapter(
     switch (ne.code) {
       case ErrorCode.JetStream404NoMessages:
       case ErrorCode.JetStream408RequestTimeout:
-      case ErrorCode.JetStream409MaxAckPendingExceeded:
+      case ErrorCode.JetStream409:
         return [null, null];
       default:
         return [ne, null];

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -66,6 +66,9 @@ export function millis(ns: Nanos) {
 }
 
 export function isFlowControlMsg(msg: Msg): boolean {
+  if (msg.data.length > 0) {
+    return false;
+  }
   const h = msg.headers;
   if (!h) {
     return false;
@@ -78,6 +81,10 @@ export function isHeartbeatMsg(msg: Msg): boolean {
 }
 
 export function checkJsError(msg: Msg): NatsError | null {
+  // JS error only if no payload - otherwise assume it is application data
+  if (msg.data.length !== 0) {
+    return null;
+  }
   const h = msg.headers;
   if (!h) {
     return null;
@@ -94,9 +101,15 @@ export function checkJsErrorCode(
   }
   description = description.toLowerCase();
   switch (code) {
+    case 404:
+      // 404 for jetstream will provide different messages ensure we
+      // keep whatever the server returned
+      return new NatsError(description, "404");
     case 408:
+      return new NatsError(description, ErrorCode.JetStream408RequestTimeout);
+    case 409:
       return NatsError.errorForCode(
-        ErrorCode.JetStream408RequestTimeout,
+        ErrorCode.JetStream409MaxAckPendingExceeded,
         new Error(description),
       );
     case 503:

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -111,7 +111,7 @@ export function checkJsErrorCode(
       // the description can be exceeded max waiting or max ack pending
       return new NatsError(
         description,
-        ErrorCode.JetStream409MaxWaitingExceeded,
+        ErrorCode.JetStream409,
       );
     case 503:
       return NatsError.errorForCode(

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -104,13 +104,14 @@ export function checkJsErrorCode(
     case 404:
       // 404 for jetstream will provide different messages ensure we
       // keep whatever the server returned
-      return new NatsError(description, "404");
+      return new NatsError(description, ErrorCode.JetStream404NoMessages);
     case 408:
       return new NatsError(description, ErrorCode.JetStream408RequestTimeout);
     case 409:
-      return NatsError.errorForCode(
-        ErrorCode.JetStream409MaxAckPendingExceeded,
-        new Error(description),
+      // the description can be exceeded max waiting or max ack pending
+      return new NatsError(
+        description,
+        ErrorCode.JetStream409MaxWaitingExceeded,
       );
     case 503:
       return NatsError.errorForCode(

--- a/nats-base-client/msg.ts
+++ b/nats-base-client/msg.ts
@@ -20,18 +20,13 @@ import { TD } from "./encoders.ts";
 import { ErrorCode, NatsError } from "./error.ts";
 
 export function isRequestError(msg: Msg): (NatsError | null) {
-  if (msg && msg.headers) {
+  // to consider an error from the server we expect no payload
+  if (msg && msg.data.length === 0 && msg.headers) {
     const headers = msg.headers as MsgHdrsImpl;
     if (headers.hasError) {
+      // only 503s are expected from core NATS (404/408/409s are JetStream)
       if (headers.code === 503) {
         return NatsError.errorForCode(ErrorCode.NoResponders);
-      } else {
-        let desc = headers.description;
-        if (desc === "") {
-          desc = ErrorCode.RequestError;
-        }
-        desc = desc.toLowerCase();
-        return new NatsError(desc, headers.status);
       }
     }
   }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -311,7 +311,7 @@ export interface JetStreamClient {
     data?: Uint8Array,
     options?: Partial<JetStreamPublishOptions>,
   ): Promise<PubAck>;
-  pull(stream: string, durable: string): Promise<JsMsg>;
+  pull(stream: string, durable: string, expires?: number): Promise<JsMsg>;
   fetch(
     stream: string,
     durable: string,

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -3080,7 +3080,6 @@ Deno.test("jetstream - pull error: max_waiting", async () => {
       3000,
       ErrorCode.JetStream408RequestTimeout,
     ),
-    // this a server bug, it should be a 408
     expectError(3000, ErrorCode.JetStream409MaxWaitingExceeded),
   ]);
 

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -3075,7 +3075,7 @@ Deno.test("jetstream - pull error: max_waiting", async () => {
     }
     return d;
   }
-  const errors = await Promise.all([
+  await Promise.all([
     expectError(
       3000,
       ErrorCode.JetStream408RequestTimeout,

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -74,7 +74,7 @@ function callbackConsume(debug = false): JsMsgCallback {
     if (err) {
       switch (err.code) {
         case ErrorCode.JetStream408RequestTimeout:
-        case ErrorCode.JetStream409MaxAckPendingExceeded:
+        case ErrorCode.JetStream409:
         case ErrorCode.JetStream404NoMessages:
           return;
         default:
@@ -817,7 +817,7 @@ Deno.test("jetstream - pull sub - attached callback", async () => {
     if (err) {
       switch (err.code) {
         case ErrorCode.JetStream408RequestTimeout:
-        case ErrorCode.JetStream409MaxAckPendingExceeded:
+        case ErrorCode.JetStream409:
         case ErrorCode.JetStream404NoMessages:
           return;
         default:
@@ -3080,7 +3080,7 @@ Deno.test("jetstream - pull error: max_waiting", async () => {
       3000,
       ErrorCode.JetStream408RequestTimeout,
     ),
-    expectError(3000, ErrorCode.JetStream409MaxWaitingExceeded),
+    expectError(3000, ErrorCode.JetStream409),
   ]);
 
   await cleanup(ns, nc);


### PR DESCRIPTION
[FIX] the base client request introspected a message and if an status code was set, it turned that into an error. The logic for this was not quite correct one requirement is for the message payload of this type of error be empty and NATS core currently can only expect error of 503 (no responders). Any interpretation of the status code unless a 503, should be delegated - in this case to JetStream which can then make better interpretation of the code (which could simply be a marker for no messages, or a request timeout on requests that have an expiration.

[CHANGE] js.pull(stream,dur) now also adds an optional expires - the expires also overrides the request timeout.

FIX #273