### PR TITLE
[FEAT] [JS] added JSM API to list stream names

### DIFF
--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -34,6 +34,7 @@ import {
   StreamInfoRequestOptions,
   StreamListResponse,
   StreamMsgResponse,
+  StreamNames,
   StreamUpdateConfig,
   SuccessResponse,
 } from "./types.ts";
@@ -258,6 +259,18 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     };
     const subj = `${this.prefix}.STREAM.LIST`;
     return new ListerImpl<ObjectStoreStatus>(subj, filter, this);
+  }
+
+  names(subject = ""): Lister<string> {
+    const payload = subject?.length ? { subject } : {};
+    const listerFilter: ListerFieldFilter<string> = (
+      v: unknown,
+    ): string[] => {
+      const slr = v as StreamNames;
+      return slr.streams;
+    };
+    const subj = `${this.prefix}.STREAM.NAMES`;
+    return new ListerImpl<string>(subj, listerFilter, this, payload);
   }
 }
 

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -1376,6 +1376,13 @@ export interface StreamAPI {
    * being a ObjectStore (that is having names that have the prefix `OBJ_`)
    */
   listObjectStores(): Lister<ObjectStoreStatus>;
+
+  /**
+   * Return a Lister of stream names
+   * @param subject - if specified, the results are filtered to streams that contain the
+   *  subject (can be wildcarded)
+   */
+  names(subject?: string): Lister<string>;
 }
 
 /**


### PR DESCRIPTION
An optional subject can be specified to filter to include only streams that contain or match the specified subject (can contain wildcards).