### PR TITLE
support ConsumerConfiguration `backoff`

### DIFF
--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -62,7 +62,7 @@ export function nanos(millis: number): Nanos {
 }
 
 export function millis(ns: Nanos) {
-  return ns / 1000000;
+  return Math.floor(ns / 1000000);
 }
 
 export function isFlowControlMsg(msg: Msg): boolean {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -820,6 +820,7 @@ export interface ConsumerUpdateConfig {
   "max_batch"?: number;
   "max_expires"?: Nanos;
   "inactive_threshold"?: Nanos;
+  "backoff"?: Nanos[];
 }
 
 export interface Consumer {

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -39,6 +39,8 @@ import {
   JsMsg,
   JsMsgCallback,
   JSONCodec,
+  millis,
+  Nanos,
   nanos,
   NatsConnectionImpl,
   NatsError,
@@ -49,6 +51,7 @@ import {
   StringCodec,
 } from "../nats-base-client/internal_mod.ts";
 import {
+  assertArrayIncludes,
   assertEquals,
   assertRejects,
   assertThrows,
@@ -3133,4 +3136,60 @@ Deno.test("jetstream - mirror alternates", async () => {
   await nc.close();
   await nc1.close();
   await NatsServer.stopAll(servers);
+});
+
+Deno.test("jetstream - backoff", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.7.2")) {
+    return;
+  }
+
+  const { stream, subj } = await initStream(nc);
+  const jsm = await nc.jetstreamManager();
+
+  const backoff = [nanos(250), nanos(1000), nanos(3000)];
+  const ci = await jsm.consumers.add(stream, {
+    durable_name: "me",
+    ack_policy: AckPolicy.Explicit,
+    max_deliver: 4,
+    deliver_subject: "here",
+    backoff,
+  });
+
+  assert(ci.config.backoff);
+  assertEquals(ci.config.backoff[0], backoff[0]);
+  assertEquals(ci.config.backoff[1], backoff[1]);
+  assertEquals(ci.config.backoff[2], backoff[2]);
+
+  const js = nc.jetstream();
+  await js.publish(subj);
+
+  const opts = consumerOpts();
+  opts.bind(stream, "me");
+  opts.manualAck();
+
+  const arrive: number[] = [];
+  let start = 0;
+  const sub = await js.subscribe(subj, opts);
+  await (async () => {
+    for await (const m of sub) {
+      if (start === 0) {
+        start = Date.now();
+      }
+      arrive.push(Date.now());
+      if (m.info.redeliveryCount === 4) {
+        break;
+      }
+    }
+  })();
+
+  const delta = arrive.map((v) => {
+    return v - start;
+  });
+
+  assert(delta[1] > 250 && delta[1] < 1000);
+  assert(delta[2] > 1250 && delta[2] < 1500);
+  assert(delta[3] > 4250 && delta[2] < 4500);
+
+  await cleanup(ns, nc);
 });


### PR DESCRIPTION
[FEAT] support ConsumerConfiguration `backoff` - a list of nanos which changes the behaviour of ack_wait to match the list provided in backoff

FIX #299