### PR TITLE
Early PONG rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,4 +838,6 @@ The relationship between these is:
 
 ## JetStream
 
-JetStream is the NATS persistence engine providing streaming, message, and worker queues with At-Least-Once semantics. [Support for JetStream is built-in](jetstream.md).
+JetStream is the NATS persistence engine providing streaming, message, and
+worker queues with At-Least-Once semantics.
+[Support for JetStream is built-in](jetstream.md).

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -217,6 +217,9 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.resetOutbound();
 
     const pong = deferred<void>();
+    pong.catch(() => {
+      // provide at least one catch - as pong rejection can happen before it is expected
+    });
     this.pongs.unshift(pong);
 
     this.connectError = (err?: Error) => {

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -192,9 +192,12 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.outbound.reset();
     const pongs = this.pongs;
     this.pongs = [];
-    // reject the pongs
+    // reject the pongs - the disconnect from here shouldn't have a trace
+    // because that confuses API consumers
+    const err = NatsError.errorForCode(ErrorCode.Disconnect);
+    err.stack = "";
     pongs.forEach((p) => {
-      p.reject(NatsError.errorForCode(ErrorCode.Disconnect));
+      p.reject(err);
     });
     this.parser = new Parser(this);
     this.infoReceived = false;

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -244,7 +244,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.transport.disconnect();
   }
 
-  async disconnected(_err?: Error): Promise<void> {
+  async disconnected(err?: Error): Promise<void> {
     this.dispatchStatus(
       {
         type: Events.Disconnect,
@@ -265,7 +265,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
           this._close(err);
         });
     } else {
-      await this._close();
+      await this._close(err);
     }
   }
 

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -246,10 +246,10 @@ export class DenoTransport implements Transport {
       .then().catch();
   }
 
-  private async _closed(err?: Error, internal = true): Promise<void> {
+  async _closed(err?: Error, internal = true): Promise<void> {
     if (this.done) return;
     this.closeError = err;
-    if (!err) {
+    if (!err && internal) {
       try {
         // this is a noop but gives us a place to hang
         // a close and ensure that we sent all before closing

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -229,7 +229,8 @@ Deno.test("drain - reject subscription drain on closed sub iter", async () => {
   const { ns, nc } = await setup();
   const sub = nc.subscribe("foo");
   sub.unsubscribe();
-  for await (const m of sub) {
+  for await (const _m of sub) {
+    // nothing to do here
   }
   await assertThrowsAsyncErrorCode(() => {
     return sub.drain();

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -28,7 +28,6 @@ import { NatsServer } from "./helpers/launcher.ts";
 import {
   assert,
   assertEquals,
-  assertRejects,
   assertThrows,
 } from "https://deno.land/std@0.152.0/testing/asserts.ts";
 import {
@@ -346,7 +345,7 @@ Deno.test("headers - codec", async () => {
   const { ns, nc } = await setup({}, {});
 
   nc.subscribe("foo", {
-    callback: (err, msg) => {
+    callback: (_err, msg) => {
       const h = headers(500, "custom status from client");
       msg.respond(Empty, { headers: h });
     },

--- a/tests/jsmuxedinbox_test.ts
+++ b/tests/jsmuxedinbox_test.ts
@@ -25,7 +25,7 @@ Deno.test("jsmuxedinbox - basics", async () => {
   type cookie = { n: number };
 
   nc.subscribe("q", {
-    callback: (err, msg) => {
+    callback: (_err, msg) => {
       msg.respond();
     },
   });


### PR DESCRIPTION
[FIX] added a catch to the initial pong promise as it seems possible in some difficult scenarios in node for the pong to be rejected before other handlers are setup. See https://github.com/nats-io/nats.js/issues/523

[LINT] fixed some linter and fmt warnings