### PR TITLE
Feature disablements

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -252,7 +252,7 @@ export class JetStreamClientImpl extends BaseApiClient
     const args: Partial<PullOptions> = {};
     args.batch = opts.batch || 1;
     if (max_bytes) {
-      const fv = this.nc.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
+      const fv = this.nc.features.get(Feature.JS_PULL_MAX_BYTES);
       if (!fv.ok) {
         throw new Error(
           `max_bytes is only supported on servers ${fv.min} or better`,
@@ -827,7 +827,7 @@ class JetStreamPullSubscriptionImpl extends JetStreamSubscriptionImpl
     args.batch = opts.batch || 1;
     args.no_wait = opts.no_wait || false;
     if ((opts.max_bytes ?? 0) > 0) {
-      const fv = this.js.nc.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
+      const fv = this.js.nc.features.get(Feature.JS_PULL_MAX_BYTES);
       if (!fv.ok) {
         throw new Error(
           `max_bytes is only supported on servers ${fv.min} or better`,

--- a/nats-base-client/jsmconsumer_api.ts
+++ b/nats-base-client/jsmconsumer_api.ts
@@ -65,7 +65,7 @@ export class ConsumerAPIImpl extends BaseApiClient implements ConsumerAPI {
     }
 
     const nci = this.nc as NatsConnectionImpl;
-    const { min, ok: newAPI } = nci.protocol.features.get(
+    const { min, ok: newAPI } = nci.features.get(
       Feature.JS_NEW_CONSUMER_CREATE_API,
     );
 

--- a/nats-base-client/kv.ts
+++ b/nats-base-client/kv.ts
@@ -248,7 +248,7 @@ export class Bucket implements KV, KvRemove {
     const discardNew = have ? compare(have, parseSemVer("2.7.2")) >= 0 : false;
     sc.discard = discardNew ? DiscardPolicy.New : DiscardPolicy.Old;
 
-    const { ok: direct, min } = nci.protocol.features.get(
+    const { ok: direct, min } = nci.features.get(
       Feature.JS_ALLOW_DIRECT,
     );
     if (!direct && opts.allow_direct === true) {

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -37,7 +37,7 @@ import {
 } from "./types.ts";
 
 import type { SemVer } from "./semver.ts";
-import { parseSemVer } from "./semver.ts";
+import { Features, parseSemVer } from "./semver.ts";
 
 import { parseOptions } from "./options.ts";
 import { QueuedIterator, QueuedIteratorImpl } from "./queued_iterator.ts";
@@ -501,5 +501,9 @@ export class NatsConnectionImpl implements NatsConnection {
     const start = Date.now();
     await this.flush();
     return Date.now() - start;
+  }
+
+  get features(): Features {
+    return this.protocol.features;
   }
 }

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -488,7 +488,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
       ? undefined
       : this.servers.update(info);
     if (!this.infoReceived) {
-      this.features = new Features(parseSemVer(info.version));
+      this.features.update(parseSemVer(info.version));
       this.infoReceived = true;
       if (this.transport.isEncrypted()) {
         this.servers.updateTLSName();

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -1170,8 +1170,8 @@ Deno.test("basics - server version", async () => {
   assertEquals(nci.protocol.features.require("3.0.0"), false);
   assertEquals(nci.protocol.features.require("2.8.2"), true);
 
-  const ok = nci.protocol.features.require("2.8.3");
-  const bytes = nci.protocol.features.get(Feature.JS_PULL_MAX_BYTES);
+  const ok = nci.features.require("2.8.3");
+  const bytes = nci.features.get(Feature.JS_PULL_MAX_BYTES);
   assertEquals(ok, bytes.ok);
   assertEquals(bytes.min, "2.8.3");
   assertEquals(ok, nci.protocol.features.supports(Feature.JS_PULL_MAX_BYTES));

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -72,7 +72,6 @@ import {
   isHeartbeatMsg,
   Js409Errors,
 } from "../nats-base-client/jsutil.ts";
-import { Features } from "../nats-base-client/semver.ts";
 import { assertIsError } from "https://deno.land/std@0.138.0/testing/asserts.ts";
 
 function callbackConsume(debug = false): JsMsgCallback {
@@ -3315,7 +3314,7 @@ Deno.test("jetstream - pull consumer max_bytes rejected on old servers", async (
 
   // change the version of the server to fail pull with max bytes
   const nci = nc as NatsConnectionImpl;
-  nci.protocol.features = new Features({ major: 2, minor: 7, micro: 0 });
+  nci.features.update("2.7.0");
 
   const jsm = await nc.jetstreamManager();
   await jsm.consumers.add(stream, {

--- a/tests/kv_test.ts
+++ b/tests/kv_test.ts
@@ -58,7 +58,6 @@ import { Lock, NatsServer, notCompatible } from "./helpers/mod.ts";
 import { QueuedIteratorImpl } from "../nats-base-client/queued_iterator.ts";
 import { JetStreamSubscriptionInfoable } from "../nats-base-client/jsclient.ts";
 import { connect } from "../src/mod.ts";
-import { Features } from "../nats-base-client/semver.ts";
 
 Deno.test("kv - key validation", () => {
   const bad = [
@@ -1406,7 +1405,7 @@ Deno.test("kv - allow direct", async () => {
 
   // now let's pretend we got a server that doesn't support it
   const nci = nc as NatsConnectionImpl;
-  nci.protocol.features = new Features({ major: 2, minor: 8, micro: 0 });
+  nci.features.update("2.8.0");
   nci.info!.version = "2.8.0";
 
   await assertRejects(


### PR DESCRIPTION
[FEAT] added mechanism where a `Feature` can be disabled by the user. This requires casting the connection to a `NatsConnectionImpl`, and then accessing the `Features` controller as `nc.features.disable(Feature)`. This is an experimental feature, currently supporting a very small number of options