### PR TITLE
[FIX] Include headers when sending a request with `noMux`

### DIFF
--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -199,7 +199,10 @@ export class NatsConnectionImpl implements NatsConnection {
         },
       );
       (sub as SubscriptionImpl).requestSubject = subject;
-      this.protocol.publish(subject, data, { reply: inbox });
+      this.protocol.publish(subject, data, {
+        reply: inbox,
+        headers: opts.headers,
+      });
       return d;
     } else {
       const r = new Request(this.protocol.muxSubscriptions, subject, opts);


### PR DESCRIPTION
When sending a request with a custom subject for the reply, `noMux` must
be set to `true`. In this case, however, the eventual headers were not
forwarded to the server when performing the actual request. With this
commit, the headers are included as well in the `noMux` case.

FIX #305