### PR TITLE
sub discard

### DIFF
--- a/nats-base-client/subscriptions.ts
+++ b/nats-base-client/subscriptions.ts
@@ -89,6 +89,7 @@ export class Subscriptions {
       if (sub) {
         sub.callback(err, {} as Msg);
         sub.close();
+        this.subs.delete(sub.sid);
         return sub !== this.mux;
       }
     }


### PR DESCRIPTION
This is actually an edge case trying a sub that didn't have permissions (on the same subject) due to buffering etc, and because the server doesn't provide the ID the subscription ID that created the problem, writing the test with the same subscription would end up calling the handler for the first subscription twice, and that made a negative test fail.

Now the part that I am not sure about is that if there's a disconnect and in the meanwhile, the permission has changed, the reconnect won't re-establish the sub. Possibly this means dispatching of the error should internally mark that object as reaped while keeping the sub registration open (so reconnect can resub).

This is why this sort of behavior where sub permission errors are not final is kind of a tricky condition. While in some cases R.I. has several where the client will restart multiple times on initialization of an environment, so the sub permission shouldn't be a terminal error, the point is still that the rejected subscription is dead, so even with a server configuration fix, where the permission is re-assigned, that subscription possibly doesn't exist on the server so it is not doing anything until the client restarts.