### PR TITLE
[FIX] jetstream `fetch()` error while disconnected from the server

### DIFF
--- a/nats-base-client/jsclient.ts
+++ b/nats-base-client/jsclient.ts
@@ -353,7 +353,8 @@ export class JetStreamClientImpl extends BaseApiClient
       timer = timeout<void>(expires);
       timer.catch(() => {
         if (!sub.isClosed()) {
-          sub.drain();
+          sub.drain()
+            .catch(() => {});
           timer = null;
         }
         if (monitor) {

--- a/nats-base-client/subscription.ts
+++ b/nats-base-client/subscription.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 The NATS Authors
+ * Copyright 2020-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -161,10 +161,13 @@ export class SubscriptionImpl extends QueuedIteratorImpl<Msg>
     }
     if (!this.drained) {
       this.protocol.unsub(this);
-      this.drained = this.protocol.flush(deferred<void>());
-      this.drained.then(() => {
-        this.protocol.subscriptions.cancel(this);
-      });
+      this.drained = this.protocol.flush(deferred<void>())
+        .then(() => {
+          this.protocol.subscriptions.cancel(this);
+        })
+        .catch(() => {
+          this.protocol.subscriptions.cancel(this);
+        });
     }
     return this.drained;
   }


### PR DESCRIPTION
[FIX] Fixes an issue where a drain() call was not catching a possible promise rejection of a PONG, this happened for inflight requests while disconnected from the nats-server.

FIX #416