### PR TITLE
[FIX] properly close() when in a disconnected state

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -343,6 +343,12 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   async dialLoop(): Promise<void> {
     let lastError: Error | undefined;
     while (true) {
+      if (this._closed) {
+        // if we are disconnected, and close is called, the client
+        // still tries to reconnect - to match the reconnect policy
+        // in the case of close, want to stop.
+        this.servers.clear();
+      }
       const wait = this.options.reconnectDelayHandler
         ? this.options.reconnectDelayHandler()
         : DEFAULT_RECONNECT_TIME_WAIT;

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -203,6 +203,10 @@ export class Servers {
     this.currentServer = this.servers[0];
   }
 
+  clear(): void {
+    this.servers.length = 0;
+  }
+
   updateTLSName(): void {
     const cs = this.getCurrentServer();
     if (!isIP(cs.hostname)) {

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -263,7 +263,7 @@ export class DenoTransport implements Transport {
     }
     this.done = true;
     try {
-      this.conn.close();
+      this.conn?.close();
     } catch (_err) {
       // ignored
     }


### PR DESCRIPTION
[FIX] if the client attempted to close() while in a disconnected state, the close promise wouldn't resolve because under the covers if the policy allowed the client to reconnect, it would still be trying to do so.