### PR TITLE
[CHANGE] [experimental] mrequest iterator signature

### DIFF
--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -142,7 +142,7 @@ export interface NatsConnection {
     subject: string,
     data: Uint8Array,
     opts: Partial<RequestManyOptions>,
-  ): Promise<QueuedIterator<Msg | Error>>;
+  ): Promise<QueuedIterator<Msg>>;
 
   /**
    * Returns a Promise that resolves when the client receives a reply from

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -33,14 +33,7 @@ import {
   NatsError,
   StringCodec,
 } from "../src/mod.ts";
-import {
-  assertErrorCode,
-  Connection,
-  disabled,
-  Lock,
-  NatsServer,
-  TestServer,
-} from "./helpers/mod.ts";
+import { assertErrorCode, disabled, Lock, NatsServer } from "./helpers/mod.ts";
 import {
   deferred,
   delay,
@@ -1116,27 +1109,6 @@ Deno.test("basics - request many waits for timer late response", async () => {
   const time = Date.now() - start;
   assert(time >= 2000);
   assertEquals(count, 1);
-  await cleanup(ns, nc);
-});
-
-Deno.test("basics - request many stops on error", async () => {
-  const { ns, nc } = await setup({});
-  const nci = nc as NatsConnectionImpl;
-
-  const subj = createInbox();
-
-  const iter = await nci.requestMany(subj, Empty, {
-    strategy: RequestStrategy.Timer,
-    maxWait: 2000,
-  });
-  const d = deferred<Error>();
-  for await (const mer of iter) {
-    if (mer instanceof Error) {
-      d.resolve(mer);
-    }
-  }
-  const err = await d;
-  assertErrorCode(err, ErrorCode.NoResponders);
   await cleanup(ns, nc);
 });
 


### PR DESCRIPTION
[CHANGE] mrequest iterator signature - possible errors at core NATS level can only be sub/no responder type errors which should fail the request