### PR TITLE
KV republish and configuration option changes

### DIFF
--- a/nats-base-client/kv.ts
+++ b/nats-base-client/kv.ts
@@ -219,14 +219,28 @@ export class Bucket implements KV, KvRemove {
     sc.subjects = [this.subjectForBucket()];
     sc.retention = RetentionPolicy.Limits;
     sc.max_msgs_per_subject = bo.history;
-    sc.max_bytes = bo.maxBucketSize;
+    if (bo.maxBucketSize) {
+      bo.max_bytes = bo.maxBucketSize;
+    }
+    if (bo.max_bytes) {
+      sc.max_bytes = bo.max_bytes;
+    }
     sc.max_msg_size = bo.maxValueSize;
     sc.storage = bo.storage;
     const location = opts.placementCluster ?? "";
     if (location) {
-      sc.placement = {} as Placement;
-      sc.placement.cluster = location;
-      sc.placement.tags = [];
+      opts.placement = {} as Placement;
+      opts.placement.cluster = location;
+      opts.placement.tags = [];
+    }
+    if (opts.placement) {
+      sc.placement = opts.placement;
+    }
+    if (opts.republish) {
+      sc.republish = opts.republish;
+    }
+    if (opts.description) {
+      sc.description = opts.description;
     }
 
     const nci = (this.js as JetStreamClientImpl).nc;

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -2477,12 +2477,22 @@ export interface KvCodecs {
 }
 
 export interface KvLimits {
+  description: string;
   replicas: number;
   history: number;
+  max_bytes: number;
+  /**
+   * @deprecated use max_bytes
+   */
   maxBucketSize: number;
   maxValueSize: number;
   ttl: number; // millis
   storage: StorageType;
+  placement: Placement;
+  republish: Republish;
+  /**
+   * @deprecated: use placement
+   */
   placementCluster: string;
 
   /**
@@ -2497,7 +2507,7 @@ export interface KvStatus extends KvLimits {
   values: number;
 
   /**
-   * deprecated: use placementCluster
+   * @deprecated
    * FIXME: remove this on 1.8
    */
   bucket_location: string;


### PR DESCRIPTION
[FEAT] republish configuration can be applied to kv

[DEPRECATED] KvOptions.maxBucketSize, KvOptions.backingStore, KvOptions.placementCluster, are deprecated, use KvOptions.max_bytes, KvOptions.storage and KvOptions.placement instead. This normalizes some of the configuration properties with the Go client, and their associated StreamConfiguration options.