### PR TITLE
cleanup StreamConfig/StreamUpdateConfig and KvOptions/KvStatus options

### DIFF
--- a/nats-base-client/kv.ts
+++ b/nats-base-client/kv.ts
@@ -36,6 +36,7 @@ import {
   KvRemove,
   KvStatus,
   MsgRequest,
+  Placement,
   PurgeOpts,
   PurgeResponse,
   RetentionPolicy,
@@ -218,6 +219,12 @@ export class Bucket implements KV, KvRemove {
     sc.max_bytes = bo.maxBucketSize;
     sc.max_msg_size = bo.maxValueSize;
     sc.storage = bo.storage;
+    const location = opts.placementCluster ?? "";
+    if (location) {
+      sc.placement = {} as Placement;
+      sc.placement.cluster = location;
+      sc.placement.tags = [];
+    }
 
     const nci = (this.js as JetStreamClientImpl).nc;
     const have = nci.getServerVersion();
@@ -701,6 +708,8 @@ export class Bucket implements KV, KvRemove {
       ttl: si.config.max_age,
       bucket_location: cluster,
       backingStore: si.config.storage,
+      storage: si.config.storage,
+      replicas: si.config.num_replicas,
     } as KvStatus;
   }
 }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -582,13 +582,9 @@ export interface StreamConfig extends StreamUpdateConfig {
   name: string;
   retention: RetentionPolicy;
   storage: StorageType;
-  "template_owner"?: string;
   "max_consumers": number;
-  placement?: Placement;
   mirror?: StreamSource; // same as a source
   sealed: boolean;
-  "deny_delete": boolean;
-  "deny_purge": boolean;
 }
 
 export interface StreamUpdateConfig {
@@ -605,6 +601,10 @@ export interface StreamUpdateConfig {
   sources?: StreamSource[];
   "allow_rollup_hdrs": boolean;
   "num_replicas": number;
+
+  placement?: Placement;
+  "deny_delete": boolean;
+  "deny_purge": boolean;
 }
 
 export interface StreamSource {
@@ -911,26 +911,37 @@ export interface KvCodecs {
   value: KvCodec<Uint8Array>;
 }
 
-export interface KvStatus {
-  bucket: string;
-  values: number;
+export interface KvLimits {
+  replicas: number;
   history: number;
-  ttl: Nanos;
+  maxBucketSize: number;
+  maxValueSize: number;
+  ttl: number; // millis
+  storage: StorageType;
+  placementCluster: string;
+
+  /**
+   * deprecated: use storage
+   * FIXME: remove this on 1.8
+   */
   backingStore: StorageType;
 }
 
-export interface KvOptions {
-  replicas: number;
-  history: number;
+export interface KvStatus extends KvLimits {
+  bucket: string;
+  values: number;
+
+  /**
+   * deprecated: use placementCluster
+   * FIXME: remove this on 1.8
+   */
+  bucket_location: string;
+}
+
+export interface KvOptions extends KvLimits {
   timeout: number;
-  maxBucketSize: number;
-  maxValueSize: number;
-  placementCluster: string;
-  mirrorBucket: string;
-  ttl: number; // millis
   streamName: string;
   codec: KvCodecs;
-  storage: StorageType;
   bindOnly: boolean;
 }
 

--- a/tests/kv_test.ts
+++ b/tests/kv_test.ts
@@ -875,16 +875,19 @@ Deno.test("kv - mem and file", async () => {
   const js = nc.jetstream();
   const d = await js.views.kv("default") as Bucket;
   assertEquals((await d.status()).backingStore, StorageType.File);
+  assertEquals((await d.status()).storage, StorageType.File);
 
   const f = await js.views.kv("file", {
     storage: StorageType.File,
   }) as Bucket;
   assertEquals((await f.status()).backingStore, StorageType.File);
+  assertEquals((await f.status()).storage, StorageType.File);
 
   const m = await js.views.kv("mem", {
     storage: StorageType.Memory,
   }) as Bucket;
   assertEquals((await m.status()).backingStore, StorageType.Memory);
+  assertEquals((await m.status()).storage, StorageType.Memory);
 
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
[FIX] [KV] `placementCluster` was not honored.
[FIX] [KV] `KvStatus` didn't report the storage type or the number of replicas, requiring inspecting the stream
[DEPRECATE] [KV] `backingStore` in `KvStatus` is deprecated, use `storage`
[DEPRECATE] [KV] `bucket_location` in `KvStatus` is deprecated, use `placementCluster`
[CHANGE] [JETSTREAM] removed `template_owner` option from `StreamConfig` as this option is not supported
[CHANGE] [JETSTREAM] `placement`, "deny_delete", "deny_purge" options for stream is now updatable (`StreamUpdateConfig`)