### PR TITLE
[FEAT] Added json()/string() utilities to Msg and other variants

### DIFF
--- a/nats-base-client/jsmdirect_api.ts
+++ b/nats-base-client/jsmdirect_api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The NATS Authors
+ * Copyright 2022-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -27,6 +27,8 @@ import {
 } from "./types.ts";
 import { checkJsError, validateStreamName } from "./jsutil.ts";
 import { MsgHdrs } from "./headers.ts";
+import { Codec, JSONCodec } from "./codec.ts";
+import { TD } from "./encoders.ts";
 
 export class DirectStreamAPIImpl extends BaseApiClient
   implements DirectStreamAPI {
@@ -71,6 +73,7 @@ export class DirectStreamAPIImpl extends BaseApiClient
 export class DirectMsgImpl implements DirectMsg {
   data: Uint8Array;
   header: MsgHdrs;
+  static jc?: Codec<unknown>;
 
   constructor(m: Msg) {
     if (!m.headers) {
@@ -95,5 +98,16 @@ export class DirectMsgImpl implements DirectMsg {
 
   get stream(): string {
     return this.header.get(DirectMsgHeaders.Stream);
+  }
+
+  json<T = unknown>(): T {
+    if (!DirectMsgImpl.jc) {
+      DirectMsgImpl.jc = JSONCodec();
+    }
+    return DirectMsgImpl.jc.decode(this.data) as T;
+  }
+
+  string(): string {
+    return TD.decode(this.data);
   }
 }

--- a/nats-base-client/jsmsg.ts
+++ b/nats-base-client/jsmsg.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The NATS Authors
+ * Copyright 2021-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -192,5 +192,13 @@ export class JsMsgImpl implements JsMsg {
 
   term() {
     this.doAck(TERM);
+  }
+
+  json<T = unknown>(): T {
+    return this.msg.json();
+  }
+
+  string(): string {
+    return this.msg.string();
   }
 }

--- a/nats-base-client/kv.ts
+++ b/nats-base-client/kv.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 The NATS Authors
+ * Copyright 2021-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -434,30 +434,12 @@ export class Bucket implements KV, KvRemove {
   }
 
   smToEntry(sm: StoredMsg): KvEntry {
-    return {
-      bucket: this.bucket,
-      key: sm.subject.substring(this.prefixLen),
-      value: sm.data,
-      delta: 0,
-      created: sm.time,
-      revision: sm.seq,
-      operation: sm.header.get(kvOperationHdr) as OperationType || "PUT",
-      length: this.dataLen(sm.data, sm.header),
-    };
+    return new KvStoredEntryImpl(this.bucket, this.prefixLen, sm);
   }
 
   jmToEntry(jm: JsMsg): KvEntry {
     const key = this.decodeKey(jm.subject.substring(this.prefixLen));
-    return {
-      bucket: this.bucket,
-      key: key,
-      value: jm.data,
-      created: new Date(millis(jm.info.timestampNanos)),
-      revision: jm.seq,
-      operation: jm.headers?.get(kvOperationHdr) as OperationType || "PUT",
-      delta: jm.info.pending,
-      length: this.dataLen(jm.data, jm.headers),
-    } as KvEntry;
+    return new KvJsMsgEntryImpl(this.bucket, key, jm);
   }
 
   create(k: string, data: Uint8Array): Promise<number> {
@@ -918,5 +900,105 @@ export class KvStatusImpl implements KvStatus {
 
   get size(): number {
     return this.si.state.bytes;
+  }
+}
+
+class KvStoredEntryImpl implements KvEntry {
+  bucket: string;
+  sm: StoredMsg;
+  prefixLen: number;
+
+  constructor(bucket: string, prefixLen: number, sm: StoredMsg) {
+    this.bucket = bucket;
+    this.prefixLen = prefixLen;
+    this.sm = sm;
+  }
+
+  get key(): string {
+    return this.sm.subject.substring(this.prefixLen);
+  }
+
+  get value(): Uint8Array {
+    return this.sm.data;
+  }
+
+  get delta(): number {
+    return 0;
+  }
+
+  get created(): Date {
+    return this.sm.time;
+  }
+
+  get revision(): number {
+    return this.sm.seq;
+  }
+
+  get operation(): OperationType {
+    return this.sm.header.get(kvOperationHdr) as OperationType || "PUT";
+  }
+
+  get length(): number {
+    const slen = this.sm.header.get(JsHeaders.MessageSizeHdr) || "";
+    if (slen !== "") {
+      return parseInt(slen, 10);
+    }
+    return this.sm.data.length;
+  }
+
+  json<T>(): T {
+    return this.sm.json();
+  }
+
+  string(): string {
+    return this.sm.string();
+  }
+}
+
+class KvJsMsgEntryImpl implements KvEntry {
+  bucket: string;
+  key: string;
+  sm: JsMsg;
+
+  constructor(bucket: string, key: string, sm: JsMsg) {
+    this.bucket = bucket;
+    this.key = key;
+    this.sm = sm;
+  }
+
+  get value(): Uint8Array {
+    return this.sm.data;
+  }
+
+  get created(): Date {
+    return new Date(millis(this.sm.info.timestampNanos));
+  }
+
+  get revision(): number {
+    return this.sm.seq;
+  }
+
+  get operation(): OperationType {
+    return this.sm.headers?.get(kvOperationHdr) as OperationType || "PUT";
+  }
+
+  get delta(): number {
+    return this.sm.info.pending;
+  }
+
+  get length(): number {
+    const slen = this.sm.headers?.get(JsHeaders.MessageSizeHdr) || "";
+    if (slen !== "") {
+      return parseInt(slen, 10);
+    }
+    return this.sm.data.length;
+  }
+
+  json<T>(): T {
+    return this.sm.json();
+  }
+
+  string(): string {
+    return this.sm.string();
   }
 }

--- a/nats-base-client/service.ts
+++ b/nats-base-client/service.ts
@@ -130,6 +130,14 @@ export class ServiceMsgImpl implements ServiceMsg {
     opts.headers?.set(ServiceErrorHeader, description);
     return this.msg.respond(data, opts);
   }
+
+  json<T = unknown>(): T {
+    return this.msg.json();
+  }
+
+  string(): string {
+    return this.msg.string();
+  }
 }
 
 export interface ServiceGroup {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -430,6 +430,18 @@ export interface Msg {
    * @param opts
    */
   respond(data?: Uint8Array, opts?: PublishOptions): boolean;
+
+  /**
+   * Convenience method to parse the message payload as JSON. This method
+   * will throw an exception if there's a parsing error;
+   */
+  json<T>(): T;
+
+  /**
+   * Convenience method to parse the message payload as string. This method
+   * may throw an exception if there's a conversion error
+   */
+  string(): string;
 }
 
 /**
@@ -1547,6 +1559,16 @@ export interface JsMsg {
    * that the acknowledgement was received.
    */
   ackAck(): Promise<boolean>;
+  /**
+   * Convenience method to parse the message payload as JSON. This method
+   * will throw an exception if there's a parsing error;
+   */
+  json<T>(): T;
+  /**
+   * Convenience method to parse the message payload as string. This method
+   * may throw an exception if there's a conversion error
+   */
+  string(): string;
 }
 
 export interface DeliveryInfo {
@@ -1617,6 +1639,18 @@ export interface StoredMsg {
    * The time the message was received
    */
   time: Date;
+
+  /**
+   * Convenience method to parse the message payload as JSON. This method
+   * will throw an exception if there's a parsing error;
+   */
+  json<T>(): T;
+
+  /**
+   * Convenience method to parse the message payload as string. This method
+   * may throw an exception if there's a conversion error
+   */
+  string(): string;
 }
 
 export interface DirectMsg extends StoredMsg {
@@ -2587,6 +2621,18 @@ export interface KvEntry {
   delta?: number;
   operation: "PUT" | "DEL" | "PURGE";
   length: number;
+
+  /**
+   * Convenience method to parse the entry payload as JSON. This method
+   * will throw an exception if there's a parsing error;
+   */
+  json<T>(): T;
+
+  /**
+   * Convenience method to parse the entry payload as string. This method
+   * may throw an exception if there's a conversion error
+   */
+  string(): string;
 }
 
 /**

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 The NATS Authors
+ * Copyright 2020-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -1176,4 +1176,62 @@ Deno.test("basics - close promise resolves", async () => {
   }).catch((err) => {
     fail(err);
   });
+});
+
+Deno.test("basics - msg typed payload", async () => {
+  const ns = await NatsServer.start();
+  const nc = await connect({ port: ns.port });
+
+  nc.subscribe("echo", {
+    callback: (_err, msg) => {
+      msg.respond(msg.data);
+    },
+  });
+
+  assertEquals((await nc.request("echo", Empty)).string(), "");
+  assertEquals(
+    (await nc.request("echo", StringCodec().encode("hello"))).string(),
+    "hello",
+  );
+  assertEquals(
+    (await nc.request("echo", StringCodec().encode("5"))).string(),
+    "5",
+  );
+
+  await assertRejects(
+    async () => {
+      const r = await nc.request("echo", Empty);
+      r.json<number>();
+    },
+    Error,
+    "Bad JSON",
+  );
+
+  assertEquals(
+    (await nc.request("echo", JSONCodec().encode(null))).json(),
+    null,
+  );
+  assertEquals(
+    (await nc.request("echo", JSONCodec().encode(undefined))).json(),
+    null,
+  );
+  assertEquals((await nc.request("echo", JSONCodec().encode(5))).json(), 5);
+  assertEquals(
+    (await nc.request("echo", JSONCodec().encode("hello"))).json(),
+    "hello",
+  );
+  assertEquals(
+    (await nc.request("echo", JSONCodec().encode(["hello"]))).json(),
+    ["hello"],
+  );
+  assertEquals(
+    (await nc.request("echo", JSONCodec().encode({ one: "two" }))).json(),
+    { one: "two" },
+  );
+  assertEquals(
+    (await nc.request("echo", JSONCodec().encode([{ one: "two" }]))).json(),
+    [{ one: "two" }],
+  );
+
+  await cleanup(ns, nc);
 });

--- a/tests/kv_test.ts
+++ b/tests/kv_test.ts
@@ -59,6 +59,7 @@ import { Lock, NatsServer, notCompatible } from "./helpers/mod.ts";
 import { QueuedIteratorImpl } from "../nats-base-client/queued_iterator.ts";
 import { JetStreamSubscriptionInfoable } from "../nats-base-client/jsclient.ts";
 import { connect } from "../src/mod.ts";
+import { JSONCodec } from "https://deno.land/x/nats@v1.10.2/nats-base-client/codec.ts";
 
 Deno.test("kv - key validation", () => {
   const bad = [
@@ -1698,6 +1699,24 @@ Deno.test("kv - previous sequence", async () => {
     await kv.put("A", Empty, { previousSeq: 1 });
   });
   assertEquals(await kv.put("B", Empty, { previousSeq: 2 }), 5);
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - encoded entry", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  if (await notCompatible(ns, nc, "2.6.3")) {
+    return;
+  }
+  const js = nc.jetstream();
+  const kv = await js.views.kv("K");
+  await kv.put("a", StringCodec().encode("hello"));
+  await kv.put("b", JSONCodec().encode(5));
+  await kv.put("c", JSONCodec().encode(["hello", 5]));
+
+  assertEquals((await kv.get("a"))?.string(), "hello");
+  assertEquals((await kv.get("b"))?.json(), 5);
+  assertEquals((await kv.get("c"))?.json(), ["hello", 5]);
 
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
[FEAT] Added json()/string() utilities to Msg, JsMsg, KvEntry, StoredMsg, DirectMsg this allows clients to decode payloads easier while still requiring accountability on the client (as decoding can fail)

Fix #476