### PR TITLE
StreamInfo pagination support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.8.4" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.9.0" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
       - name: Add hosts to /etc/hosts

--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -103,11 +103,13 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     const { total } = si;
 
     // check how many subjects we got in the first request
-    let have = Object.getOwnPropertyNames(si.state.subjects).length;
+    let have = si.state.subjects
+      ? Object.getOwnPropertyNames(si.state.subjects).length
+      : 1;
 
     // if the response is paged, we have a large list of subjects
     // handle the paging and return a StreamInfo with all of it
-    if (total > have) {
+    if (total && total > have) {
       const infos: StreamInfo[] = [si];
       const paged = data || {} as unknown as ApiPagedRequest;
       while (total > have) {

--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -14,6 +14,7 @@
  */
 
 import {
+  ApiPagedRequest,
   Empty,
   JetStreamOptions,
   KvStatus,
@@ -96,9 +97,39 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     data?: Partial<StreamInfoRequestOptions>,
   ): Promise<StreamInfo> {
     validateStreamName(name);
-    const r = await this._request(`${this.prefix}.STREAM.INFO.${name}`, data);
-    const si = r as StreamInfo;
+    const subj = `${this.prefix}.STREAM.INFO.${name}`;
+    const r = await this._request(subj, data);
+    let si = r as StreamInfo;
+    const { total } = si;
 
+    // check how many subjects we got in the first request
+    let have = Object.getOwnPropertyNames(si.state.subjects).length;
+
+    // if the response is paged, we have a large list of subjects
+    // handle the paging and return a StreamInfo with all of it
+    if (total > have) {
+      const infos: StreamInfo[] = [si];
+      const paged = data || {} as unknown as ApiPagedRequest;
+      while (total > have) {
+        paged.offset = have;
+        const r = await this._request(subj, paged) as StreamInfo;
+        infos.push(r);
+        have += Object.getOwnPropertyNames(r.state.subjects).length;
+      }
+      // collect all the subjects
+      let subjects = {};
+      for (let i = 0; i < infos.length; i++) {
+        si = infos[i];
+        if (si.state.subjects) {
+          subjects = Object.assign(subjects, si.state.subjects);
+        }
+      }
+      // don't give the impression we paged
+      si.offset = 0;
+      si.total = 0;
+      si.limit = 0;
+      si.state.subjects = subjects;
+    }
     this._fixInfo(si);
     return si;
   }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -1252,6 +1252,7 @@ export interface ConsumerOptsBuilder {
  * An interface for listing. Returns a promise with typed list.
  */
 export interface Lister<T> {
+  [Symbol.asyncIterator](): AsyncIterator<T>;
   next(): Promise<T[]>;
 }
 
@@ -1305,7 +1306,7 @@ export type StreamInfoRequestOptions = {
    * Only include information matching the specified subject filter
    */
   "subjects_filter": string;
-};
+} & ApiPagedRequest;
 
 export interface StreamAPI {
   /**
@@ -1659,7 +1660,7 @@ export interface StreamAlternate {
 /**
  * Stream configuration info
  */
-export interface StreamInfo {
+export interface StreamInfo extends ApiPaged {
   /**
    * The active configuration for the Stream
    */

--- a/tests/jstest_util.ts
+++ b/tests/jstest_util.ts
@@ -94,7 +94,7 @@ export async function initStream(
 ): Promise<{ stream: string; subj: string }> {
   const jsm = await nc.jetstreamManager();
   const subj = `${stream}.A`;
-  const sc = Object.assign(opts, { name: stream, subjects: [subj] });
+  const sc = Object.assign({ name: stream, subjects: [subj] }, opts);
   await jsm.streams.add(sc);
   return { stream, subj };
 }


### PR DESCRIPTION
[FEAT] added internal pagination to `jsm.streams.info()`, if required, the call will collect the necessary pages and merge `subjects`. `StreamInfoRequestOptions` now also has support for `ApiPagedRequest`.

[FIX] `Lister` interface was missing `Symbol.asyncIterator`, so it couldn't be used directly as intended.