### PR TITLE
[FIX] add support `previousRevision` in ObjectStorePutOps

### DIFF
--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -2884,6 +2884,7 @@ export interface ObjectInfo extends ObjectStoreMeta {
   digest: string;
   deleted: boolean;
   mtime: string;
+  revision: number;
 }
 
 export interface ObjectLink {
@@ -2930,7 +2931,13 @@ export type ObjectStorePutOpts = {
   /**
    * maximum number of millis for the put requests to succeed
    */
-  timeout: number;
+  timeout?: number;
+  /**
+   * If set the ObjectStore must be at the current sequence or the
+   * put will fail. Note the sequence accounts where the metadata
+   * for the entry is stored.
+   */
+  previousRevision?: number;
 };
 
 export interface ObjectStore {

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -4234,7 +4234,7 @@ Deno.test("jetstream - push heartbeat callback", async () => {
 });
 
 Deno.test("jetstream - consumer opt multi subject filter", () => {
-  let opts = new ConsumerOptsBuilderImpl();
+  const opts = new ConsumerOptsBuilderImpl();
   opts.filterSubject("foo");
   let co = opts.getOpts();
   assertEquals(co.config.filter_subject, "foo");

--- a/tests/objectstore_test.ts
+++ b/tests/objectstore_test.ts
@@ -923,3 +923,81 @@ Deno.test("objectstore - cannot put links", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("objectstore - put purges old entries", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.6.3")) {
+    return;
+  }
+
+  const js = nc.jetstream();
+  const os = await js.views.os("OBJS", { description: "testing" });
+
+  // we expect 10 messages per put
+  const t = async (first: number, last: number) => {
+    const status = await os.status();
+    const si = status.streamInfo;
+    assertEquals(si.state.first_seq, first);
+    assertEquals(si.state.last_seq, last);
+  };
+
+  const blob = new Uint8Array(9);
+  let oi = await os.put(
+    { name: "BLOB", description: "myblob", options: { max_chunk_size: 1 } },
+    readableStreamFrom(crypto.getRandomValues(blob)),
+  );
+  assertEquals(oi.revision, 10);
+  await t(1, 10);
+
+  oi = await os.put(
+    { name: "BLOB", description: "myblob", options: { max_chunk_size: 1 } },
+    readableStreamFrom(crypto.getRandomValues(blob)),
+  );
+  assertEquals(oi.revision, 20);
+  await t(11, 20);
+  await cleanup(ns, nc);
+});
+
+Deno.test("objectstore - put previous sequences", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.6.3")) {
+    return;
+  }
+
+  const js = nc.jetstream();
+  const os = await js.views.os("OBJS", { description: "testing" });
+
+  // putting the first
+  let oi = await os.put(
+    { name: "A", options: { max_chunk_size: 1 } },
+    readableStreamFrom(crypto.getRandomValues(new Uint8Array(9))),
+    { previousRevision: 0 },
+  );
+  assertEquals(oi.revision, 10);
+
+  // putting another value, but the first value for the key - so previousRevision is 0
+  oi = await os.put(
+    { name: "B", options: { max_chunk_size: 1 } },
+    readableStreamFrom(crypto.getRandomValues(new Uint8Array(3))),
+    { previousRevision: 0 },
+  );
+  assertEquals(oi.revision, 14);
+
+  // update A, previous A is found at 10
+  oi = await os.put(
+    { name: "A", options: { max_chunk_size: 1 } },
+    readableStreamFrom(crypto.getRandomValues(new Uint8Array(3))),
+    { previousRevision: 10 },
+  );
+  assertEquals(oi.revision, 18);
+
+  // update A, previous A is found at 18
+  oi = await os.put(
+    { name: "A", options: { max_chunk_size: 1 } },
+    readableStreamFrom(Empty),
+    { previousRevision: 18 },
+  );
+  assertEquals(oi.revision, 19);
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
Currently, it is possible to add the same object twice, but not trigger the prune functionality, thus data assets are found twice in the stream. The option `previousRevision` allows the client to specify the revision that the previous object represented (`0` for not expecting the object to exist in the stream). If the update of the metadata entry fails, the data chunks are removed.