### PR TITLE
[BUMP] nkeys.js dependency to 1.0.4

### DIFF
--- a/nats-base-client/nkeys.ts
+++ b/nats-base-client/nkeys.ts
@@ -1,1 +1,1 @@
-export * as nkeys from "https://raw.githubusercontent.com/nats-io/nkeys.js/v1.0.3/modules/esm/mod.ts";
+export * as nkeys from "https://raw.githubusercontent.com/nats-io/nkeys.js/v1.0.4/modules/esm/mod.ts";

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -33,7 +33,7 @@ import {
 } from "../nats-base-client/internal_mod.ts";
 import type { TlsOptions } from "../nats-base-client/types.ts";
 
-const VERSION = "1.10.1";
+const VERSION = "1.10.2";
 const LANG = "nats.deno";
 
 // if trying to simply write to the connection for some reason


### PR DESCRIPTION
[BUMP] nkeys.js dependency to 1.0.4 as downstream projects (nats.ws) when in a cjs module configuration with some bundlers would failed to propagate the dependency

[BUMP] client version to 1.10.2