### PR TITLE
[FEAT] multiple authenticators

### DIFF
--- a/nats-base-client/options.ts
+++ b/nats-base-client/options.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The NATS Authors
+ * Copyright 2021-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -71,19 +71,6 @@ export function parseOptions(opts?: ConnectionOptions): ConnectionOptions {
   }
   const options = extend(defaultOptions(), opts);
 
-  // tokens don't get users
-  if (opts.user && opts.token) {
-    throw NatsError.errorForCode(ErrorCode.BadAuthentication);
-  }
-
-  // if authenticator, no other options allowed
-  if (
-    opts.authenticator && (
-      opts.token || opts.user || opts.pass
-    )
-  ) {
-    throw NatsError.errorForCode(ErrorCode.BadAuthentication);
-  }
   options.authenticator = buildAuthenticator(options);
 
   ["reconnectDelayHandler", "authenticator"].forEach((n) => {

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -104,7 +104,9 @@ export class Connect {
     this.name = opts.name;
 
     const creds =
-      (opts && opts.authenticator ? opts.authenticator(nonce) : {}) || {};
+      (opts && typeof opts.authenticator === "function"
+        ? opts.authenticator(nonce)
+        : {}) || {};
     extend(this, creds);
   }
 }

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -226,7 +226,7 @@ export interface ConnectionOptions {
    * authentication configurations
    * if {@link user} and {@link pass} or the {@link token} options are set.
    */
-  authenticator?: Authenticator;
+  authenticator?: Authenticator | Authenticator[];
   /**
    * When set to `true` the client will print protocol messages that it receives
    * or sends to the server.

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -1157,4 +1157,50 @@ Deno.test("auth - sub with permission error discards", async () => {
   await q();
 
   await cleanup(ns, nc);
+});
+
+Deno.test("auth - creds and un and pw and token", async () => {
+  const creds = `-----BEGIN NATS USER JWT-----
+    eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJFU1VQS1NSNFhGR0pLN0FHUk5ZRjc0STVQNTZHMkFGWERYQ01CUUdHSklKUEVNUVhMSDJBIiwiaWF0IjoxNTQ0MjE3NzU3LCJpc3MiOiJBQ1pTV0JKNFNZSUxLN1FWREVMTzY0VlgzRUZXQjZDWENQTUVCVUtBMzZNSkpRUlBYR0VFUTJXSiIsInN1YiI6IlVBSDQyVUc2UFY1NTJQNVNXTFdUQlAzSDNTNUJIQVZDTzJJRUtFWFVBTkpYUjc1SjYzUlE1V002IiwidHlwZSI6InVzZXIiLCJuYXRzIjp7InB1YiI6e30sInN1YiI6e319fQ.kCR9Erm9zzux4G6M-V2bp7wKMKgnSNqMBACX05nwePRWQa37aO_yObbhcJWFGYjo1Ix-oepOkoyVLxOJeuD8Bw
+  ------END NATS USER JWT------
+
+************************* IMPORTANT *************************
+  NKEY Seed printed below can be used sign and prove identity.
+    NKEYs are sensitive and should be treated as secrets.
+
+  -----BEGIN USER NKEY SEED-----
+    SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4
+  ------END USER NKEY SEED------
+`;
+
+  const conf = {
+    operator:
+      "eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJhdWQiOiJURVNUUyIsImV4cCI6MTg1OTEyMTI3NSwianRpIjoiWE5MWjZYWVBIVE1ESlFSTlFPSFVPSlFHV0NVN01JNVc1SlhDWk5YQllVS0VRVzY3STI1USIsImlhdCI6MTU0Mzc2MTI3NSwiaXNzIjoiT0NBVDMzTVRWVTJWVU9JTUdOR1VOWEo2NkFIMlJMU0RBRjNNVUJDWUFZNVFNSUw2NU5RTTZYUUciLCJuYW1lIjoiU3luYWRpYSBDb21tdW5pY2F0aW9ucyBJbmMuIiwibmJmIjoxNTQzNzYxMjc1LCJzdWIiOiJPQ0FUMzNNVFZVMlZVT0lNR05HVU5YSjY2QUgyUkxTREFGM01VQkNZQVk1UU1JTDY1TlFNNlhRRyIsInR5cGUiOiJvcGVyYXRvciIsIm5hdHMiOnsic2lnbmluZ19rZXlzIjpbIk9EU0tSN01ZRlFaNU1NQUo2RlBNRUVUQ1RFM1JJSE9GTFRZUEpSTUFWVk40T0xWMllZQU1IQ0FDIiwiT0RTS0FDU1JCV1A1MzdEWkRSVko2NTdKT0lHT1BPUTZLRzdUNEhONk9LNEY2SUVDR1hEQUhOUDIiLCJPRFNLSTM2TFpCNDRPWTVJVkNSNlA1MkZaSlpZTVlXWlZXTlVEVExFWjVUSzJQTjNPRU1SVEFCUiJdfX0.hyfz6E39BMUh0GLzovFfk3wT4OfualftjdJ_eYkLfPvu5tZubYQ_Pn9oFYGCV_6yKy3KMGhWGUCyCdHaPhalBw",
+    resolver: "MEMORY",
+    "resolver_preload": {
+      ACZSWBJ4SYILK7QVDELO64VX3EFWB6CXCPMEBUKA36MJJQRPXGEEQ2WJ:
+        "eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJXVFdYVDNCT1JWSFNLQkc2T0pIVVdFQ01QRVdBNldZVEhNRzVEWkJBUUo1TUtGU1dHM1FRIiwiaWF0IjoxNTQ0MjE3NzU3LCJpc3MiOiJPQ0FUMzNNVFZVMlZVT0lNR05HVU5YSjY2QUgyUkxTREFGM01VQkNZQVk1UU1JTDY1TlFNNlhRRyIsInN1YiI6IkFDWlNXQko0U1lJTEs3UVZERUxPNjRWWDNFRldCNkNYQ1BNRUJVS0EzNk1KSlFSUFhHRUVRMldKIiwidHlwZSI6ImFjY291bnQiLCJuYXRzIjp7ImxpbWl0cyI6eyJzdWJzIjotMSwiY29ubiI6LTEsImltcG9ydHMiOi0xLCJleHBvcnRzIjotMSwiZGF0YSI6LTEsInBheWxvYWQiOi0xLCJ3aWxkY2FyZHMiOnRydWV9fX0.q-E7bBGTU0uoTmM9Vn7WaEHDzCUrqvPDb9mPMQbry_PNzVAjf0RG9vd15lGxW5lu7CuGVqpj4CYKhNDHluIJAg",
+    },
+  };
+  const ns = await NatsServer.start(conf);
+  const te = new TextEncoder();
+  const nc = await connect(
+    {
+      port: ns.port,
+      authenticator: [
+        credsAuthenticator(te.encode(creds)),
+        nkeyAuthenticator(
+          te.encode(
+            "SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4",
+          ),
+        ),
+      ],
+      user: "a",
+      pass: "secret",
+      token: "mytoken",
+    },
+  );
+  await nc.flush();
+  await nc.close();
+  await ns.stop();
 });

--- a/tests/jetstream_test.ts
+++ b/tests/jetstream_test.ts
@@ -4234,7 +4234,7 @@ Deno.test("jetstream - push heartbeat callback", async () => {
 });
 
 Deno.test("jetstream - consumer opt multi subject filter", () => {
-  let opts = new ConsumerOptsBuilderImpl();
+  const opts = new ConsumerOptsBuilderImpl();
   opts.filterSubject("foo");
   let co = opts.getOpts();
   assertEquals(co.config.filter_subject, "foo");

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,13 +15,17 @@
 import {
   assert,
   assertEquals,
+  assertExists,
   assertMatch,
 } from "https://deno.land/std@0.171.0/testing/asserts.ts";
 
 import { connect, ConnectionOptions } from "../src/mod.ts";
 import { DenoTransport } from "../src/deno_transport.ts";
 import { Connect } from "../nats-base-client/protocol.ts";
-import { buildAuthenticator } from "../nats-base-client/authenticator.ts";
+import {
+  Authenticator,
+  credsAuthenticator,
+} from "../nats-base-client/authenticator.ts";
 import { extend } from "../nats-base-client/util.ts";
 import { defaultOptions, parseOptions } from "../nats-base-client/options.ts";
 import { Servers } from "../nats-base-client/servers.ts";
@@ -56,16 +60,18 @@ Deno.test("properties - default connect properties", () => {
   assertEquals(cc.name, undefined, "name");
 });
 
-Deno.test("properties - configured token options", async () => {
+Deno.test("properties - configured token options", () => {
   let opts = defaultOptions();
   opts.servers = "127.0.0.1:4222";
   opts.name = "test";
   opts.token = "abc";
   opts.pedantic = true;
   opts.verbose = true;
-  // simulate the authenticator - as 'token' is mapped to 'auth_token'
-  opts.authenticator = buildAuthenticator(opts);
-  const auth = await opts.authenticator();
+
+  opts = parseOptions(opts);
+  assertExists(opts.authenticator);
+  const fn = opts.authenticator as Authenticator;
+  const auth = fn();
   opts = extend(opts, auth);
 
   const c = new Connect({ version, lang }, opts);
@@ -79,14 +85,15 @@ Deno.test("properties - configured token options", async () => {
   assertEquals(cc.auth_token, opts.token);
 });
 
-Deno.test("properties - configured user/pass options", async () => {
+Deno.test("properties - configured user/pass options", () => {
   let opts = defaultOptions();
   opts.servers = "127.0.0.1:4222";
   opts.user = "test";
   opts.pass = "secret";
-  // simulate the autheticator
-  opts.authenticator = buildAuthenticator(opts);
-  const auth = await opts.authenticator();
+  opts = parseOptions(opts);
+  assertExists(opts.authenticator);
+  const fn = opts.authenticator as Authenticator;
+  const auth = fn();
   opts = extend(opts, auth);
 
   const c = new Connect({ version, lang }, opts);
@@ -107,11 +114,14 @@ Deno.test("properties - tls doesn't leak options", () => {
     ca: "ca",
   };
 
-  let opts = { tls: tlsOptions, cert: "another" };
-  const auth = buildAuthenticator(opts);
-  opts = extend(opts, auth);
+  const opts = { tls: tlsOptions, cert: "another" };
+  let po = parseOptions(opts);
+  assertExists(po.authenticator);
+  const fn = po.authenticator as Authenticator;
+  const auth = fn() || {};
+  po = extend(po, auth);
 
-  const c = new Connect({ version: "1.2.3", lang: "test" }, opts);
+  const c = new Connect({ version: "1.2.3", lang: "test" }, po);
   const cc = JSON.parse(JSON.stringify(c));
   assertEquals(cc.tls_required, true);
   assertEquals(cc.cert, undefined);
@@ -134,4 +144,42 @@ Deno.test("properties - port is only honored if no servers provided", () => {
     const cs = servers.getCurrentServer();
     assertEquals(cs.listen, t.expected);
   });
+});
+
+Deno.test("properties - multi", () => {
+  const creds = `-----BEGIN NATS USER JWT-----
+    eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiJFU1VQS1NSNFhGR0pLN0FHUk5ZRjc0STVQNTZHMkFGWERYQ01CUUdHSklKUEVNUVhMSDJBIiwiaWF0IjoxNTQ0MjE3NzU3LCJpc3MiOiJBQ1pTV0JKNFNZSUxLN1FWREVMTzY0VlgzRUZXQjZDWENQTUVCVUtBMzZNSkpRUlBYR0VFUTJXSiIsInN1YiI6IlVBSDQyVUc2UFY1NTJQNVNXTFdUQlAzSDNTNUJIQVZDTzJJRUtFWFVBTkpYUjc1SjYzUlE1V002IiwidHlwZSI6InVzZXIiLCJuYXRzIjp7InB1YiI6e30sInN1YiI6e319fQ.kCR9Erm9zzux4G6M-V2bp7wKMKgnSNqMBACX05nwePRWQa37aO_yObbhcJWFGYjo1Ix-oepOkoyVLxOJeuD8Bw
+  ------END NATS USER JWT------
+
+************************* IMPORTANT *************************
+  NKEY Seed printed below can be used sign and prove identity.
+    NKEYs are sensitive and should be treated as secrets.
+
+  -----BEGIN USER NKEY SEED-----
+    SUAIBDPBAUTWCWBKIO6XHQNINK5FWJW4OHLXC3HQ2KFE4PEJUA44CNHTC4
+  ------END USER NKEY SEED------
+`;
+
+  const authenticator = credsAuthenticator(new TextEncoder().encode(creds));
+
+  let opts = defaultOptions();
+  opts.servers = "127.0.0.1:4222";
+  opts.user = "test";
+  opts.pass = "secret";
+  opts.token = "mytoken";
+  opts.authenticator = authenticator;
+
+  opts = parseOptions(opts);
+  assertExists(opts.authenticator);
+
+  const c = new Connect({ version, lang }, opts, "hello");
+  const cc = JSON.parse(JSON.stringify(c));
+
+  assertEquals(cc.user, opts.user);
+  assertEquals(cc.pass, opts.pass);
+  assertEquals(cc.auth_token, opts.token);
+  assertExists(cc.jwt);
+  assertExists(cc.sig);
+  assert(cc.sig.length > 0);
+  assertExists(cc.nkey);
 });


### PR DESCRIPTION
- it is now possible to specify multiple authenticators, previously this was rejected by the client.
- all generated/specified authenticators are aggregated, and their authentication results are aggregated. Note that creds and jwt authenticators write the `nkey` and `sig` properties, so if both are specified, it is important that they both use the same nkey.