### PR TITLE
[CHANGE] SERVICE API changes

### DIFF
--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -207,6 +207,7 @@ export { compare, parseSemVer } from "./semver.ts";
 export {
   addService,
   ServiceError,
+  ServiceErrorCodeHeader,
   ServiceErrorHeader,
   ServiceVerb,
 } from "./service.ts";

--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -59,6 +59,20 @@ export function validName(name = ""): string {
   return "";
 }
 
+export function strictValidName(name = ""): string {
+  if (name === "") {
+    throw Error(`name required`);
+  }
+  const bad = [".", "*", ">", "<", ":", '"', "/", "\\", "|", "?"];
+  for (let i = 0; i < bad.length; i++) {
+    const v = bad[i];
+    if (name.indexOf(v) !== -1) {
+      return `cannot contain '${v}'`;
+    }
+  }
+  return "";
+}
+
 export function defaultConsumer(
   name: string,
   opts: Partial<ConsumerConfig> = {},

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -34,6 +34,7 @@ export {
   RequestStrategy,
   RetentionPolicy,
   ServiceError,
+  ServiceErrorCodeHeader,
   ServiceErrorHeader,
   ServiceVerb,
   StorageType,


### PR DESCRIPTION
- [CHANGE] separated service error header into two headers, one with the code the other with the message
- [CHANGE] clamped down on the service name to be a filesystem safe name 
- [CHANGE] STATUS is now STATS to better reflect its intention, things named with status, changed to be stats. 
- [CHANGE] PING now returns the name and id of the service and is intended for client RTT calculations - [CHANGE] control subject (for invoking monitoring) can now specify a prefix (this replaces `$SRV` and is intended for cross account).