### PR TITLE
subscription closed, terminated iterators that had pending messages

### DIFF
--- a/nats-base-client/queued_iterator.ts
+++ b/nats-base-client/queued_iterator.ts
@@ -134,7 +134,6 @@ export class QueuedIteratorImpl<T> implements QueuedIterator<T> {
         this.inflight = yields.length;
         this.yields = [];
         for (let i = 0; i < yields.length; i++) {
-          // some iterators could inject a callback
           if (typeof yields[i] === "function") {
             const fn = yields[i] as unknown as callbackFn;
             try {

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -787,7 +787,7 @@ Deno.test("basics - subs pending count", async () => {
     for await (const _m of sub) {
       count++;
       assertEquals(count, sub.getProcessed());
-      assertEquals(sub.getProcessed() + sub.getPending(), 11);
+      assertEquals(sub.getProcessed() + sub.getPending(), 12);
     }
   })();
 

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -214,10 +214,23 @@ Deno.test("drain - reject subscribe on draining", async () => {
   await ns.stop();
 });
 
-Deno.test("drain - reject subscription drain on closed sub", async () => {
+Deno.test("drain - reject subscription drain on closed sub callback", async () => {
+  const { ns, nc } = await setup();
+  const sub = nc.subscribe("foo", { callback: () => {} });
+  sub.unsubscribe();
+  await assertThrowsAsyncErrorCode(() => {
+    return sub.drain();
+  }, ErrorCode.SubClosed);
+  await nc.close();
+  await ns.stop();
+});
+
+Deno.test("drain - reject subscription drain on closed sub iter", async () => {
   const { ns, nc } = await setup();
   const sub = nc.subscribe("foo");
   sub.unsubscribe();
+  for await (const m of sub) {
+  }
   await assertThrowsAsyncErrorCode(() => {
     return sub.drain();
   }, ErrorCode.SubClosed);


### PR DESCRIPTION
[FIX] fixed an issue where if an unsubscribe was set on a subscription and the subscription used an iterator, the iterator was stopped immediately rather than waiting for the currently in-flight messages to be processed.