### PR TITLE
[FEAT] support `push_bound`

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -444,7 +444,12 @@ export class JetStreamClientImpl extends BaseApiClient
           ) {
             throw new Error("subject does not match consumer");
           }
+          // check if server returned push_bound, but there's no qn
           const qn = jsi.config.deliver_group ?? "";
+          if (qn === "" && info.push_bound === true) {
+            throw new Error(`duplicate subscription`);
+          }
+
           const rqn = info.config.deliver_group ?? "";
           if (qn !== rqn) {
             if (rqn === "") {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -738,6 +738,7 @@ export interface ConsumerInfo {
   "num_waiting": number;
   "num_pending": number;
   cluster?: ClusterInfo;
+  "push_bound": boolean;
 }
 
 export interface ConsumerListResponse extends ApiResponse, ApiPaged {

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -3134,3 +3134,39 @@ Deno.test("jetstream - mirror alternates", async () => {
   await nc1.close();
   await NatsServer.stopAll(servers);
 });
+
+Deno.test("jetstream - push bound", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const { stream, subj } = await initStream(nc);
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.consumers.add(stream, {
+    durable_name: "me",
+    deliver_subject: "here",
+  });
+
+  const opts = consumerOpts();
+  opts.durable("me");
+  opts.manualAck();
+  opts.ackExplicit();
+  opts.deliverTo("here");
+  opts.callback((_err, msg) => {
+    if (msg) {
+      msg.ack();
+    }
+  });
+  const js = nc.jetstream();
+  await js.subscribe(subj, opts);
+
+  const nc2 = await connect({ port: ns.port });
+  const js2 = nc2.jetstream();
+  await assertRejects(
+    async () => {
+      await js2.subscribe(subj, opts);
+    },
+    Error,
+    "duplicate subscription",
+  );
+
+  await cleanup(ns, nc, nc2);
+});


### PR DESCRIPTION
[FEAT] support rejection of push subscriptions if `push_bound` is reported by the server on non `deliver_group` consumers.

https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-15.md#push-consumer-active-information-and-queue-group-binding

FIX #297