### PR TITLE
fixed duplicate kv/object store lists when unexpected stream types were included

### DIFF
--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -295,8 +295,8 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     const listerFilter: ListerFieldFilter<string> = (
       v: unknown,
     ): string[] => {
-      const slr = v as StreamNames;
-      return slr.streams;
+      const sr = v as StreamNames;
+      return sr.streams;
     };
     const subj = `${this.prefix}.STREAM.NAMES`;
     return new ListerImpl<string>(subj, listerFilter, this, payload);

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -1547,6 +1547,7 @@ Deno.test("jsm - list all", async () => {
   assertEquals(obs.length, 1);
   assertEquals(obs[0].bucket, `os`);
 
+  // test names as well
   const names = await (await jsm.streams.names()).next();
   assertEquals(names.length, 3);
   assertArrayIncludes(names, ["A", "KV_kv", "OBJ_os"]);

--- a/tests/jsm_test.ts
+++ b/tests/jsm_test.ts
@@ -1523,7 +1523,7 @@ Deno.test("jsm - consumer name is validated", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("jsm - list kvs", async () => {
+Deno.test("jsm - list all", async () => {
   const { ns, nc } = await setup(
     jetstreamServerConf({}, true),
   );
@@ -1532,31 +1532,24 @@ Deno.test("jsm - list kvs", async () => {
   await jsm.streams.add({ name: "A", subjects: ["a"] });
   let kvs = await jsm.streams.listKvs().next();
   assertEquals(kvs.length, 0);
+  let obs = await jsm.streams.listObjectStores().next();
+  assertEquals(obs.length, 0);
 
   const js = nc.jetstream();
-  await js.views.kv("A");
+  await js.views.os("os");
+  await js.views.kv("kv");
+
   kvs = await jsm.streams.listKvs().next();
   assertEquals(kvs.length, 1);
-  assertEquals(kvs[0].bucket, `A`);
+  assertEquals(kvs[0].bucket, `kv`);
 
-  await cleanup(ns, nc);
-});
+  obs = await jsm.streams.listObjectStores().next();
+  assertEquals(obs.length, 1);
+  assertEquals(obs[0].bucket, `os`);
 
-Deno.test("jsm - list objectstores", async () => {
-  const { ns, nc } = await setup(
-    jetstreamServerConf({}, true),
-  );
-
-  const jsm = await nc.jetstreamManager();
-  await jsm.streams.add({ name: "A", subjects: ["a"] });
-  let objs = await jsm.streams.listObjectStores().next();
-  assertEquals(objs.length, 0);
-
-  const js = nc.jetstream();
-  await js.views.os("A");
-  objs = await jsm.streams.listObjectStores().next();
-  assertEquals(objs.length, 1);
-  assertEquals(objs[0].bucket, "A");
+  const names = await (await jsm.streams.names()).next();
+  assertEquals(names.length, 3);
+  assertArrayIncludes(names, ["A", "KV_kv", "OBJ_os"]);
 
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
[FIX] Lister was filtering stream responses for objectstore and kv, but offset calculations are made as a whole. Added check of total count that lister results are not duplicated.