### PR TITLE
[FIX] malformed status created a NaN code

### DIFF
--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The NATS Authors
+ * Copyright 2020-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -143,11 +143,17 @@ export class MsgHdrsImpl implements MsgHdrs {
     const lines = s.split("\r\n");
     const h = lines[0];
     if (h !== HEADER) {
-      let str = h.replace(HEADER, "");
-      mh._code = parseInt(str, 10);
-      const scode = mh._code.toString();
-      str = str.replace(scode, "");
-      mh._description = str.trim();
+      // malformed headers could add extra space without adding a code or description
+      let str = h.replace(HEADER, "").trim();
+      if (str.length > 0) {
+        mh._code = parseInt(str, 10);
+        if (isNaN(mh._code)) {
+          mh._code = 0;
+        }
+        const scode = mh._code.toString();
+        str = str.replace(scode, "");
+        mh._description = str.trim();
+      }
     }
     if (lines.length >= 1) {
       lines.slice(1).map((s) => {

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -377,9 +377,11 @@ Deno.test("headers - malformed headers", async () => {
   const h = headers(1, "h");
   nc.publish("foo", Empty, { headers: h });
 
-  // these have extra spaces single new line insteaof crlf after the subject and after the status
   const tests: t[] = [
     {
+      // extra spaces after subject, only new line after lengths
+      // trailing space after default status - this resulted in a
+      // NaN for the code but no crash
       proto: "HPUB foo  13 15\nNATS/1.0 \r\n\r\nhi\r\n",
       expected: {
         payload: "hi",
@@ -388,6 +390,8 @@ Deno.test("headers - malformed headers", async () => {
       },
     },
     {
+      // extra spaces and pub lengths not followed by crlf
+      // status line followed by extra spaces etc
       proto: "HPUB foo  17 19\nNATS/1.0  1 H\r\n\r\nhi\r\n",
       expected: {
         payload: "hi",
@@ -403,6 +407,7 @@ Deno.test("headers - malformed headers", async () => {
       },
     },
     {
+      // this was the issue that broke java client
       proto: "HPUB foo 12 12\r\nNATS/1.0\r\n\r\n\r\n",
       expected: {
         payload: "",

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 The NATS Authors
+ * Copyright 2020-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,6 +33,7 @@ import {
 import {
   MsgHdrsImpl,
   MsgImpl,
+  NatsConnectionImpl,
   Parser,
 } from "../nats-base-client/internal_mod.ts";
 import { Publisher } from "../nats-base-client/protocol.ts";
@@ -355,5 +356,82 @@ Deno.test("headers - codec", async () => {
   assertEquals(r.headers?.code, 500);
   assertEquals(r.headers?.description, "custom status from client");
 
+  await cleanup(ns, nc);
+});
+
+Deno.test("headers - malformed headers", async () => {
+  const { ns, nc } = await setup({ debug: true }, { debug: true });
+  const nci = nc as NatsConnectionImpl;
+
+  type t = {
+    proto: string;
+    expected: {
+      payload: string;
+      code?: number;
+      description?: string;
+      key?: string;
+      value?: string;
+    };
+  };
+
+  const h = headers(1, "h");
+  nc.publish("foo", Empty, { headers: h });
+
+  // these have extra spaces single new line insteaof crlf after the subject and after the status
+  const tests: t[] = [
+    {
+      proto: "HPUB foo  13 15\nNATS/1.0 \r\n\r\nhi\r\n",
+      expected: {
+        payload: "hi",
+        code: 0,
+        description: "",
+      },
+    },
+    {
+      proto: "HPUB foo  17 19\nNATS/1.0  1 H\r\n\r\nhi\r\n",
+      expected: {
+        payload: "hi",
+        code: 1,
+        description: "H",
+      },
+    },
+    {
+      // server will convert this to msg, so no headers
+      proto: "HPUB foo 0 0\r\n\r\n",
+      expected: {
+        payload: "",
+      },
+    },
+    {
+      proto: "HPUB foo 12 12\r\nNATS/1.0\r\n\r\n\r\n",
+      expected: {
+        payload: "",
+        code: 0,
+        description: "",
+      },
+    },
+  ];
+
+  const sub = nc.subscribe("foo", { max: tests.length });
+  let i = 0;
+  const done = (async () => {
+    for await (const m of sub) {
+      const t = tests[i++];
+      assertEquals(m.string(), t.expected.payload);
+      if (typeof t.expected.code === "number") {
+        assertEquals(m.headers?.code, t.expected.code);
+        assertEquals(m.headers?.description, t.expected.description);
+        if (t.expected.key) {
+          assertEquals(m.headers?.get(t.expected.key), t.expected.value);
+        }
+      }
+    }
+  })();
+
+  tests.forEach((v) => {
+    nci.protocol.sendCommand(v.proto);
+  });
+
+  await done;
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
A malformed status line, the client tried to parse a space which would yield NaN - this is degenerate, but at least it doesn't have an unexpected code value