### PR TITLE
fix: support optional tls connections if available with the server

### DIFF
--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -128,11 +128,11 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
 }
 
 export function checkOptions(info: ServerInfo, options: ConnectionOptions) {
-  const { proto, tls_required: tlsRequired } = info;
+  const { proto, tls_available: tlsAvailable } = info;
   if ((proto === undefined || proto < 1) && options.noEcho) {
     throw new NatsError("noEcho", ErrorCode.ServerOptionNotAvailable);
   }
-  if (options.tls && !tlsRequired) {
+  if (options.tls && !tlsAvailable) {
     throw new NatsError("tls", ErrorCode.ServerOptionNotAvailable);
   }
 }


### PR DESCRIPTION
- Fixes and issue where TLS was only allowed if required by the server, if tls is not required clients should still be able to connect


**Issue**
When connecting to a NATS server that supports TLS but does not require it the `nats.deno` client cannot connect to it.

**Fix**
Throw error when validating TLS config only when `options.tls` is provided AND `ServerInfo.tls_available` is false