### PR TITLE
[FEAT] `jsm.streams.list()` can now specify a subject filter

### DIFF
--- a/nats-base-client/jslister.ts
+++ b/nats-base-client/jslister.ts
@@ -24,11 +24,13 @@ export class ListerImpl<T> implements Lister<T>, AsyncIterable<T> {
   subject: string;
   jsm: BaseApiClient;
   filter: ListerFieldFilter<T>;
+  payload: unknown;
 
   constructor(
     subject: string,
     filter: ListerFieldFilter<T>,
     jsm: BaseApiClient,
+    payload?: unknown,
   ) {
     if (!subject) {
       throw new Error("subject is required");
@@ -38,6 +40,7 @@ export class ListerImpl<T> implements Lister<T>, AsyncIterable<T> {
     this.offset = 0;
     this.pageInfo = {} as ApiPaged;
     this.filter = filter;
+    this.payload = payload || {};
   }
 
   async next(): Promise<T[]> {
@@ -49,6 +52,9 @@ export class ListerImpl<T> implements Lister<T>, AsyncIterable<T> {
     }
 
     const offset = { offset: this.offset } as ApiPagedRequest;
+    if (this.payload) {
+      Object.assign(offset, this.payload);
+    }
     try {
       const r = await this.jsm._request(
         this.subject,

--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -148,8 +148,9 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     return si;
   }
 
-  list(): Lister<StreamInfo> {
-    const filter: ListerFieldFilter<StreamInfo> = (
+  list(subject = ""): Lister<StreamInfo> {
+    const payload = subject?.length ? { subject } : {};
+    const listerFilter: ListerFieldFilter<StreamInfo> = (
       v: unknown,
     ): StreamInfo[] => {
       const slr = v as StreamListResponse;
@@ -159,7 +160,7 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
       return slr.streams;
     };
     const subj = `${this.prefix}.STREAM.LIST`;
-    return new ListerImpl<StreamInfo>(subj, filter, this);
+    return new ListerImpl<StreamInfo>(subj, listerFilter, this, payload);
   }
 
   // FIXME: init of sealed, deny_delete, deny_purge shouldn't be necessary

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -1342,8 +1342,9 @@ export interface StreamAPI {
   delete(stream: string): Promise<boolean>;
   /**
    * Lists all streams stored by JetStream
+   * @param subject - only return streams that include the specified subject
    */
-  list(): Lister<StreamInfo>;
+  list(subject?: string): Lister<StreamInfo>;
   /**
    * Deletes the specified message sequence from the stream
    * @param stream


### PR DESCRIPTION
This will limit the list to include streams that include the specified subject.