### PR TITLE
[FIX] kv status is exposed to the client as millis on set, but on status() it was returned raw in nanos

### DIFF
--- a/nats-base-client/kv.ts
+++ b/nats-base-client/kv.ts
@@ -734,7 +734,7 @@ export class Bucket implements KV, KvRemove {
       bucket: this.bucketName(),
       values: si.state.messages,
       history: si.config.max_msgs_per_subject,
-      ttl: si.config.max_age,
+      ttl: millis(si.config.max_age),
       bucket_location: cluster,
       backingStore: si.config.storage,
       storage: si.config.storage,

--- a/tests/kv_test.ts
+++ b/tests/kv_test.ts
@@ -1436,3 +1436,19 @@ Deno.test("kv - republish", async () => {
   await sub.closed;
   await cleanup(ns, nc);
 });
+
+Deno.test("kv - ttl is in nanos", async () => {
+  const { ns, nc } = await setup(
+    jetstreamServerConf({}, true),
+  );
+  const js = nc.jetstream();
+
+  const b = await js.views.kv("a", { ttl: 1000 });
+  const status = await b.status();
+  assertEquals(status.ttl, 1000);
+
+  const jsm = await nc.jetstreamManager();
+  const si = await jsm.streams.info("KV_a");
+  assertEquals(si.config.max_age, nanos(1000));
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION


FIX #317