### PR TITLE
list kvs and objectstores

### DIFF
--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -1362,6 +1362,18 @@ export interface StreamAPI {
    * @param subject
    */
   find(subject: string): Promise<string>;
+
+  /**
+   * Returns a list of KvStatus for all streams that are identified as
+   * being a KV (that is having names that have the prefix `KV_`)
+   */
+  listKvs(): Lister<KvStatus>;
+
+  /**
+   * Returns a list of ObjectStoreInfo for all streams that are identified as
+   * being a ObjectStore (that is having names that have the prefix `OBJ_`)
+   */
+  listObjectStores(): Lister<ObjectStoreStatus>;
 }
 
 /**
@@ -2573,6 +2585,11 @@ export interface KvStatus extends KvLimits {
    * FIXME: remove this on 1.8
    */
   bucket_location: string;
+
+  /**
+   * The StreamInfo backing up the KV
+   */
+  streamInfo: StreamInfo;
 }
 
 export interface KvOptions extends KvLimits {
@@ -2766,7 +2783,7 @@ export interface ObjectLink {
   name?: string;
 }
 
-export type ObjectStoreInfo = {
+export type ObjectStoreStatus = {
   bucket: string;
   description: string;
   ttl: Nanos;
@@ -2775,7 +2792,16 @@ export type ObjectStoreInfo = {
   sealed: boolean;
   size: number;
   backingStore: string;
+  /**
+   * The StreamInfo backing up the ObjectStore
+   */
+  streamInfo: StreamInfo;
 };
+
+/**
+ * @deprecated {@see ObjectStoreStatus}
+ */
+export type ObjectStoreInfo = ObjectStoreStatus;
 
 export type ObjectStoreOptions = {
   description?: string;
@@ -2811,8 +2837,8 @@ export interface ObjectStore {
       }
     >,
   ): Promise<QueuedIterator<ObjectInfo | null>>;
-  seal(): Promise<ObjectStoreInfo>;
-  status(opts?: Partial<StreamInfoRequestOptions>): Promise<ObjectStoreInfo>;
+  seal(): Promise<ObjectStoreStatus>;
+  status(opts?: Partial<StreamInfoRequestOptions>): Promise<ObjectStoreStatus>;
   update(name: string, meta: Partial<ObjectStoreMeta>): Promise<PubAck>;
   destroy(): Promise<boolean>;
 }

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -1497,3 +1497,41 @@ Deno.test("jsm - consumer name is validated", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("jsm - list kvs", async () => {
+  const { ns, nc } = await setup(
+    jetstreamServerConf({}, true),
+  );
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "A", subjects: ["a"] });
+  let kvs = await jsm.streams.listKvs().next();
+  assertEquals(kvs.length, 0);
+
+  const js = nc.jetstream();
+  await js.views.kv("A");
+  kvs = await jsm.streams.listKvs().next();
+  assertEquals(kvs.length, 1);
+  assertEquals(kvs[0].bucket, `A`);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - list objectstores", async () => {
+  const { ns, nc } = await setup(
+    jetstreamServerConf({}, true),
+  );
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "A", subjects: ["a"] });
+  let objs = await jsm.streams.listObjectStores().next();
+  assertEquals(objs.length, 0);
+
+  const js = nc.jetstream();
+  await js.views.os("A");
+  objs = await jsm.streams.listObjectStores().next();
+  assertEquals(objs.length, 1);
+  assertEquals(objs[0].bucket, "A");
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
[FEAT] added `jsm.streams.listKvs()` to provide a list of all the `KvStatus` for all streams that use the kv naming strategy.

[FEAT] [BETA] added `jsm.streams.listObjectStores()` to provide a list of all the `ObjectStoreStatus` for all streams that use the objectstore naming strategy.

[FEAT] [KV] `KvStatus` now has the property `streamInfo` with the `StreamInfo` for the KV.

[CHANGE] [BREAKING] [KV] `KvStatus.bucket` is now the user-specified name of the KV used when created - not the stream backing it. This is consistent with the Go client. Previously it returned `KV_` + name. For the actual stream name see `KvStatus.streamInfo.config.name`

[CHANGE] `ObjectStoreInfo` is deprecated use `ObjectStoreStatus` instead.