### PR TITLE
misc client parity functionality

### DIFF
--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -315,4 +315,13 @@ export class NatsConnectionImpl implements NatsConnection {
     const info = this.info;
     return info ? parseSemVer(info.version) : undefined;
   }
+
+  async rtt(): Promise<number> {
+    if (!this.protocol._closed && !this.protocol.connected) {
+      throw NatsError.errorForCode(ErrorCode.Disconnect);
+    }
+    const start = Date.now();
+    await this.flush();
+    return Date.now() - start;
+  }
 }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -78,6 +78,7 @@ export interface NatsConnection {
 
   jetstreamManager(opts?: JetStreamOptions): Promise<JetStreamManager>;
   jetstream(opts?: JetStreamOptions): JetStreamClient;
+  rtt(): Promise<number>;
 }
 
 export interface ConnectionOptions {
@@ -770,14 +771,34 @@ export interface MsgDeleteRequest extends SeqMsgRequest {
   "no_erase"?: boolean;
 }
 
-export interface JetStreamAccountStats {
+export interface AccountLimits {
+  "max_memory": number;
+  "max_storage": number;
+  "max_streams": number;
+  "max_consumers": number;
+  "memory_max_stream_bytes": number;
+  "storage_max_stream_bytes": number;
+  "max_bytes_required": number;
+}
+
+export interface JetStreamUsage {
   memory: number;
   storage: number;
   streams: number;
   consumers: number;
-  api: JetStreamApiStats;
+}
+
+export interface JetStreamUsageAccountLimits extends JetStreamUsage {
   limits: AccountLimits;
+}
+
+export interface JetStreamAccountStats extends JetStreamUsageAccountLimits {
+  api: JetStreamApiStats;
   domain?: string;
+  tiers?: {
+    R1?: JetStreamUsageAccountLimits;
+    R3?: JetStreamUsageAccountLimits;
+  };
 }
 
 export interface JetStreamApiStats {
@@ -787,13 +808,6 @@ export interface JetStreamApiStats {
 
 export interface AccountInfoResponse
   extends ApiResponse, JetStreamAccountStats {}
-
-export interface AccountLimits {
-  "max_memory": number;
-  "max_storage": number;
-  "max_streams": number;
-  "max_consumers": number;
-}
 
 export interface ConsumerConfig extends ConsumerUpdateConfig {
   "ack_policy": AckPolicy;

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -923,3 +923,32 @@ Deno.test("basics - port and server are mutually exclusive", async () => {
     undefined,
   );
 });
+
+Deno.test("basics - rtt", async () => {
+  const { ns, nc } = await setup({}, {
+    maxReconnectAttempts: 5,
+    reconnectTimeWait: 250,
+  });
+  const rtt = await nc.rtt();
+  assert(rtt > 0);
+
+  await ns.stop();
+  await delay(500);
+  await assertRejects(
+    async () => {
+      await nc.rtt();
+    },
+    Error,
+    ErrorCode.Disconnect,
+  );
+
+  await nc.closed();
+
+  await assertRejects(
+    async () => {
+      await nc.rtt();
+    },
+    Error,
+    ErrorCode.ConnectionClosed,
+  );
+});


### PR DESCRIPTION
[FEAT] nc#rtt() returns the number of millis for a round trip to the server
[FEAT] jsm#getAccountInfo() now reports tiered usage and limits
[TEST] added a test validating underlying jetstream error codes