### PR TITLE
[FIX] processInfo random error was mapped as BadAuthentication, when it should just be whatever error it was

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -523,9 +523,8 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
         );
         this.transport.send(PING_CMD);
       } catch (err) {
-        this._close(
-          NatsError.errorForCode(ErrorCode.BadAuthentication, err),
-        );
+        // if we are dying here, this is likely some an authenticator blowing up
+        this._close(err);
       }
     }
     if (updates) {

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -443,7 +443,7 @@ Deno.test("auth - custom error", async () => {
   ).then(() => {
     fail("shouldn't have connected");
   }).catch((err) => {
-    assertErrorCode(err, ErrorCode.BadAuthentication);
+    assertEquals(err.message, "user code exploded");
   });
   await ns.stop();
 });


### PR DESCRIPTION
if during processInfo there was some sort of exception (most likely it is a bad authenticator), the error was transformed to a BadAuthentication, this was incorrect and instead what should happen is the error is telegraphed as it is to the client.