### PR TITLE
[FIX] name of the consumer was not captured when binding to an ephemeral

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -479,6 +479,11 @@ export class JetStreamClientImpl extends BaseApiClient
           jsi.last = info;
           jsi.config = info.config;
           jsi.attached = true;
+          // if not a durable capture the name of the ephemeral so
+          // that consumerInfo from the sub will work
+          if (!jsi.config.durable_name) {
+            jsi.name = info.name;
+          }
         }
       } catch (err) {
         //consumer doesn't exist


### PR DESCRIPTION
This has the effect of failing `consumerInfo()` on the subscription

FIX #329 