### PR TITLE
[internal] pushing a funtion to a queued iterator that sets an error is ignored until the next yield

### DIFF
--- a/nats-base-client/queued_iterator.ts
+++ b/nats-base-client/queued_iterator.ts
@@ -143,6 +143,10 @@ export class QueuedIteratorImpl<T> implements QueuedIterator<T> {
               // so they know to fix the callback
               throw err;
             }
+            // fn could have also set an error
+            if (this.err) {
+              throw this.err;
+            }
             continue;
           }
           // only pass messages that pass the filter


### PR DESCRIPTION
[FIX] if internal code inserted an error into an iterator by pushing a function that set the error condition, the iterator wouldn't immediately yield the error, as the error check happened prior to the execution of the function

[TEST] added tests for idle heartbeat conditions.