### PR TITLE
[FIX] change transport.send() to not return a promise

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -468,7 +468,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   }
 
   processPing() {
-    this.transport.send(PONG_CMD).catch(() => {/*ignoring socket error*/});
+    this.transport.send(PONG_CMD);
   }
 
   processPong() {
@@ -693,9 +693,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       }
     });
     if (cmds.length) {
-      this.transport.send(encode(cmds.join(""))).catch(
-        () => {/*ignoring socket error*/},
-      );
+      this.transport.send(encode(cmds.join("")));
     }
   }
 
@@ -750,7 +748,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
 
     if (this.outbound.size()) {
       const d = this.outbound.drain();
-      this.transport.send(d).catch(() => {/*ignoring socket error*/});
+      this.transport.send(d);
     }
   }
 

--- a/nats-base-client/request.ts
+++ b/nats-base-client/request.ts
@@ -81,6 +81,7 @@ export class RequestMany extends BaseRequest implements Request {
     this.done.then(() => {
       this.callback(null, null);
     });
+    // @ts-ignore: node is not a number
     this.timer = setTimeout(() => {
       this.cancel();
     }, opts.maxWait);
@@ -110,6 +111,7 @@ export class RequestMany extends BaseRequest implements Request {
 
       if (this.opts.strategy === RequestStrategy.JitterTimer) {
         clearTimeout(this.timer);
+        // @ts-ignore: node is not a number
         this.timer = setTimeout(() => {
           this.cancel();
         }, 300);

--- a/nats-base-client/transport.ts
+++ b/nats-base-client/transport.ts
@@ -73,7 +73,7 @@ export interface Transport extends AsyncIterable<Uint8Array> {
 
   isEncrypted(): boolean;
 
-  send(frame: Uint8Array): Promise<void>;
+  send(frame: Uint8Array): void;
 
   close(err?: Error): Promise<void>;
 

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -187,7 +187,7 @@ export class DenoTransport implements Transport {
     this._closed(reason).then().catch();
   }
 
-  private enqueue(frame: Uint8Array): Promise<void | Error> {
+  private enqueue(frame: Uint8Array): Promise<void> {
     if (this.done) {
       return Promise.resolve();
     }
@@ -215,7 +215,7 @@ export class DenoTransport implements Transport {
         if (this.options.debug) {
           console.error(`!!! ${render(frame)}: ${err}`);
         }
-        d.resolve(err);
+        d.reject(err);
       })
       .finally(() => {
         this.sendQueue.shift();
@@ -225,7 +225,7 @@ export class DenoTransport implements Transport {
 
   send(frame: Uint8Array): void {
     const p = this.enqueue(frame);
-    p.catch((err) => {
+    p.catch((_err) => {
       // we ignore write errors because client will
       // fail on a read or when the heartbeat timer
       // detects a stale connection
@@ -252,6 +252,7 @@ export class DenoTransport implements Transport {
       try {
         // this is a noop but gives us a place to hang
         // a close and ensure that we sent all before closing
+        // we wait for the operation to fail or succeed
         await this.enqueue(TE.encode(""));
       } catch (err) {
         if (this.options.debug) {

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 The NATS Authors
+ * Copyright 2020-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,7 +33,7 @@ import {
 } from "../nats-base-client/internal_mod.ts";
 import type { TlsOptions } from "../nats-base-client/types.ts";
 
-const VERSION = "1.7.0";
+const VERSION = "1.7.1";
 const LANG = "nats.deno";
 
 // if trying to simply write to the connection for some reason


### PR DESCRIPTION
Another unhandled promise on a K8S environment during the connect/ping exchange an EPIPE was getting generated because of aggressive throttling on resource limits (100 millis of a CPU given to the process).

Verified the change with the help of @arjenvdhave who was kind enough to test and reproduce in his environment.


See https://github.com/nats-io/nats.deno/pull/289#issuecomment-1137372830