### PR TITLE
cross-client service verification tool

### DIFF
--- a/nats-base-client/service.ts
+++ b/nats-base-client/service.ts
@@ -328,6 +328,7 @@ export class ServiceImpl extends QueuedIteratorImpl<ServiceMsg>
   ) {
     super();
     this.nc = nc;
+    config.name = config?.name?.toUpperCase() || "";
     this.config = config;
     const n = validName(this.name);
     if (n !== "") {

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -16,7 +16,6 @@
 import {
   assert,
   assertEquals,
-  assertThrows,
   fail,
 } from "https://deno.land/std@0.168.0/testing/asserts.ts";
 import { assertThrowsAsyncErrorCode } from "./helpers/asserts.ts";
@@ -28,7 +27,7 @@ import {
   StringCodec,
 } from "../src/mod.ts";
 
-import { assertErrorCode, assertThrowsErrorCode, Lock } from "./helpers/mod.ts";
+import { assertThrowsErrorCode, Lock } from "./helpers/mod.ts";
 import { cleanup, setup } from "./jstest_util.ts";
 
 Deno.test("drain - connection drains when no subs", async () => {

--- a/tests/helpers/service_metadata.ts
+++ b/tests/helpers/service_metadata.ts
@@ -1,0 +1,263 @@
+import { cli, Command, Flags } from "https://deno.land/x/cobra@v0.0.9/mod.ts";
+import {
+  connect,
+  EndpointStats,
+  NatsConnection,
+  ServiceError,
+  ServiceIdentity,
+  ServiceInfo,
+  ServiceSchema,
+  ServiceVerb,
+  StringCodec,
+} from "../../src/mod.ts";
+
+import { collect } from "../../nats-base-client/util.ts";
+import { ServiceClientImpl } from "../../nats-base-client/serviceclient.ts";
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+const root = cli({
+  use: "service-check [--name name] [--server host:port]",
+  run: async (cmd, args, flags): Promise<number> => {
+    const servers = [flags.value<string>("server")];
+    const name = flags.value<string>("name");
+
+    let error;
+    let nc: NatsConnection|null = null;
+    try {
+      nc = await connect({servers, debug: true});
+      await invoke(nc, name);
+      await checkPing(nc, name);
+      await checkInfo(nc, name);
+      await checkSchema(nc, name);
+      await checkStats(nc, name);
+    } catch (err) {
+      error = err;
+    } finally {
+      await nc?.close();
+      if(error) {
+        return Promise.reject(error);
+      }
+    }
+    return Promise.resolve(0);
+  },
+});
+root.addFlag({
+  short: "n",
+  name: "name",
+  type: "string",
+  usage: "service name to filter on",
+  default: "",
+  persistent: true,
+  required: true,
+});
+
+root.addFlag({
+  name: "server",
+  type: "string",
+  usage: "NATS server to connect to",
+  default: "localhost:4222",
+  persistent: true,
+});
+
+function filter<T extends ServiceIdentity>(name: string, responses: T[]): T[] {
+  const n = name.toUpperCase();
+  return responses.filter((r) => {
+    return r.name === n;
+  });
+}
+function filterExpectingOnly<T extends ServiceIdentity>(
+  tag: string,
+  name: string,
+  responses: T[],
+): T[] {
+  const filtered = filter(name, responses);
+  assertEquals(
+    filtered.length,
+    responses.length,
+    `expected ${tag} to have only services named ${name}`,
+  );
+  return filtered;
+}
+
+function checkResponse<T extends ServiceIdentity>(
+  tag: string,
+  responses: T[],
+  requiredKeys: string[],
+) {
+  assert(responses.length > 0);
+  requiredKeys.forEach((k) => {
+    responses.forEach((r) => {
+      assert(
+        typeof (r as Record<string, unknown>)[k] !== "undefined",
+        `expected ${tag} responses to have field ${k}`,
+      );
+      delete (r as Record<string, unknown>)[k];
+    });
+  });
+  responses.forEach((r) => {
+    assertEquals(
+      Object.keys(r).length,
+      0,
+      `expected ${tag} to not contain other properties ${JSON.stringify(r)}`,
+    );
+  });
+}
+
+async function checkStats(nc: NatsConnection, name: string) {
+  await check(nc, ServiceVerb.STATS, name, [
+    "name",
+    "id",
+    "version",
+    "num_requests",
+    "num_errors",
+    "last_error",
+    "data",
+    "processing_time",
+    "average_processing_time",
+    "started",
+  ], (v) => {
+    const stats = v as EndpointStats;
+    assertEquals(typeof stats.name, "string");
+    assertEquals(typeof stats.id, "string");
+    assertEquals(typeof stats.version, "string");
+    assertEquals(typeof stats.num_requests, "number");
+    assertEquals(typeof stats.num_errors, "number");
+    assertEquals(typeof stats.last_error, "string");
+    assertEquals(typeof stats.data, "string");
+    assertEquals(typeof stats.processing_time, "number");
+    assertEquals(
+      typeof stats.average_processing_time,
+      "number",
+    );
+    assertEquals(typeof stats.started, "string");
+  });
+}
+
+async function checkSchema(nc: NatsConnection, name: string) {
+  await check(nc, ServiceVerb.SCHEMA, name, [
+    "name",
+    "id",
+    "version",
+    "schema",
+  ], (v) => {
+    const schema = v as ServiceSchema;
+    assertEquals(typeof v.name, "string");
+    assertEquals(typeof v.id, "string");
+    assertEquals(typeof v.version, "string");
+    assertEquals(typeof schema, "object");
+    assertEquals(typeof schema.schema.request, "string");
+    assertEquals(typeof schema.schema.request, "string");
+  });
+}
+
+async function checkInfo(nc: NatsConnection, name: string) {
+  await check(nc, ServiceVerb.INFO, name, [
+    "name",
+    "id",
+    "version",
+    "description",
+    "subject",
+  ], (v) => {
+    const info = v as ServiceInfo;
+    assertEquals(typeof v.name, "string");
+    assertEquals(typeof v.id, "string");
+    assertEquals(typeof v.version, "string");
+    assertEquals(typeof info.description, "string");
+    assertEquals(typeof info.subject, "string");
+  });
+}
+
+async function checkPing(nc: NatsConnection, name: string) {
+  await check(nc, ServiceVerb.PING, name, ["name", "id", "version"], (v) => {
+    assertEquals(typeof v.name, "string");
+    assertEquals(typeof v.id, "string");
+    assertEquals(typeof v.version, "string");
+  });
+}
+
+async function invoke(nc: NatsConnection, name: string): Promise<void> {
+  const sc = nc.services.client();
+  const infos = await collect(await sc.info(name));
+  const ids = infos.map((v) => {
+    return { id: v.id, subject: v.subject };
+  });
+
+  // bad requests we need a payload
+  let proms = infos.map((v) => {
+    return nc.request(v.subject);
+  });
+  let responses = await Promise.all(proms);
+  responses.forEach((m) => {
+    assertEquals(
+      ServiceError.isServiceError(m),
+      true,
+      "expected service without payload to return error",
+    );
+  });
+
+  proms = infos.map((v, idx) => {
+    return nc.request(v.subject, StringCodec().encode(`hello ${idx}`));
+  });
+  responses = await Promise.all(proms);
+  responses.forEach((m, idx) => {
+    const r = `hello ${idx}`;
+    assertEquals(
+      StringCodec().decode(m.data),
+      r,
+      `expected service response ${r}`,
+    );
+  });
+}
+
+async function check(
+  nc: NatsConnection,
+  verb: ServiceVerb,
+  name: string,
+  keys: string[],
+  check?: (v: ServiceIdentity) => void,
+) {
+  const fn = (d: ServiceIdentity[]): void => {
+    if (check) {
+      try {
+        d.forEach(check);
+      } catch (err) {
+        throw new Error(`${verb} check: ${err.message}`);
+      }
+    }
+  };
+
+  const sc = nc.services.client() as ServiceClientImpl;
+  // all
+  let responses = filter(
+    name,
+    await collect(await sc.q<ServiceIdentity>(verb)),
+  );
+  assert(responses.length >= 1);
+  fn(responses);
+  checkResponse(`${verb}()`, responses, keys);
+
+  // just matching name
+  responses = filterExpectingOnly(
+    `${verb}(${name})`,
+    name,
+    await collect(await sc.q<ServiceIdentity>(verb, name)),
+  );
+  assert(responses.length >= 1);
+  fn(responses);
+  checkResponse(`${verb}(${name})`, responses, keys);
+
+  // specific service
+  responses = filterExpectingOnly(
+    `${verb}(${name})`,
+    name,
+    await collect(await sc.q<ServiceIdentity>(verb, name, responses[0].id)),
+  );
+  assert(responses.length === 1);
+  fn(responses);
+  checkResponse(`${verb}(${name})`, responses, keys);
+}
+
+Deno.exit(await root.execute(Deno.args));

--- a/tests/helpers/service_metadata.ts
+++ b/tests/helpers/service_metadata.ts
@@ -1,4 +1,4 @@
-import { cli, Command, Flags } from "https://deno.land/x/cobra@v0.0.9/mod.ts";
+import { cli } from "https://deno.land/x/cobra@v0.0.9/mod.ts";
 import {
   connect,
   EndpointStats,
@@ -13,35 +13,30 @@ import {
 
 import { collect } from "../../nats-base-client/util.ts";
 import { ServiceClientImpl } from "../../nats-base-client/serviceclient.ts";
-import {
-  assert,
-  assertEquals,
-} from "https://deno.land/std@0.168.0/testing/asserts.ts";
 
 const root = cli({
   use: "service-check [--name name] [--server host:port]",
-  run: async (cmd, args, flags): Promise<number> => {
+  run: async (cmd, _args, flags): Promise<number> => {
     const servers = [flags.value<string>("server")];
     const name = flags.value<string>("name");
 
     let error;
-    let nc: NatsConnection|null = null;
+    let nc: NatsConnection | null = null;
     try {
-      nc = await connect({servers, debug: true});
+      nc = await connect({ servers });
       await invoke(nc, name);
       await checkPing(nc, name);
       await checkInfo(nc, name);
       await checkSchema(nc, name);
       await checkStats(nc, name);
     } catch (err) {
+      cmd.stderr(err.message);
+      console.log(err);
       error = err;
     } finally {
       await nc?.close();
-      if(error) {
-        return Promise.reject(error);
-      }
     }
-    return Promise.resolve(0);
+    return error ? Promise.resolve(1) : Promise.resolve(0);
   },
 });
 root.addFlag({
@@ -87,20 +82,19 @@ function checkResponse<T extends ServiceIdentity>(
   responses: T[],
   requiredKeys: string[],
 ) {
-  assert(responses.length > 0);
+  assert(responses.length > 0, `expected responses for ${tag}`);
   requiredKeys.forEach((k) => {
     responses.forEach((r) => {
       assert(
-        typeof (r as Record<string, unknown>)[k] !== "undefined",
+        (r as Record<string, unknown>)[k] !== "undefined",
         `expected ${tag} responses to have field ${k}`,
       );
       delete (r as Record<string, unknown>)[k];
     });
   });
   responses.forEach((r) => {
-    assertEquals(
-      Object.keys(r).length,
-      0,
+    assert(
+      Object.keys(r).length === 0,
       `expected ${tag} to not contain other properties ${JSON.stringify(r)}`,
     );
   });
@@ -120,19 +114,20 @@ async function checkStats(nc: NatsConnection, name: string) {
     "started",
   ], (v) => {
     const stats = v as EndpointStats;
-    assertEquals(typeof stats.name, "string");
-    assertEquals(typeof stats.id, "string");
-    assertEquals(typeof stats.version, "string");
-    assertEquals(typeof stats.num_requests, "number");
-    assertEquals(typeof stats.num_errors, "number");
-    assertEquals(typeof stats.last_error, "string");
-    assertEquals(typeof stats.data, "string");
-    assertEquals(typeof stats.processing_time, "number");
+    assertEquals(typeof stats.name, "string", "name");
+    assertEquals(typeof stats.id, "string", "id");
+    assertEquals(typeof stats.version, "string", "version");
+    assertEquals(typeof stats.num_requests, "number", "num_requests");
+    assertEquals(typeof stats.num_errors, "number", "num_errors");
+    assertEquals(typeof stats.last_error, "string", "last_error");
+    assertEquals(typeof stats.data, "string", "data");
+    assertEquals(typeof stats.processing_time, "number", "processing_time");
     assertEquals(
       typeof stats.average_processing_time,
       "number",
+      "average_processing_time",
     );
-    assertEquals(typeof stats.started, "string");
+    assertEquals(typeof stats.started, "string", "started");
   });
 }
 
@@ -143,13 +138,13 @@ async function checkSchema(nc: NatsConnection, name: string) {
     "version",
     "schema",
   ], (v) => {
-    const schema = v as ServiceSchema;
-    assertEquals(typeof v.name, "string");
-    assertEquals(typeof v.id, "string");
-    assertEquals(typeof v.version, "string");
-    assertEquals(typeof schema, "object");
-    assertEquals(typeof schema.schema.request, "string");
-    assertEquals(typeof schema.schema.request, "string");
+    const o = v as ServiceSchema;
+    assertEquals(typeof o.name, "string", "name");
+    assertEquals(typeof o.id, "string", "id");
+    assertEquals(typeof o.version, "string", "version");
+    assertEquals(typeof o.schema, "object", "schema");
+    assertEquals(typeof o.schema.request, "string", "schema.request");
+    assertEquals(typeof o.schema.response, "string", "schema.response");
   });
 }
 
@@ -162,34 +157,43 @@ async function checkInfo(nc: NatsConnection, name: string) {
     "subject",
   ], (v) => {
     const info = v as ServiceInfo;
-    assertEquals(typeof v.name, "string");
-    assertEquals(typeof v.id, "string");
-    assertEquals(typeof v.version, "string");
-    assertEquals(typeof info.description, "string");
-    assertEquals(typeof info.subject, "string");
+    assertEquals(typeof v.name, "string", "name");
+    assertEquals(typeof v.id, "string", "id");
+    assertEquals(typeof v.version, "string", "version");
+    assertEquals(typeof info.description, "string", "description");
+    assertEquals(typeof info.subject, "string", "subject");
   });
 }
 
 async function checkPing(nc: NatsConnection, name: string) {
   await check(nc, ServiceVerb.PING, name, ["name", "id", "version"], (v) => {
-    assertEquals(typeof v.name, "string");
-    assertEquals(typeof v.id, "string");
-    assertEquals(typeof v.version, "string");
+    assertEquals(typeof v.name, "string", "name");
+    assertEquals(typeof v.id, "string", "id");
+    assertEquals(typeof v.version, "string", "version");
   });
 }
 
 async function invoke(nc: NatsConnection, name: string): Promise<void> {
   const sc = nc.services.client();
   const infos = await collect(await sc.info(name));
-  const ids = infos.map((v) => {
-    return { id: v.id, subject: v.subject };
-  });
 
-  // bad requests we need a payload
   let proms = infos.map((v) => {
     return nc.request(v.subject);
   });
   let responses = await Promise.all(proms);
+  responses.forEach((m) => {
+    assertEquals(
+      ServiceError.isServiceError(m),
+      true,
+      "expected service without payload to return error",
+    );
+  });
+
+  // the service should throw/register an error if "error" is specified as payload
+  proms = infos.map((v) => {
+    return nc.request(v.subject, StringCodec().encode("error"));
+  });
+  responses = await Promise.all(proms);
   responses.forEach((m) => {
     assertEquals(
       ServiceError.isServiceError(m),
@@ -235,6 +239,7 @@ async function check(
     name,
     await collect(await sc.q<ServiceIdentity>(verb)),
   );
+
   assert(responses.length >= 1);
   fn(responses);
   checkResponse(`${verb}()`, responses, keys);
@@ -258,6 +263,18 @@ async function check(
   assert(responses.length === 1);
   fn(responses);
   checkResponse(`${verb}(${name})`, responses, keys);
+}
+
+function assert(v: unknown, msg?: string) {
+  if (typeof v === undefined || typeof v === null || v === false) {
+    throw new Error(msg || "expected value to be truthy");
+  }
+}
+
+function assertEquals(v: unknown, expected: unknown, msg?: string) {
+  if (v !== expected) {
+    throw new Error(msg || `expected ${v} === ${expected}`);
+  }
 }
 
 Deno.exit(await root.execute(Deno.args));

--- a/tests/service_test.ts
+++ b/tests/service_test.ts
@@ -19,18 +19,21 @@ import {
   assertRejects,
   fail,
 } from "https://deno.land/std@0.168.0/testing/asserts.ts";
+
+import { collect, delay } from "../nats-base-client/util.ts";
+import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
 import {
+  connect,
   createInbox,
   ErrorCode,
+  JSONCodec,
   Msg,
   NatsError,
+  nuid,
   QueuedIterator,
   ServiceVerb,
   StringCodec,
-} from "../nats-base-client/mod.ts";
-import { collect, delay } from "../nats-base-client/util.ts";
-import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
-import { connect, JSONCodec, nuid } from "../src/mod.ts";
+} from "../src/mod.ts";
 
 Deno.test("service - control subject", () => {
   const test = (verb: ServiceVerb) => {
@@ -716,32 +719,61 @@ Deno.test("service - service errors", async () => {
 
 Deno.test("service - cross platform service test", async () => {
   const nc = await connect({ servers: "demo.nats.io", debug: false });
-  // const name = `echo_${nuid.next()}`;
-  const name = "X";
-  const srv = await nc.services.add({
+  const name = `echo_${nuid.next()}`;
+  const _srv = await nc.services.add({
     name,
     version: "0.0.1",
     endpoint: {
       subject: createInbox(),
+      handler: (_err: NatsError | null, m: ServiceMsg): void => {
+        if (m.data.length === 0) {
+          m.respondError(400, "need a string", JSONCodec().encode(""));
+        } else {
+          if (StringCodec().decode(m.data) === "error") {
+            throw new Error("service asked to throw an error");
+          }
+          m.respond(m.data);
+        }
+      },
     },
-  });
-  (async () => {
-    for await (const m of srv) {
-      if (m.data.length === 0) {
-        m.respondError(400, "need a string", JSONCodec().encode(""));
-      } else {
-        m.respond(m.data);
-      }
-    }
-  })().then();
+    schema: { request: "a", response: "b" },
+    statsHandler: (): Promise<unknown> => {
+      return Promise.resolve("hello world");
+    },
+  }) as ServiceImpl;
 
-  const args =  ["deno", "run", "-A", "./tests/helpers/service_metadata.ts", "--name", name, "--server", "demo.nats.io"];
-  console.log(args.join(" "));
-  await delay(100000);
+  const args = [
+    "deno",
+    "run",
+    "-A",
+    "./tests/helpers/service_metadata.ts",
+    "--name",
+    name,
+    "--server",
+    "demo.nats.io",
+  ];
+
+  const p = Deno.run({ cmd: args, stderr: "piped", stdout: "piped" });
+  const [status, stdout, stderr] = await Promise.all([
+    p.status(),
+    p.output(),
+    p.stderrOutput(),
+  ]);
+
+  if (!status.success) {
+    const sc = StringCodec();
+    // console.log(sc.decode(stdout))
+    console.log(sc.decode(stderr));
+    console.log(sc.decode(stdout));
+    fail(sc.decode(stderr));
+  }
+  p.close();
 
   // const p = Deno.run({cmd: ["deno", "run", "-A", "./tests/helpers/service_metadata.ts", "--name", name, "--server", "demo.nats.io"]});
   // const s = await p.status();
   // console.log(s);
+
+  // await delay(100000);
 
   await nc.close();
 });

--- a/tests/service_test.ts
+++ b/tests/service_test.ts
@@ -769,11 +769,5 @@ Deno.test("service - cross platform service test", async () => {
   }
   p.close();
 
-  // const p = Deno.run({cmd: ["deno", "run", "-A", "./tests/helpers/service_metadata.ts", "--name", name, "--server", "demo.nats.io"]});
-  // const s = await p.status();
-  // console.log(s);
-
-  // await delay(100000);
-
   await nc.close();
 });


### PR DESCRIPTION
cross client service metadata verification
requires a service:
- that echos back payload
- returns a service error message if payload is empty
- throws an error (or registers an internal error) if the payload value is "error"

clients can execute as:
`deno run -A https://raw.githubusercontent.com/nats-io/nats.deno/main/tests/helpers/service_metadata.ts --server demo.nats.io --name serviceName`