### PR TITLE
[FEAT] [EXPERIMENTAL] direct get of messages for KV

### DIFF
--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -14,9 +14,11 @@
  */
 
 import {
+  DirectMsg,
   Empty,
   JetStreamOptions,
   Lister,
+  Msg,
   MsgDeleteRequest,
   MsgRequest,
   NatsConnection,
@@ -24,6 +26,7 @@ import {
   PurgeOpts,
   PurgeResponse,
   PurgeTrimOpts,
+  RepublishedHeaders,
   StoredMsg,
   StreamAPI,
   StreamConfig,
@@ -36,7 +39,7 @@ import {
 } from "./types.ts";
 import { BaseApiClient } from "./jsbaseclient_api.ts";
 import { ListerFieldFilter, ListerImpl } from "./jslister.ts";
-import { validateStreamName } from "./jsutil.ts";
+import { checkJsError, validateStreamName } from "./jsutil.ts";
 import { headers, MsgHdrs, MsgHdrsImpl } from "./headers.ts";
 
 export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
@@ -162,8 +165,62 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     return new StoredMsgImpl(sm);
   }
 
+  async getDirectMessage(
+    stream: string,
+    query: MsgRequest,
+  ): Promise<StoredMsg> {
+    validateStreamName(stream);
+    const r = await this.nc.request(
+      `$JS.DS.GET.${stream}`,
+      this.jc.encode(query),
+    );
+
+    // response is not a JS.API response
+    const err = checkJsError(r);
+    if (err) {
+      return Promise.reject(err);
+    }
+    const dm = new DirectMsgImpl(r);
+    return Promise.resolve(dm);
+  }
+
   find(subject: string): Promise<string> {
     return this.findStream(subject);
+  }
+}
+
+export class DirectMsgImpl implements DirectMsg {
+  data: Uint8Array;
+  header: MsgHdrs;
+
+  constructor(m: Msg) {
+    if (!m.headers) {
+      throw new Error("headers expected");
+    }
+    this.data = m.data;
+    this.header = m.headers;
+  }
+
+  get subject(): string {
+    return this.header.get(RepublishedHeaders.JsSubject);
+  }
+
+  get seq(): number {
+    const v = this.header.get(RepublishedHeaders.JsSequence);
+    return typeof v === "string" ? parseInt(v) : 0;
+  }
+
+  get time(): Date {
+    return new Date(this.header.get(RepublishedHeaders.JsTimeStamp));
+  }
+
+  get stream(): string {
+    return this.header.get(RepublishedHeaders.JsStream);
+  }
+
+  get lastSequence(): number {
+    const v = this.header.get(RepublishedHeaders.JsLastSequence);
+    return typeof v === "string" ? parseInt(v) : 0;
   }
 }
 

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -89,7 +89,7 @@ export function checkJsError(msg: Msg): NatsError | null {
   if (!h) {
     return null;
   }
-  return checkJsErrorCode(h.code, h.status);
+  return checkJsErrorCode(h.code, h.description);
 }
 
 export function checkJsErrorCode(

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -516,6 +516,11 @@ export interface StoredMsg {
   time: Date;
 }
 
+export interface DirectMsg extends StoredMsg {
+  stream: string;
+  lastSequence: number;
+}
+
 export interface Advisory {
   kind: AdvisoryKind;
   data: unknown;
@@ -601,10 +606,10 @@ export interface StreamUpdateConfig {
   sources?: StreamSource[];
   "allow_rollup_hdrs": boolean;
   "num_replicas": number;
-
   placement?: Placement;
   "deny_delete": boolean;
   "deny_purge": boolean;
+  "allow_direct": boolean;
 }
 
 export interface StreamSource {
@@ -943,6 +948,7 @@ export interface KvOptions extends KvLimits {
   streamName: string;
   codec: KvCodecs;
   bindOnly: boolean;
+  allow_direct: boolean;
 }
 
 /**
@@ -981,3 +987,11 @@ export interface KvPutOptions {
 }
 
 export type callbackFn = () => void;
+
+export enum RepublishedHeaders {
+  JsStream = "Nats-Stream",
+  JsSequence = "Nats-Sequence",
+  JsTimeStamp = "Nats-Time-Stamp",
+  JsSubject = "Nats-Subject",
+  JsLastSequence = "Nats-Last-Sequence",
+}


### PR DESCRIPTION
- [FEAT] implemented getDirectMessage() experimental feature
- [FEAT] [KV] experimental - KvOptions can now specify `allow_direct` which enables the creation of streams on servers that supported that enable the direct api which may provide better performance on gets for KV.
- [FIX] internal checkJsErrorCode() was passing a status instead of a description, creating error descriptions prefixed by the error code