### PR TITLE
[FIX] support tls_available

### DIFF
--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -128,11 +128,13 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
 }
 
 export function checkOptions(info: ServerInfo, options: ConnectionOptions) {
-  const { proto, tls_required: tlsRequired } = info;
+  const { proto, tls_required: tlsRequired, tls_available: tlsAvailable } =
+    info;
   if ((proto === undefined || proto < 1) && options.noEcho) {
     throw new NatsError("noEcho", ErrorCode.ServerOptionNotAvailable);
   }
-  if (options.tls && !tlsRequired) {
+  const tls = tlsRequired || tlsAvailable || false;
+  if (options.tls && !tls) {
     throw new NatsError("tls", ErrorCode.ServerOptionNotAvailable);
   }
 }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -312,9 +312,11 @@ export interface ConnectionOptions {
   /**
    * When set (can be an empty object), the client requires a secure connection.
    * TlsOptions honored depend on the runtime. Consult the specific NATS javascript
-   * client GitHub repo/documentation.
+   * client GitHub repo/documentation. When set to null, the client should fail
+   * should not connect using TLS. In the case where TLS is available on the server
+   * a standard connection will be used. If TLS is required, the connection will fail.
    */
-  tls?: TlsOptions;
+  tls?: TlsOptions | null;
   /**
    * Set to a client authentication token. Note that these tokens are
    * a specific authentication strategy on the nats-server. This option

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -80,8 +80,9 @@ export class DenoTransport implements Transport {
       this.conn = await Deno.connect(hp);
       const info = await this.peekInfo();
       checkOptions(info, this.options);
-      const { tls_required: tlsRequired } = info;
-      if (tlsRequired) {
+      const { tls_required: tlsRequired, tls_available: tlsAvailable } = info;
+      const desired = tlsAvailable === true && options.tls !== null;
+      if (tlsRequired || desired) {
         const tlsn = hp.tlsName ? hp.tlsName : hp.hostname;
         await this.startTLS(tlsn);
       } else {


### PR DESCRIPTION
servers that enable `allow_non_tls` report that they have `tls_available`. This fix enables auto-upgrade by the client to a tls connection unless the `tls` connect option is set to `null`. Previously the client was only responding to `tls_required`.