### PR TITLE
[UPDATE] deno to 1.29.1 and std to 0.168.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.27.0]
+        deno-version: [1.29.1]
 
     steps:
       - name: Git Checkout Deno Module

--- a/bin/exports.ts
+++ b/bin/exports.ts
@@ -1,10 +1,10 @@
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import {
   basename,
   extname,
   join,
   resolve,
-} from "https://deno.land/std@0.152.0/path/mod.ts";
+} from "https://deno.land/std@0.168.0/path/mod.ts";
 
 const argv = parse(
   Deno.args,

--- a/dependencies.md
+++ b/dependencies.md
@@ -4,5 +4,5 @@ This file lists the dependencies used in this repository.
 
 | Dependency                                 | License     |
 | ------------------------------------------ | ----------- |
-| https://deno.land/std@0.152.0/flags/mod.ts | MIT License |
+| https://deno.land/std@0.168.0/flags/mod.ts | MIT License |
 | http://github.com/nats-io/nkeys.js         | Apache-2.0  |

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import { connect, Nuid } from "../src/mod.ts";
 import { Bench, Metric } from "../nats-base-client/bench.ts";
 const defaults = {

--- a/examples/nats-events.ts
+++ b/examples/nats-events.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import { connect, ConnectionOptions } from "../src/mod.ts";
 
 const argv = parse(

--- a/examples/nats-pub.ts
+++ b/examples/nats-pub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import {
   connect,
   ConnectionOptions,

--- a/examples/nats-rep.ts
+++ b/examples/nats-rep.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import {
   connect,
   ConnectionOptions,

--- a/examples/nats-req.ts
+++ b/examples/nats-req.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import {
   connect,
   ConnectionOptions,

--- a/examples/nats-sub.ts
+++ b/examples/nats-sub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
 import {
   connect,
   ConnectionOptions,

--- a/examples/services/01_services.ts
+++ b/examples/services/01_services.ts
@@ -24,7 +24,7 @@ import {
   ServiceMsg,
   ServiceStats,
 } from "../../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.161.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 // connect to NATS on demo.nats.io
 const nc = await connect({ servers: ["demo.nats.io"] });

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-import { BufWriter } from "https://deno.land/std@0.152.0/io/mod.ts";
-import { Deferred, deferred } from "https://deno.land/std@0.152.0/async/mod.ts";
+import { BufWriter } from "https://deno.land/std@0.168.0/io/mod.ts";
+import { Deferred, deferred } from "../nats-base-client/internal_mod.ts";
 import Conn = Deno.Conn;
 import {
   checkOptions,

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -89,6 +89,7 @@ export class DenoTransport implements Transport {
         this.writer = new BufWriter(this.conn);
       }
     } catch (err) {
+      this.conn?.close();
       throw err.name === "ConnectionRefused"
         ? NatsError.errorForCode(ErrorCode.ConnectionRefused)
         : err;
@@ -248,6 +249,7 @@ export class DenoTransport implements Transport {
 
   async _closed(err?: Error, internal = true): Promise<void> {
     if (this.done) return;
+    this.done = true;
     this.closeError = err;
     if (!err && internal) {
       try {
@@ -261,7 +263,6 @@ export class DenoTransport implements Transport {
         }
       }
     }
-    this.done = true;
     try {
       this.conn?.close();
     } catch (_err) {

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -17,7 +17,7 @@ import {
   assertEquals,
   assertRejects,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   connect,
   createInbox,
@@ -255,15 +255,12 @@ Deno.test("auth - req permissions keep connection", async () => {
     }
   })();
 
-  await assertRejects(
+  const err = await assertRejects(
     async () => {
       await nc.request("bar");
     },
-    (err: Error) => {
-      const ne = err as NatsError;
-      assertEquals(ne.code, ErrorCode.PermissionsViolation);
-    },
-  );
+  ) as NatsError;
+  assertEquals(err.code, ErrorCode.PermissionsViolation);
 
   const v = await errStatus;
   assertEquals(v.data, ErrorCode.PermissionsViolation);

--- a/tests/authenticator_test.ts
+++ b/tests/authenticator_test.ts
@@ -185,7 +185,6 @@ Deno.test("authenticator - nkey fn", async () => {
   let nkey = user.getPublicKey();
 
   const authenticator = nkeyAuthenticator(() => {
-    console.log(`using ${seed}`);
     return seed;
   });
 

--- a/tests/authenticator_test.ts
+++ b/tests/authenticator_test.ts
@@ -9,7 +9,7 @@ import {
   tokenAuthenticator,
   usernamePasswordAuthenticator,
 } from "../nats-base-client/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { nkeys } from "../nats-base-client/nkeys.ts";
 import {
   encodeAccount,

--- a/tests/autounsub_test.ts
+++ b/tests/autounsub_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import { createInbox, Empty, ErrorCode, Subscription } from "../src/mod.ts";
 import { Lock } from "./helpers/mod.ts";

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -16,6 +16,7 @@ import {
   assert,
   assertArrayIncludes,
   assertEquals,
+  assertExists,
   assertRejects,
   assertThrows,
   fail,
@@ -1129,7 +1130,7 @@ Deno.test("basics - server version", async () => {
 
 Deno.test("basics - info", async () => {
   const { ns, nc } = await setup({});
-  console.log(nc.info);
+  assertExists(nc.info);
   await cleanup(ns, nc);
 });
 

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -14,11 +14,12 @@
  */
 import {
   assert,
+  assertArrayIncludes,
   assertEquals,
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import { assertThrowsAsyncErrorCode } from "./helpers/asserts.ts";
 
@@ -46,7 +47,6 @@ import { cleanup, setup } from "./jstest_util.ts";
 import { RequestStrategy } from "../nats-base-client/types.ts";
 import { Feature } from "../nats-base-client/semver.ts";
 import NetAddr = Deno.NetAddr;
-import { assertArrayIncludes } from "https://deno.land/std@0.75.0/testing/asserts.ts";
 
 Deno.test("basics - connect port", async () => {
   const ns = await NatsServer.start();

--- a/tests/bench_test.ts
+++ b/tests/bench_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { Bench, connect, createInbox } from "../src/mod.ts";
 import { BenchOpts, Metric } from "../nats-base-client/bench.ts";
 

--- a/tests/binary_test.ts
+++ b/tests/binary_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { createInbox, Msg } from "../src/mod.ts";
 import { deferred } from "../nats-base-client/internal_mod.ts";
 import { cleanup, setup } from "./jstest_util.ts";

--- a/tests/buffer_test.ts
+++ b/tests/buffer_test.ts
@@ -11,7 +11,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   DenoBuffer,
   MAX_SIZE,

--- a/tests/clobber_test.ts
+++ b/tests/clobber_test.ts
@@ -16,7 +16,7 @@
 import { NatsServer } from "./helpers/launcher.ts";
 import { createInbox, DataBuffer } from "../nats-base-client/internal_mod.ts";
 import { connect } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 function makeBuffer(N: number): Uint8Array {
   const buf = new Uint8Array(N);

--- a/tests/codec_test.ts
+++ b/tests/codec_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { JSONCodec, StringCodec } from "../nats-base-client/codec.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 Deno.test("codec - string", () => {
   const sc = StringCodec();

--- a/tests/consumeropts_test.ts
+++ b/tests/consumeropts_test.ts
@@ -17,7 +17,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import {
   consumerOpts,

--- a/tests/databuffer_test.ts
+++ b/tests/databuffer_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { DataBuffer } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("databuffer - empty", () => {

--- a/tests/doublesubs_test.ts
+++ b/tests/doublesubs_test.ts
@@ -25,9 +25,9 @@ import {
 import {
   assertArrayIncludes,
   assertEquals,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { extend } from "../nats-base-client/util.ts";
-import { join, resolve } from "https://deno.land/std@0.152.0/path/mod.ts";
+import { join, resolve } from "https://deno.land/std@0.168.0/path/mod.ts";
 
 async function runDoubleSubsTest(tls: boolean) {
   const cwd = Deno.cwd();

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -18,7 +18,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { assertThrowsAsyncErrorCode } from "./helpers/asserts.ts";
 import {
   connect,
@@ -126,15 +126,13 @@ Deno.test("drain - publish after drain fails", async () => {
   nc.subscribe(subj);
   await nc.drain();
 
-  assertThrows(() => {
-    nc.publish(subj);
-  }, (err: Error) => {
-    assertErrorCode(
-      err,
-      ErrorCode.ConnectionClosed,
-      ErrorCode.ConnectionDraining,
-    );
-  });
+  assertThrowsErrorCode(
+    () => {
+      nc.publish(subj);
+    },
+    ErrorCode.ConnectionClosed,
+    ErrorCode.ConnectionDraining,
+  );
   await ns.stop();
 });
 

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -14,7 +14,7 @@
  */
 import { Lock, NatsServer, ServerSignals } from "../tests/helpers/mod.ts";
 import { connect, Events, ServersChanged } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { delay, NatsConnectionImpl } from "../nats-base-client/internal_mod.ts";
 import { setup } from "./jstest_util.ts";
 

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -29,7 +29,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   MsgHdrsImpl,
   MsgImpl,

--- a/tests/heartbeats_test.ts
+++ b/tests/heartbeats_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import {
   DebugEvents,

--- a/tests/helpers/asserts.ts
+++ b/tests/helpers/asserts.ts
@@ -17,7 +17,7 @@ import {
   assert,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { isNatsError, NatsError } from "../../nats-base-client/error.ts";
 
 export function assertErrorCode(err?: Error, ...codes: string[]) {
@@ -42,9 +42,8 @@ export function assertThrowsErrorCode<T = void>(
   fn: () => T,
   ...codes: string[]
 ) {
-  assertThrows(fn, (err: Error) => {
-    assertErrorCode(err, ...codes);
-  });
+  const err = assertThrows(fn);
+  assertErrorCode(err as Error, ...codes);
 }
 
 export async function assertThrowsAsyncErrorCode<T = void>(

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -14,8 +14,8 @@
  */
 
 import { NatsServer } from "./mod.ts";
-import { parse } from "https://deno.land/std@0.152.0/flags/mod.ts";
-import { rgb24 } from "https://deno.land/std@0.152.0/fmt/colors.ts";
+import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
+import { rgb24 } from "https://deno.land/std@0.168.0/fmt/colors.ts";
 
 const defaults = {
   c: 2,

--- a/tests/helpers/conf_test.ts
+++ b/tests/helpers/conf_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { toConf } from "./launcher.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 Deno.test("conf - serializing simple", () => {
   const x = {

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 // deno-lint-ignore-file no-explicit-any
-import * as path from "https://deno.land/std@0.152.0/path/mod.ts";
-import { rgb24 } from "https://deno.land/std@0.152.0/fmt/colors.ts";
+import * as path from "https://deno.land/std@0.168.0/path/mod.ts";
+import { rgb24 } from "https://deno.land/std@0.168.0/fmt/colors.ts";
 import { check } from "./mod.ts";
 import {
   Deferred,
@@ -24,7 +24,7 @@ import {
   nuid,
   timeout,
 } from "../../nats-base-client/internal_mod.ts";
-import { assert } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assert } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { jsopts } from "../jstest_util.ts";
 
 export const ServerSignals = Object.freeze({

--- a/tests/helpers/mod.ts
+++ b/tests/helpers/mod.ts
@@ -4,7 +4,7 @@ import { cleanup } from "../jstest_util.ts";
 import { compare, parseSemVer } from "../../nats-base-client/semver.ts";
 export { check } from "./check.ts";
 export { Lock } from "./lock.ts";
-import { red, yellow } from "https://deno.land/std@0.152.0/fmt/colors.ts";
+import { red, yellow } from "https://deno.land/std@0.168.0/fmt/colors.ts";
 export { Connection, TestServer } from "./test_server.ts";
 export {
   assertBetween,

--- a/tests/idleheartbeats_test.ts
+++ b/tests/idleheartbeats_test.ts
@@ -17,7 +17,7 @@ import { IdleHeartbeat } from "../nats-base-client/idleheartbeat.ts";
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.136.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { deferred } from "../nats-base-client/util.ts";
 
 Deno.test("idleheartbeat - basic", async () => {

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { connect, createInbox, ErrorCode } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 import { assert } from "../nats-base-client/denobuffer.ts";
 import { QueuedIteratorImpl } from "../nats-base-client/queued_iterator.ts";

--- a/tests/jetream409_test.ts
+++ b/tests/jetream409_test.ts
@@ -14,8 +14,10 @@ import {
   NatsError,
   StringCodec,
 } from "../nats-base-client/mod.ts";
-import { assertRejects } from "https://deno.land/std@0.152.0/testing/asserts.ts";
-import { assertStringIncludes } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import {
+  assertRejects,
+  assertStringIncludes,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   cleanup,
   initStream,

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -283,7 +283,7 @@ Deno.test("jetstream - get message last by subject", async () => {
 });
 
 Deno.test("jetstream - publish first sequence", async () => {
-  const { ns, nc } = await setup(jetstreamServerConf(), { debug: true });
+  const { ns, nc } = await setup(jetstreamServerConf());
   const { subj } = await initStream(nc);
 
   const js = nc.jetstream();
@@ -3853,7 +3853,6 @@ Deno.test("jetstream - ordered consumer reset", async () => {
 Deno.test("jetstream - fetch on stopped server doesn't close client", async () => {
   let { ns, nc } = await setup(jetstreamServerConf(), {
     maxReconnectAttempts: -1,
-    debug: true,
   });
   (async () => {
     let reconnects = 0;

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -14,11 +14,13 @@
  */
 import {
   assert,
+  assertArrayIncludes,
   assertEquals,
+  assertExists,
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import {
   AckPolicy,
@@ -68,10 +70,6 @@ import {
 } from "https://raw.githubusercontent.com/nats-io/jwt.js/main/src/jwt.ts";
 import { StreamUpdateConfig } from "../nats-base-client/types.ts";
 import { JetStreamManagerImpl } from "../nats-base-client/jsm.ts";
-import {
-  assertArrayIncludes,
-  assertExists,
-} from "https://deno.land/std@0.75.0/testing/asserts.ts";
 import { Feature } from "../nats-base-client/semver.ts";
 import { convertStreamSourceDomain } from "../nats-base-client/jsmstream_api.ts";
 
@@ -719,18 +717,16 @@ Deno.test("jsm - get message", async () => {
   assertEquals(sm.seq, 2);
   assertEquals(jc.decode(sm.data), 2);
 
-  await assertRejects(
+  const err = await assertRejects(
     async () => {
       await jsm.streams.getMessage(stream, { seq: 3 });
     },
-    (err: Error) => {
-      if (
-        err.message !== "stream store eof" && err.message !== "no message found"
-      ) {
-        fail(`unexpected error message ${err.message}`);
-      }
-    },
-  );
+  ) as Error;
+  if (
+    err.message !== "stream store eof" && err.message !== "no message found"
+  ) {
+    fail(`unexpected error message ${err.message}`);
+  }
 
   await cleanup(ns, nc);
 });

--- a/tests/jsmsg_test.ts
+++ b/tests/jsmsg_test.ts
@@ -15,7 +15,7 @@
 import {
   assertEquals,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { connect, createInbox, Empty, Msg, StringCodec } from "../src/mod.ts";
 import { nanos } from "../nats-base-client/jsutil.ts";
 import { parseInfo, toJsMsg } from "../nats-base-client/jsmsg.ts";

--- a/tests/json_test.ts
+++ b/tests/json_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   createInbox,
   ErrorCode,

--- a/tests/jstest_util.ts
+++ b/tests/jstest_util.ts
@@ -1,7 +1,7 @@
-import * as path from "https://deno.land/std@0.152.0/path/mod.ts";
+import * as path from "https://deno.land/std@0.168.0/path/mod.ts";
 import { NatsServer } from "../tests/helpers/mod.ts";
 import { connect } from "../src/mod.ts";
-import { assert } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assert } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   ConnectionOptions,
   extend,

--- a/tests/kv_test.ts
+++ b/tests/kv_test.ts
@@ -36,7 +36,7 @@ import {
   assertEquals,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import {
   ConnectionOptions,

--- a/tests/mrequest_test.ts
+++ b/tests/mrequest_test.ts
@@ -20,11 +20,11 @@ import { Empty, Events, RequestStrategy } from "../nats-base-client/types.ts";
 import {
   assert,
   assertEquals,
+  assertRejects,
   fail,
-} from "https://deno.land/std@0.138.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { StringCodec } from "../nats-base-client/codec.ts";
 import { deferred, delay } from "../nats-base-client/util.ts";
-import { assertRejects } from "https://deno.land/std@0.125.0/testing/asserts.ts";
 
 async function requestManyCount(noMux = false): Promise<void> {
   const { ns, nc } = await setup({});

--- a/tests/noresponders_test.ts
+++ b/tests/noresponders_test.ts
@@ -19,7 +19,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 Deno.test("noresponders - option", async () => {
   const srv = await NatsServer.start();

--- a/tests/objectstore_test.ts
+++ b/tests/objectstore_test.ts
@@ -20,17 +20,17 @@ import {
   assertEquals,
   assertExists,
   equal,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { DataBuffer } from "../nats-base-client/databuffer.ts";
-import { crypto } from "https://deno.land/std@0.152.0/crypto/mod.ts";
+import { crypto } from "https://deno.land/std@0.168.0/crypto/mod.ts";
 import {
   Empty,
   headers,
   StorageType,
   StringCodec,
 } from "../nats-base-client/mod.ts";
-import { assertRejects } from "https://deno.land/std@0.152.0/testing/asserts.ts";
-import { equals } from "https://deno.land/std@0.152.0/bytes/mod.ts";
+import { assertRejects } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+import { equals } from "https://deno.land/std@0.168.0/bytes/mod.ts";
 import { ObjectInfo, ObjectStoreMeta } from "../nats-base-client/types.ts";
 import { SHA256 } from "../nats-base-client/sha256.js";
 import { Base64UrlCodec } from "../nats-base-client/base64.ts";

--- a/tests/parseip_test.ts
+++ b/tests/parseip_test.ts
@@ -19,7 +19,7 @@
 // license that can be found in the LICENSE file.
 import { parseIP } from "../nats-base-client/internal_mod.ts";
 
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { ipV4 } from "../nats-base-client/ipparser.ts";
 
 Deno.test("ipparser", () => {

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -30,7 +30,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import type { Publisher } from "../nats-base-client/protocol.ts";
 
 const te = new TextEncoder();

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   assertMatch,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 import { connect, ConnectionOptions } from "../src/mod.ts";
 import { DenoTransport } from "../src/deno_transport.ts";

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -27,7 +27,7 @@ import { assertErrorCode } from "./helpers/mod.ts";
 import {
   assertEquals,
   equal,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { protoLen } from "../nats-base-client/util.ts";
 
 Deno.test("protocol - mux subscription unknown return null", async () => {

--- a/tests/queues_test.ts
+++ b/tests/queues_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { createInbox, Subscription } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { cleanup, setup } from "./jstest_util.ts";
 
 Deno.test("queues - deliver to single queue", async () => {

--- a/tests/resub_test.ts
+++ b/tests/resub_test.ts
@@ -2,7 +2,7 @@ import { cleanup, setup } from "./jstest_util.ts";
 import { createInbox } from "../nats-base-client/protocol.ts";
 import { Msg } from "../nats-base-client/types.ts";
 import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 Deno.test("resub - iter", async () => {
   const { ns, nc } = await setup();

--- a/tests/semver_test.ts
+++ b/tests/semver_test.ts
@@ -8,8 +8,8 @@ import {
   assert,
   assertEquals,
   assertFalse,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
-import { assertThrows } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+  assertThrows,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 Deno.test("semver", () => {
   const pt: { a: string; b: string; r: number }[] = [

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -14,7 +14,7 @@
  *
  */
 import { isIPV4OrHostname, Servers } from "../nats-base-client/servers.ts";
-import { assertEquals } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import type { ServerInfo } from "../nats-base-client/types.ts";
 import { setTransportFactory } from "../nats-base-client/internal_mod.ts";
 

--- a/tests/service_test.ts
+++ b/tests/service_test.ts
@@ -18,7 +18,7 @@ import {
   assertExists,
   assertRejects,
   fail,
-} from "https://deno.land/std@0.125.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import {
   createInbox,
   ErrorCode,
@@ -556,8 +556,7 @@ Deno.test("service - reset", async () => {
   await nc.request("q");
   await nc.request("q");
 
-  service._stats.num_errors = 1;
-  service._stats.last_error = new Error("hello");
+  service.countError(new Error("hello"));
 
   const m = nc.services.client();
   let stats = await collect(await m.stats());
@@ -599,9 +598,7 @@ Deno.test("service - iter", async () => {
 
   await nc.request("q");
   await nc.request("q");
-
-  service._stats.num_errors = 1;
-  service._stats.last_error = new Error("hello");
+  service.countError(new Error("hello"));
 
   const m = nc.services.client();
   let stats = await collect(await m.stats());

--- a/tests/sub_extensions_test.ts
+++ b/tests/sub_extensions_test.ts
@@ -15,7 +15,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { createInbox, Msg, StringCodec } from "../src/mod.ts";
 import {
   deferred,

--- a/tests/timeout_test.ts
+++ b/tests/timeout_test.ts
@@ -16,7 +16,7 @@
 import {
   assertStringIncludes,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { connect } from "../src/connect.ts";
 import { createInbox, Empty } from "../nats-base-client/mod.ts";
 

--- a/tests/tls_test.ts
+++ b/tests/tls_test.ts
@@ -15,14 +15,14 @@
 import {
   assertEquals,
   fail,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { connect, ErrorCode } from "../src/mod.ts";
 import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 
-import { join, resolve } from "https://deno.land/std@0.152.0/path/mod.ts";
+import { join, resolve } from "https://deno.land/std@0.168.0/path/mod.ts";
 import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
 import { cleanup } from "./jstest_util.ts";
-import { assertRejects } from "https://deno.land/std@0.125.0/testing/asserts.ts";
+import { assertRejects } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 Deno.test("tls - fail if server doesn't support TLS", async () => {
   const ns = await NatsServer.start();

--- a/tests/token_test.ts
+++ b/tests/token_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fail } from "https://deno.land/std@0.152.0/testing/asserts.ts";
+import { fail } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { connect, ErrorCode } from "../src/mod.ts";
 import { assertErrorCode, NatsServer } from "./helpers/mod.ts";
 

--- a/tests/typedsub_test.ts
+++ b/tests/typedsub_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { assertErrorCode, assertThrowsErrorCode } from "./helpers/asserts.ts";
 import {
   createInbox,

--- a/tests/types_test.ts
+++ b/tests/types_test.ts
@@ -25,7 +25,7 @@ import { DataBuffer, deferred } from "../nats-base-client/internal_mod.ts";
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.152.0/testing/asserts.ts";
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { NatsServer } from "./helpers/launcher.ts";
 
 function mh(nc: NatsConnection, subj: string): Promise<Msg> {


### PR DESCRIPTION
[FIX] utility test functions that relied on older apis
[FIX] linter errors revealed by new version of deno