### PR TITLE
Allow # in stream name validation function

### DIFF
--- a/nats-base-client/jsutil.ts
+++ b/nats-base-client/jsutil.ts
@@ -49,7 +49,7 @@ export function validName(name = ""): string {
   if (name === "") {
     throw Error(`name required`);
   }
-  const RE = /^[-\w]+$/g;
+  const RE = /^[-\w,#]+$/g;
   const m = name.match(RE);
   if (m === null) {
     for (const c of name.split("")) {


### PR DESCRIPTION
I faced an issue when I tried to pullSubscribe from a stream whose name contains a # character.
I got the following error 
Invalid stream name - stream name cannot contain '#'.

So I followed up and saw that in your last releases, you changed something in the validation function.
Since # char is allowed according to your docs and I also succeeded to create a stream with #, I've changed a bit the regex you are using in order to validate the stream name
