### PR TITLE
Expose permission errors at the request api level

### DIFF
--- a/nats-base-client/error.ts
+++ b/nats-base-client/error.ts
@@ -96,6 +96,7 @@ export class NatsError extends Error {
   name: string;
   message: string;
   code: string;
+  permissionContext?: { operation: string; subject: string };
   chainedError?: Error;
   // these are for supporting jetstream
   api_error?: ApiError;

--- a/nats-base-client/jsmsg.ts
+++ b/nats-base-client/jsmsg.ts
@@ -136,7 +136,7 @@ export class JsMsgImpl implements JsMsg {
       if (this.msg.reply) {
         const mi = this.msg as MsgImpl;
         const proto = mi.publisher as unknown as ProtocolHandler;
-        const r = new Request(proto.muxSubscriptions);
+        const r = new Request(proto.muxSubscriptions, this.msg.reply);
         proto.request(r);
         try {
           proto.publish(

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -173,7 +173,7 @@ export class NatsConnectionImpl implements NatsConnection {
         : createInbox(this.options.inboxPrefix);
       const d = deferred<Msg>();
       const errCtx = new Error();
-      this.subscribe(
+      const sub = this.subscribe(
         inbox,
         {
           max: 1,
@@ -198,10 +198,11 @@ export class NatsConnectionImpl implements NatsConnection {
           },
         },
       );
+      (sub as SubscriptionImpl).requestSubject = subject;
       this.protocol.publish(subject, data, { reply: inbox });
       return d;
     } else {
-      const r = new Request(this.protocol.muxSubscriptions, opts);
+      const r = new Request(this.protocol.muxSubscriptions, subject, opts);
       this.protocol.request(r);
 
       try {

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -433,11 +433,15 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     const status: Status = { type: Events.Error, data: err.code };
     if (err.permissionContext) {
       status.permissionContext = err.permissionContext;
-      isMuxPermissionError = this.subscriptions.mux &&
-        this.subscriptions.mux.subject === err.permissionContext.subject;
+      const mux = this.subscriptions.getMux();
+      isMuxPermissionError = mux?.subject === err.permissionContext.subject;
     }
     this.subscriptions.handleError(err);
     this.muxSubscriptions.handleError(isMuxPermissionError, err);
+    if (isMuxPermissionError) {
+      // remove the permission - enable it to be recreated
+      this.subscriptions.setMux(null);
+    }
     this.dispatchStatus(status);
     await this.handleError(err);
   }

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -386,7 +386,15 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   static toError(s: string) {
     const t = s ? s.toLowerCase() : "";
     if (t.indexOf("permissions violation") !== -1) {
-      return new NatsError(s, ErrorCode.PermissionsViolation);
+      const err = new NatsError(s, ErrorCode.PermissionsViolation);
+      const m = s.match(/(Publish|Subscription) to "(\S+)"/);
+      if (m) {
+        err.permissionContext = {
+          operation: m[1].toLowerCase(),
+          subject: m[2],
+        };
+      }
+      return err;
     } else if (t.indexOf("authorization violation") !== -1) {
       return new NatsError(s, ErrorCode.AuthorizationViolation);
     } else if (t.indexOf("user authentication expired") !== -1) {
@@ -421,8 +429,16 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   async processError(m: Uint8Array) {
     const s = decode(m);
     const err = ProtocolHandler.toError(s);
+    let isMuxPermissionError = false;
+    const status: Status = { type: Events.Error, data: err.code };
+    if (err.permissionContext) {
+      status.permissionContext = err.permissionContext;
+      isMuxPermissionError = this.subscriptions.mux &&
+        this.subscriptions.mux.subject === err.permissionContext.subject;
+    }
     this.subscriptions.handleError(err);
-    this.dispatchStatus({ type: Events.Error, data: err.code });
+    this.muxSubscriptions.handleError(isMuxPermissionError, err);
+    this.dispatchStatus(status);
     await this.handleError(err);
   }
 

--- a/nats-base-client/request.ts
+++ b/nats-base-client/request.ts
@@ -24,13 +24,16 @@ export class Request {
   deferred: Deferred<Msg>;
   timer: Timeout<Msg>;
   ctx: Error;
+  requestSubject: string;
   private mux: MuxSubscription;
 
   constructor(
     mux: MuxSubscription,
+    requestSubject: string,
     opts: RequestOptions = { timeout: 1000 },
   ) {
     this.mux = mux;
+    this.requestSubject = requestSubject;
     this.received = 0;
     this.deferred = deferred();
     this.token = nuid.next();

--- a/nats-base-client/subscription.ts
+++ b/nats-base-client/subscription.ts
@@ -37,6 +37,7 @@ export class SubscriptionImpl extends QueuedIteratorImpl<Msg>
   info?: unknown;
   cleanupFn?: (sub: Subscription, info?: unknown) => void;
   closed: Deferred<void>;
+  requestSubject?: string;
 
   constructor(
     protocol: ProtocolHandler,

--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -17,12 +17,13 @@ import type { NatsError } from "./error.ts";
 import type { Msg } from "./types.ts";
 
 export class Subscriptions {
-  mux!: SubscriptionImpl;
+  mux: SubscriptionImpl | null;
   subs: Map<number, SubscriptionImpl>;
   sidCounter: number;
 
   constructor() {
     this.sidCounter = 0;
+    this.mux = null;
     this.subs = new Map<number, SubscriptionImpl>();
   }
 
@@ -37,7 +38,7 @@ export class Subscriptions {
     return s;
   }
 
-  setMux(s: SubscriptionImpl): SubscriptionImpl {
+  setMux(s: SubscriptionImpl | null): SubscriptionImpl | null {
     this.mux = s;
     return s;
   }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -31,6 +31,7 @@ export enum Events {
 export interface Status {
   type: Events | DebugEvents;
   data: string | ServersChanged | number;
+  permissionContext?: { operation: string; subject: string };
 }
 
 export enum DebugEvents {

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -20,15 +20,19 @@ import {
 } from "https://deno.land/std@0.136.0/testing/asserts.ts";
 import {
   connect,
+  createInbox,
   credsAuthenticator,
+  Empty,
   ErrorCode,
   Events,
   jwtAuthenticator,
+  NatsError,
   nkeyAuthenticator,
   Status,
   StringCodec,
   tokenAuthenticator,
   usernamePasswordAuthenticator,
+  UserPass,
 } from "../src/mod.ts";
 import { assertErrorCode, NatsServer } from "./helpers/mod.ts";
 import { deferred, nkeys } from "../nats-base-client/internal_mod.ts";
@@ -40,7 +44,6 @@ import {
   encodeOperator,
   encodeUser,
 } from "https://raw.githubusercontent.com/nats-io/jwt.js/main/src/jwt.ts";
-import { UserPass } from "https://raw.githubusercontent.com/nats-io/nats.deno/main/nats-base-client/authenticator.ts";
 
 const conf = {
   authorization: {
@@ -242,7 +245,6 @@ Deno.test("auth - req permissions keep connection", async () => {
   const errStatus = deferred<Status>();
   const _ = (async () => {
     for await (const s of nc.status()) {
-      console.log(s);
       errStatus.resolve(s);
     }
   })();
@@ -251,8 +253,10 @@ Deno.test("auth - req permissions keep connection", async () => {
     async () => {
       await nc.request("bar");
     },
-    Error,
-    ErrorCode.Timeout,
+    (err: Error) => {
+      const ne = err as NatsError;
+      assertEquals(ne.code, ErrorCode.PermissionsViolation);
+    },
   );
 
   const v = await errStatus;
@@ -613,4 +617,263 @@ Deno.test("auth - bad auth is notified", async () => {
   assertErrorCode(err!, ErrorCode.AuthorizationViolation);
 
   await ns.stop();
+});
+
+Deno.test("auth - perm request error", async () => {
+  const ns = await NatsServer.start({
+    authorization: {
+      users: [{
+        user: "a",
+        password: "b",
+        permission: {
+          publish: "r",
+        },
+      }, {
+        user: "s",
+        password: "s",
+        permission: {
+          subscribe: "q",
+        },
+      }],
+    },
+  });
+
+  const [nc, sc] = await Promise.all([
+    connect(
+      { port: ns.port, user: "a", pass: "b" },
+    ),
+    connect(
+      { port: ns.port, user: "s", pass: "s" },
+    ),
+  ]);
+
+  sc.subscribe("q", {
+    callback: (err, msg) => {
+      if (err) {
+        return;
+      }
+      msg.respond();
+    },
+  });
+
+  const status = deferred<Status>();
+  (async () => {
+    for await (const s of nc.status()) {
+      if (
+        s.permissionContext?.operation === "publish" &&
+        s.permissionContext?.subject === "q"
+      ) {
+        status.resolve(s);
+      }
+    }
+  })().then();
+
+  const response = deferred<Error>();
+  nc.request("q")
+    .catch((err) => {
+      response.resolve(err);
+    });
+
+  const [r, s] = await Promise.all([response, status]);
+  assertErrorCode(r, ErrorCode.PermissionsViolation);
+  const ne = r as NatsError;
+  assertEquals(ne.permissionContext?.operation, "publish");
+  assertEquals(ne.permissionContext?.subject, "q");
+
+  assertEquals(s.type, Events.Error);
+  assertEquals(s.data, ErrorCode.PermissionsViolation);
+  assertEquals(s.permissionContext?.operation, "publish");
+  assertEquals(s.permissionContext?.subject, "q");
+
+  await cleanup(ns, nc, sc);
+});
+
+Deno.test("auth - perm request error no mux", async () => {
+  const ns = await NatsServer.start({
+    authorization: {
+      users: [{
+        user: "a",
+        password: "b",
+        permission: {
+          publish: "r",
+        },
+      }, {
+        user: "s",
+        password: "s",
+        permission: {
+          subscribe: "q",
+        },
+      }],
+    },
+  });
+
+  const [nc, sc] = await Promise.all([
+    connect(
+      { port: ns.port, user: "a", pass: "b" },
+    ),
+    connect(
+      { port: ns.port, user: "s", pass: "s" },
+    ),
+  ]);
+
+  sc.subscribe("q", {
+    callback: (err, msg) => {
+      if (err) {
+        return;
+      }
+      msg.respond();
+    },
+  });
+
+  const status = deferred<Status>();
+  (async () => {
+    for await (const s of nc.status()) {
+      if (
+        s.permissionContext?.operation === "publish" &&
+        s.permissionContext?.subject === "q"
+      ) {
+        status.resolve(s);
+      }
+    }
+  })().then();
+
+  const response = deferred<Error>();
+  nc.request("q", Empty, { noMux: true, timeout: 1000 })
+    .catch((err) => {
+      response.resolve(err);
+    });
+
+  const [r, s] = await Promise.all([response, status]);
+  assertErrorCode(r, ErrorCode.PermissionsViolation);
+  const ne = r as NatsError;
+  assertEquals(ne.permissionContext?.operation, "publish");
+  assertEquals(ne.permissionContext?.subject, "q");
+
+  assertEquals(s.type, Events.Error);
+  assertEquals(s.data, ErrorCode.PermissionsViolation);
+  assertEquals(s.permissionContext?.operation, "publish");
+  assertEquals(s.permissionContext?.subject, "q");
+
+  await cleanup(ns, nc, sc);
+});
+
+Deno.test("auth - perm request error deliver to sub", async () => {
+  const ns = await NatsServer.start({
+    authorization: {
+      users: [{
+        user: "a",
+        password: "b",
+        permission: {
+          publish: "r",
+        },
+      }, {
+        user: "s",
+        password: "s",
+        permission: {
+          subscribe: "q",
+        },
+      }],
+    },
+  });
+
+  const [nc, sc] = await Promise.all([
+    connect(
+      { port: ns.port, user: "a", pass: "b" },
+    ),
+    connect(
+      { port: ns.port, user: "s", pass: "s" },
+    ),
+  ]);
+
+  sc.subscribe("q", {
+    callback: (err, msg) => {
+      if (err) {
+        return;
+      }
+      msg.respond();
+    },
+  });
+
+  const status = deferred<Status>();
+  (async () => {
+    for await (const s of nc.status()) {
+      if (
+        s.permissionContext?.operation === "publish" &&
+        s.permissionContext?.subject === "q"
+      ) {
+        status.resolve(s);
+      }
+    }
+  })().then();
+
+  const inbox = createInbox();
+  const sub = nc.subscribe(inbox, {
+    callback: () => {
+    },
+  });
+
+  const response = deferred<Error>();
+  nc.request("q", Empty, { noMux: true, reply: inbox, timeout: 1000 })
+    .catch((err) => {
+      response.resolve(err);
+    });
+
+  const [r, s] = await Promise.all([response, status]);
+  assertErrorCode(r, ErrorCode.PermissionsViolation);
+  const ne = r as NatsError;
+  assertEquals(ne.permissionContext?.operation, "publish");
+  assertEquals(ne.permissionContext?.subject, "q");
+
+  assertEquals(s.type, Events.Error);
+  assertEquals(s.data, ErrorCode.PermissionsViolation);
+  assertEquals(s.permissionContext?.operation, "publish");
+  assertEquals(s.permissionContext?.subject, "q");
+
+  assertEquals(sub.isClosed(), false);
+
+  await cleanup(ns, nc, sc);
+});
+
+Deno.test("auth - mux sub ok", async () => {
+  const ns = await NatsServer.start({
+    authorization: {
+      users: [{
+        user: "a",
+        password: "b",
+        permission: {
+          subscribe: "r",
+        },
+      }, {
+        user: "s",
+        password: "s",
+        permission: {
+          subscribe: "q",
+        },
+      }],
+    },
+  });
+
+  const [nc, sc] = await Promise.all([
+    connect(
+      { port: ns.port, user: "a", pass: "b" },
+    ),
+    connect(
+      { port: ns.port, user: "s", pass: "s" },
+    ),
+  ]);
+
+  sc.subscribe("q", {
+    callback: (_err, msg) => {
+      msg.respond();
+    },
+  });
+
+  const response = deferred<NatsError>();
+  nc.request("q")
+    .catch((err) => {
+      response.resolve(err);
+    });
+  const ne = await response as NatsError;
+  assertEquals(ne.permissionContext?.operation, "subscription");
+  await cleanup(ns, nc, sc);
 });

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -34,7 +34,7 @@ Deno.test("protocol - mux subscription unknown return null", async () => {
   const mux = new MuxSubscription();
   mux.init();
 
-  const r = new Request(mux);
+  const r = new Request(mux, "");
   r.token = "alberto";
   mux.add(r);
   assertEquals(mux.size(), 1);


### PR DESCRIPTION
[FEAT] request api only rejects responses due to timeouts or no responders, but in the case of permissions, the client may not be able to publish to the request subject or subscribe to the mux inbox, this change rejects the request providing a more context relevant error. Previously it was only possible to learn about the error via the async error notification.

FIX #266