### PR TITLE
[EXPERIMENTAL] [JETSTREAM] pull consumers can now specify `max_bytes` on `PullOptions`

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -70,6 +70,7 @@ import { headers } from "./headers.ts";
 import { consumerOpts, isConsumerOptsBuilder } from "./jsconsumeropts.ts";
 import { Bucket } from "./kv.ts";
 import { NatsConnectionImpl } from "./nats.ts";
+import { Feature } from "./semver.ts";
 
 export interface JetStreamSubscriptionInfoable {
   info: JetStreamSubscriptionInfo | null;
@@ -696,6 +697,12 @@ class JetStreamPullSubscriptionImpl extends JetStreamSubscriptionImpl
     args.batch = opts.batch || 1;
     args.no_wait = opts.no_wait || false;
     if ((opts.max_bytes ?? 0) > 0) {
+      const fv = this.js.nc.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
+      if (!fv.ok) {
+        throw new Error(
+          `max_bytes is only supported on servers ${fv.min} or better`,
+        );
+      }
       args.max_bytes = opts.max_bytes!;
     }
 

--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -211,6 +211,12 @@ export class JetStreamClientImpl extends BaseApiClient
     const args: Partial<PullOptions> = {};
     args.batch = opts.batch || 1;
     if (max_bytes) {
+      const fv = this.nc.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
+      if (!fv.ok) {
+        throw new Error(
+          `max_bytes is only supported on servers ${fv.min} or better`,
+        );
+      }
       args.max_bytes = max_bytes;
     }
     args.no_wait = opts.no_wait || false;

--- a/nats-base-client/jsmsg.ts
+++ b/nats-base-client/jsmsg.ts
@@ -16,7 +16,6 @@ import {
   DeliveryInfo,
   JsMsg,
   Msg,
-  NextRequest,
   PullOptions,
   RequestOptions,
 } from "./types.ts";
@@ -178,7 +177,7 @@ export class JsMsgImpl implements JsMsg {
     this.doAck(WPI);
   }
 
-  next(subj: string, opts: Partial<NextRequest> = { batch: 1 }) {
+  next(subj: string, opts: Partial<PullOptions> = { batch: 1 }) {
     const args: Partial<PullOptions> = {};
     args.batch = opts.batch || 1;
     args.no_wait = opts.no_wait || false;

--- a/nats-base-client/semver.ts
+++ b/nats-base-client/semver.ts
@@ -21,3 +21,45 @@ export function compare(a: SemVer, b: SemVer): number {
   if (a.micro > b.micro) return 1;
   return 0;
 }
+
+export enum Feature {
+  JS_PULL_MAX_BYTES = "js_pull_max_bytes",
+}
+
+type FeatureVersion = {
+  ok: boolean;
+  min: string;
+};
+
+export class Features {
+  server: SemVer;
+  features: Map<Feature, FeatureVersion>;
+  constructor(v: SemVer) {
+    this.features = new Map<Feature, FeatureVersion>();
+    this.server = v;
+
+    this.set(Feature.JS_PULL_MAX_BYTES, "2.8.5");
+  }
+
+  set(f: Feature, requires: string) {
+    this.features.set(f, {
+      min: requires,
+      ok: compare(this.server, parseSemVer(requires)) >= 0,
+    });
+  }
+
+  get(f: Feature): FeatureVersion {
+    return this.features.get(f) || { min: "unknown", ok: false };
+  }
+
+  supports(f: Feature): boolean {
+    return this.get(f).ok;
+  }
+
+  require(v: SemVer | string): boolean {
+    if (typeof v === "string") {
+      v = parseSemVer(v);
+    }
+    return compare(this.server, v) >= 0;
+  }
+}

--- a/nats-base-client/semver.ts
+++ b/nats-base-client/semver.ts
@@ -38,7 +38,7 @@ export class Features {
     this.features = new Map<Feature, FeatureVersion>();
     this.server = v;
 
-    this.set(Feature.JS_PULL_MAX_BYTES, "2.8.5");
+    this.set(Feature.JS_PULL_MAX_BYTES, "2.8.3");
   }
 
   set(f: Feature, requires: string) {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -264,6 +264,7 @@ export interface PullOptions {
   batch: number;
   "no_wait": boolean;
   expires: number;
+  "max_bytes": number;
 }
 
 export interface PubAck {
@@ -442,7 +443,7 @@ export interface ConsumerAPI {
   update(
     stream: string,
     durable: string,
-    cfg: ConsumerUpdateConfig,
+    cfg: Partial<ConsumerUpdateConfig>,
   ): Promise<ConsumerInfo>;
   delete(stream: string, consumer: string): Promise<boolean>;
   list(stream: string): Lister<ConsumerInfo>;
@@ -481,6 +482,8 @@ export interface JsMsg {
   nak(millis?: number): void;
   working(): void;
   /**
+   * !! this is an experimental feature - and could be removed
+   *
    * next() combines ack() and pull(), requires the subject for a
    * subscription processing to process a message is provided
    * (can be the same) however, because the ability to specify
@@ -490,7 +493,7 @@ export interface JsMsg {
    * there was a timeout. In an iterator, the error will close
    * the iterator, requiring a subscription to be reset.
    */
-  next(subj: string, ro?: Partial<NextRequest>): void;
+  next(subj: string, ro?: Partial<PullOptions>): void;
   term(): void;
   ackAck(): Promise<boolean>;
 }
@@ -855,6 +858,7 @@ export interface ConsumerUpdateConfig {
   "max_expires"?: Nanos;
   "inactive_threshold"?: Nanos;
   "backoff"?: Nanos[];
+  "max_bytes"?: number;
 }
 
 export interface Consumer {
@@ -868,12 +872,6 @@ export interface StreamNames {
 
 export interface StreamNameBySubject {
   subject: string;
-}
-
-export interface NextRequest {
-  expires: number;
-  batch: number;
-  "no_wait": boolean;
 }
 
 export enum JsHeaders {

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -1168,12 +1168,12 @@ Deno.test("basics - server version", async () => {
   const { ns, nc } = await setup({});
   const nci = nc as NatsConnectionImpl;
   assertEquals(nci.protocol.features.require("3.0.0"), false);
-  assertEquals(nci.protocol.features.require("2.8.3"), true);
+  assertEquals(nci.protocol.features.require("2.8.2"), true);
 
-  const ok = nci.protocol.features.require("2.8.5");
+  const ok = nci.protocol.features.require("2.8.3");
   const bytes = nci.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
   assertEquals(ok, bytes.ok);
-  assertEquals(bytes.min, "2.8.5");
+  assertEquals(bytes.min, "2.8.3");
   assertEquals(ok, nci.protocol.features.supports(Feature.JS_PULL_MAX_BYTES));
 
   await cleanup(ns, nc);

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -51,6 +51,7 @@ import {
 } from "../nats-base-client/internal_mod.ts";
 import { cleanup, setup } from "./jstest_util.ts";
 import { RequestStrategy } from "../nats-base-client/types.ts";
+import { Feature } from "../nats-base-client/semver.ts";
 
 Deno.test("basics - connect port", async () => {
   const ns = await NatsServer.start();
@@ -1160,5 +1161,20 @@ Deno.test("basics - request many stops on error", async () => {
   }
   const err = await d;
   assertErrorCode(err, ErrorCode.NoResponders);
+  await cleanup(ns, nc);
+});
+
+Deno.test("basics - server version", async () => {
+  const { ns, nc } = await setup({});
+  const nci = nc as NatsConnectionImpl;
+  assertEquals(nci.protocol.features.require("3.0.0"), false);
+  assertEquals(nci.protocol.features.require("2.8.3"), true);
+
+  const ok = nci.protocol.features.require("2.8.5");
+  const bytes = nci.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
+  assertEquals(ok, bytes.ok);
+  assertEquals(bytes.min, "2.8.5");
+  assertEquals(ok, nci.protocol.features.supports(Feature.JS_PULL_MAX_BYTES));
+
   await cleanup(ns, nc);
 });

--- a/tests/jetream409_test.ts
+++ b/tests/jetream409_test.ts
@@ -188,6 +188,9 @@ Deno.test("409 - max_bytes", async () => {
 
 Deno.test("409 - max msg size", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.8.3")) {
+    return;
+  }
   const { stream, subj } = await initStream(nc);
 
   const jsm = await nc.jetstreamManager();

--- a/tests/jetream409_test.ts
+++ b/tests/jetream409_test.ts
@@ -1,0 +1,263 @@
+import {
+  AckPolicy,
+  JetStreamClient,
+  PullOptions,
+} from "../nats-base-client/types.ts";
+import {
+  Js409Errors,
+  nanos,
+  setMaxWaitingToFail,
+} from "../nats-base-client/jsutil.ts";
+import {
+  consumerOpts,
+  deferred,
+  NatsError,
+  StringCodec,
+} from "../nats-base-client/mod.ts";
+import { assertRejects } from "https://deno.land/std@0.125.0/testing/asserts.ts";
+import { assertStringIncludes } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import {
+  cleanup,
+  initStream,
+  jetstreamServerConf,
+  setup,
+} from "./jstest_util.ts";
+import { notCompatible } from "./helpers/mod.ts";
+
+type testArgs = {
+  js: JetStreamClient;
+  stream: string;
+  durable: string;
+  opts: PullOptions;
+  expected: Js409Errors;
+};
+
+async function expectFetchError(args: testArgs) {
+  const { js, stream, durable, opts, expected } = args;
+  const i = js.fetch(stream, durable, opts);
+  await assertRejects(
+    async () => {
+      for await (const _m of i) {
+        //nothing
+      }
+    },
+    Error,
+    expected,
+  );
+}
+
+async function expectPullSubscribeIteratorError(args: testArgs) {
+  const { js, stream, durable, opts, expected } = args;
+  const co = consumerOpts();
+  co.bind(stream, durable);
+  const sub = await js.pullSubscribe(">", co);
+  sub.pull(opts);
+
+  await assertRejects(
+    async () => {
+      for await (const _m of sub) {
+        // nothing
+      }
+    },
+    Error,
+    expected,
+  );
+}
+
+async function expectPullSubscribeCallbackError(
+  args: testArgs,
+) {
+  const { js, stream, durable, opts, expected } = args;
+
+  const d = deferred<NatsError | null>();
+  const co = consumerOpts();
+  co.bind(stream, durable);
+  co.callback((err) => {
+    d.resolve(err);
+  });
+  const sub = await js.pullSubscribe(">", co);
+  sub.pull(opts);
+  const ne = await d;
+  assertStringIncludes(ne?.message || "", expected);
+}
+
+Deno.test("409 - max_batch", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const { stream, subj } = await initStream(nc);
+
+  const jsm = await nc.jetstreamManager();
+
+  const sc = StringCodec();
+  const js = nc.jetstream();
+  for (let i = 0; i < 10; i++) {
+    await js.publish(subj, sc.encode("hello"));
+  }
+
+  await jsm.consumers.add(stream, {
+    durable_name: "a",
+    ack_policy: AckPolicy.Explicit,
+    max_batch: 1,
+  });
+
+  const opts = { batch: 10, expires: 1000 } as PullOptions;
+  const to = {
+    js,
+    stream,
+    durable: "a",
+    opts,
+    expected: Js409Errors.MaxBatchExceeded,
+  };
+
+  await expectFetchError(to);
+  await expectPullSubscribeIteratorError(to);
+  await expectPullSubscribeCallbackError(to);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("409 - max_expires", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const { stream, subj } = await initStream(nc);
+
+  const jsm = await nc.jetstreamManager();
+
+  const sc = StringCodec();
+  const js = nc.jetstream();
+  for (let i = 0; i < 10; i++) {
+    await js.publish(subj, sc.encode("hello"));
+  }
+
+  await jsm.consumers.add(stream, {
+    durable_name: "a",
+    ack_policy: AckPolicy.Explicit,
+    max_expires: nanos(1000),
+  });
+
+  const opts = { batch: 1, expires: 5000 } as PullOptions;
+  const to = {
+    js,
+    stream,
+    durable: "a",
+    opts,
+    expected: Js409Errors.MaxExpiresExceeded,
+  };
+
+  await expectFetchError(to);
+  await expectPullSubscribeIteratorError(to);
+  await expectPullSubscribeCallbackError(to);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("409 - max_bytes", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.8.3")) {
+    return;
+  }
+  const { stream, subj } = await initStream(nc);
+
+  const jsm = await nc.jetstreamManager();
+
+  const sc = StringCodec();
+  const js = nc.jetstream();
+  for (let i = 0; i < 10; i++) {
+    await js.publish(subj, sc.encode("hello"));
+  }
+
+  await jsm.consumers.add(stream, {
+    durable_name: "a",
+    ack_policy: AckPolicy.Explicit,
+    max_bytes: 10,
+  });
+
+  const opts = { max_bytes: 1024, expires: 5000 } as PullOptions;
+  const to = {
+    js,
+    stream,
+    durable: "a",
+    opts,
+    expected: Js409Errors.MaxBytesExceeded,
+  };
+
+  await expectFetchError(to);
+  await expectPullSubscribeIteratorError(to);
+  await expectPullSubscribeCallbackError(to);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("409 - max msg size", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const { stream, subj } = await initStream(nc);
+
+  const jsm = await nc.jetstreamManager();
+
+  const sc = StringCodec();
+  const js = nc.jetstream();
+  for (let i = 0; i < 10; i++) {
+    await js.publish(subj, sc.encode("hello"));
+  }
+
+  await jsm.consumers.add(stream, {
+    durable_name: "a",
+    ack_policy: AckPolicy.Explicit,
+  });
+
+  const opts = { max_bytes: 2, expires: 5000 } as PullOptions;
+  const to = {
+    js,
+    stream,
+    durable: "a",
+    opts,
+    expected: Js409Errors.MaxMessageSizeExceeded,
+  };
+
+  await expectFetchError(to);
+  await expectPullSubscribeIteratorError(to);
+  await expectPullSubscribeCallbackError(to);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("409 - max waiting", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const { stream, subj } = await initStream(nc);
+
+  const jsm = await nc.jetstreamManager();
+
+  const sc = StringCodec();
+  const js = nc.jetstream();
+  for (let i = 0; i < 10; i++) {
+    await js.publish(subj, sc.encode("hello"));
+  }
+
+  await jsm.consumers.add(stream, {
+    durable_name: "a",
+    ack_policy: AckPolicy.Explicit,
+    max_waiting: 1,
+  });
+
+  const opts = { expires: 1000 } as PullOptions;
+  const to = {
+    js,
+    stream,
+    durable: "a",
+    opts,
+    expected: Js409Errors.MaxWaitingExceeded,
+  };
+
+  const iter = js.fetch(stream, "a", { batch: 1000, expires: 5000 });
+  (async () => {
+    for await (const _m of iter) {
+      // nothing
+    }
+  })().then();
+
+  setMaxWaitingToFail(true);
+
+  await expectFetchError(to);
+  await expectPullSubscribeIteratorError(to);
+  await expectPullSubscribeCallbackError(to);
+
+  await cleanup(ns, nc);
+});

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -3301,6 +3301,9 @@ Deno.test("jetstream - ephemeral pull consumer", async () => {
 
 Deno.test("jetstream - fetch max_bytes", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.8.3")) {
+    return;
+  }
   const { stream, subj } = await initStream(nc);
 
   const jsm = await nc.jetstreamManager();
@@ -3344,6 +3347,9 @@ Deno.test("jetstream - fetch max_bytes", async () => {
 
 Deno.test("jetstream - pull consumer max_bytes", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.8.3")) {
+    return;
+  }
   const { stream, subj } = await initStream(nc);
 
   const jsm = await nc.jetstreamManager();
@@ -3383,6 +3389,9 @@ Deno.test("jetstream - pull consumer max_bytes", async () => {
 
 Deno.test("jetstream - pull consumer callback max_bytes", async () => {
   const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.8.3")) {
+    return;
+  }
   const { stream, subj } = await initStream(nc);
 
   const jsm = await nc.jetstreamManager();

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -3463,7 +3463,7 @@ Deno.test("jetstream - pull consumer max_bytes rejected on old servers", async (
       sub.pull({ expires: 2000, max_bytes: 2 });
     },
     Error,
-    "max_bytes is only supported on servers 2.8.5 or better",
+    "max_bytes is only supported on servers 2.8.3 or better",
   );
 
   await cleanup(ns, nc);


### PR DESCRIPTION
The server will limit the number of messages it sends to the `max_bytes` option. Note that if the stream contains a message with a payload larger than `max_bytes`, the consumer will fail. This means that the iterator will end with an error and callbacks will raise this error.