### PR TITLE
timestamp types were incorrectly tagged as Nanos rather than strings

### DIFF
--- a/nats-base-client/jsmdirect_api.ts
+++ b/nats-base-client/jsmdirect_api.ts
@@ -93,7 +93,11 @@ export class DirectMsgImpl implements DirectMsg {
   }
 
   get time(): Date {
-    return new Date(Date.parse(this.header.get(DirectMsgHeaders.TimeStamp)));
+    return new Date(Date.parse(this.timestamp));
+  }
+
+  get timestamp(): string {
+    return this.header.get(DirectMsgHeaders.TimeStamp);
   }
 
   get stream(): string {

--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -322,24 +322,44 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
 }
 
 export class StoredMsgImpl implements StoredMsg {
-  subject: string;
-  seq: number;
-  data: Uint8Array;
-  time: Date;
-  header: MsgHdrs;
+  _header?: MsgHdrs;
+  smr: StreamMsgResponse;
   static jc?: Codec<unknown>;
 
   constructor(smr: StreamMsgResponse) {
-    this.subject = smr.message.subject;
-    this.seq = smr.message.seq;
-    this.time = new Date(Date.parse(smr.message.time));
-    this.data = smr.message.data ? this._parse(smr.message.data) : Empty;
-    if (smr.message.hdrs) {
-      const hd = this._parse(smr.message.hdrs);
-      this.header = MsgHdrsImpl.decode(hd);
-    } else {
-      this.header = headers();
+    this.smr = smr;
+  }
+
+  get subject(): string {
+    return this.smr.message.subject;
+  }
+
+  get seq(): number {
+    return this.smr.message.seq;
+  }
+
+  get timestamp(): string {
+    return this.smr.message.time;
+  }
+
+  get time(): Date {
+    return new Date(Date.parse(this.timestamp));
+  }
+
+  get data(): Uint8Array {
+    return this.smr.message.data ? this._parse(this.smr.message.data) : Empty;
+  }
+
+  get header(): MsgHdrs {
+    if (!this._header) {
+      if (this.smr.message.hdrs) {
+        const hd = this._parse(this.smr.message.hdrs);
+        this._header = MsgHdrsImpl.decode(hd);
+      } else {
+        this._header = headers();
+      }
     }
+    return this._header;
   }
 
   _parse(s: string): Uint8Array {

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -1641,6 +1641,11 @@ export interface StoredMsg {
   time: Date;
 
   /**
+   * The raw ISO formatted date returned by the server
+   */
+  timestamp: string;
+
+  /**
    * Convenience method to parse the message payload as JSON. This method
    * will throw an exception if there's a parsing error;
    */
@@ -1760,9 +1765,9 @@ export interface StreamInfo extends ApiPaged {
    */
   config: StreamConfig;
   /**
-   * Timestamp when the stream was created
+   * The ISO Timestamp when the stream was created
    */
-  created: Nanos;
+  created: string;
   /**
    * Detail about the current State of the Stream
    */
@@ -2092,15 +2097,15 @@ export interface StreamState {
    */
   "first_seq": number;
   /**
-   * The timestamp of the first message in the Stream
+   * The ISO timestamp of the first message in the Stream
    */
-  "first_ts": number;
+  "first_ts": string;
   /**
    * Sequence number of the last message in the Stream
    */
   "last_seq": number;
   /**
-   * The timestamp of the last message in the Stream
+   * The ISO timestamp of the last message in the Stream
    */
   "last_ts": string;
   /**

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -360,7 +360,7 @@ Deno.test("headers - codec", async () => {
 });
 
 Deno.test("headers - malformed headers", async () => {
-  const { ns, nc } = await setup({ debug: true }, { debug: true });
+  const { ns, nc } = await setup();
   const nci = nc as NatsConnectionImpl;
 
   type t = {


### PR DESCRIPTION
[FIX] Added StoredMessage#timestamp returns the ISO message timestamp as provided by the server (`#time()` returns a `Date` object which will have lower precision)

[FIX] `StreamInfo.created` to be a `string` (was marked as `Nanos`), `StreamState#first_ts` to be a string.

Fixes https://github.com/nats-io/nats.js/issues/556