### PR TITLE
streams object

### DIFF
--- a/nats-base-client/consumer.ts
+++ b/nats-base-client/consumer.ts
@@ -146,7 +146,11 @@ export class PullConsumerImpl implements Consumer {
       return Promise.resolve(this._info);
     }
     const { stream_name, name } = this._info;
-    return this.api.info(stream_name, name);
+    return this.api.info(stream_name, name)
+      .then((ci) => {
+        this._info = ci;
+        return this._info;
+      });
   }
 }
 

--- a/nats-base-client/jsmstream_api.ts
+++ b/nats-base-client/jsmstream_api.ts
@@ -29,6 +29,7 @@ import {
   PurgeResponse,
   PurgeTrimOpts,
   StoredMsg,
+  Stream,
   StreamAPI,
   StreamConfig,
   StreamInfo,
@@ -50,6 +51,7 @@ import { Codec, JSONCodec } from "./codec.ts";
 import { TD } from "./encoders.ts";
 import { Feature } from "./semver.ts";
 import { NatsConnectionImpl } from "./nats.ts";
+import { StreamImpl } from "./stream.ts";
 
 export function convertStreamSourceDomain(s?: StreamSource) {
   if (s === undefined) {
@@ -318,6 +320,11 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
     };
     const subj = `${this.prefix}.STREAM.NAMES`;
     return new ListerImpl<string>(subj, listerFilter, this, payload);
+  }
+
+  async get(name: string): Promise<Stream> {
+    const si = await this.info(name);
+    return Promise.resolve(new StreamImpl(this, si));
   }
 }
 

--- a/nats-base-client/stream.ts
+++ b/nats-base-client/stream.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Consumer,
+  MsgRequest,
+  StoredMsg,
+  Stream,
+  StreamAlternate,
+  StreamAPI,
+  StreamInfo,
+  Streams,
+} from "./types.ts";
+import { StreamAPIImpl } from "./jsmstream_api.ts";
+import { ConsumerAPIImpl } from "./jsmconsumer_api.ts";
+import { OrderedConsumerOptions } from "./consumer.ts";
+import { ConsumersImpl } from "./consumers.ts";
+
+export class StreamsImpl implements Streams {
+  api: StreamAPIImpl;
+
+  constructor(api: StreamAPI) {
+    this.api = api as StreamAPIImpl;
+  }
+
+  get(stream: string): Promise<Stream> {
+    return this.api.info(stream)
+      .then((si) => {
+        return new StreamImpl(this.api, si);
+      });
+  }
+}
+
+export class StreamImpl implements Stream {
+  api: StreamAPIImpl;
+  _info: StreamInfo;
+
+  constructor(api: StreamAPI, info: StreamInfo) {
+    this.api = api as StreamAPIImpl;
+    this._info = info;
+  }
+
+  get name(): string {
+    return this._info.config.name;
+  }
+
+  alternates(): Promise<StreamAlternate[]> {
+    return this.info()
+      .then((si) => {
+        return si.alternates ? si.alternates : [];
+      });
+  }
+
+  async best(): Promise<Stream> {
+    await this.info();
+    if (this._info.alternates) {
+      const asi = await this.api.info(this._info.alternates[0].name);
+      return new StreamImpl(this.api, asi);
+    } else {
+      return this;
+    }
+  }
+
+  info(cached = false): Promise<StreamInfo> {
+    if (cached) {
+      return Promise.resolve(this._info);
+    }
+    return this.api.info(this.name)
+      .then((si) => {
+        this._info = si;
+        return this._info;
+      });
+  }
+
+  getConsumer(
+    name?: string | Partial<OrderedConsumerOptions>,
+  ): Promise<Consumer> {
+    return new ConsumersImpl(new ConsumerAPIImpl(this.api.nc, this.api.opts))
+      .get(this.name, name);
+  }
+
+  getMessage(query: MsgRequest): Promise<StoredMsg> {
+    return this.api.getMessage(this.name, query);
+  }
+}

--- a/nats-base-client/types.ts
+++ b/nats-base-client/types.ts
@@ -1070,6 +1070,15 @@ export interface JetStreamClient {
    * consumer use {@link JetStreamManager}.
    */
   consumers: Consumers;
+
+  /**
+   * Returns the interface for accessing {@link Streams}.
+   */
+  streams: Streams;
+}
+
+export interface Streams {
+  get(stream: string): Promise<Stream>;
 }
 
 export interface Consumers {
@@ -1480,6 +1489,12 @@ export interface StreamAPI {
    *  subject (can be wildcarded)
    */
   names(subject?: string): Lister<string>;
+
+  /**
+   * Returns a Stream object
+   * @param name
+   */
+  get(name: string): Promise<Stream>;
 }
 
 /**
@@ -2824,6 +2839,17 @@ export interface StreamNames {
 
 export interface StreamNameBySubject {
   subject: string;
+}
+
+export interface Stream {
+  name: string;
+  info(cached?: boolean): Promise<StreamInfo>;
+  alternates(): Promise<StreamAlternate[]>;
+  best(): Promise<Stream>;
+  getConsumer(
+    name?: string | Partial<OrderedConsumerOptions>,
+  ): Promise<Consumer>;
+  getMessage(query: MsgRequest): Promise<StoredMsg>;
 }
 
 export enum JsHeaders {

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -505,6 +505,7 @@ export class NatsServer implements PortInfo {
     conf.http = conf.http || "127.0.0.1:-1";
     conf.leafnodes = conf.leafnodes || {};
     conf.leafnodes.listen = conf.leafnodes.listen || "127.0.0.1:-1";
+    conf.server_tags = [`id:${nuid.next()}`];
 
     return conf;
   }

--- a/tests/jstest_util.ts
+++ b/tests/jstest_util.ts
@@ -19,6 +19,7 @@ import { AckPolicy, connect, nanos, PubAck } from "../src/mod.ts";
 import { assert } from "https://deno.land/std@0.177.0/testing/asserts.ts";
 import {
   ConnectionOptions,
+  Empty,
   extend,
   NatsConnection,
   nuid,
@@ -133,6 +134,7 @@ export async function createConsumer(
 export type FillOptions = {
   randomize: boolean;
   suffixes: string[];
+  payload: number;
 };
 
 export function fill(
@@ -146,6 +148,7 @@ export function fill(
   const options = Object.assign({}, {
     randomize: false,
     suffixes: "abcdefghijklmnopqrstuvwxyz".split(""),
+    payload: 0,
   }, opts) as FillOptions;
 
   function randomSuffix(): string {
@@ -153,11 +156,15 @@ export function fill(
     return options.suffixes[idx];
   }
 
+  const payload = options.payload === 0
+    ? Empty
+    : new Uint8Array(options.payload);
+
   const a = Array.from({ length: count }, (_, idx) => {
     const subj = opts.randomize
       ? `${prefix}.${randomSuffix()}`
       : `${prefix}.${options.suffixes[idx % options.suffixes.length]}`;
-    return js.publish(subj);
+    return js.publish(subj, payload);
   });
 
   return Promise.all(a);

--- a/tests/streams_test.ts
+++ b/tests/streams_test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NatsServer } from "./helpers/mod.ts";
+import { AckPolicy, connect, JSONCodec } from "../src/mod.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+} from "https://deno.land/std@0.179.0/testing/asserts.ts";
+import { assertArrayIncludes } from "https://deno.land/std@0.75.0/testing/asserts.ts";
+import {
+  cleanup,
+  initStream,
+  jetstreamServerConf,
+  setup,
+} from "./jstest_util.ts";
+
+Deno.test("streams - get", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const js = nc.jetstream();
+
+  await assertRejects(
+    async () => {
+      await js.streams.get("another");
+    },
+    Error,
+    "stream not found",
+  );
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({
+    name: "another",
+    subjects: ["a.>"],
+  });
+
+  const s = await js.streams.get("another");
+  assertExists(s);
+  assertEquals(s.name, "another");
+
+  await jsm.streams.delete("another");
+  await assertRejects(
+    async () => {
+      await s.info();
+    },
+    Error,
+    "stream not found",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("streams - mirrors", async () => {
+  const cluster = await NatsServer.jetstreamCluster(3);
+  const nc = await connect({ port: cluster[0].port });
+  const jsm = await nc.jetstreamManager();
+
+  // create a stream in a different server in the cluster
+  await jsm.streams.add({
+    name: "src",
+    subjects: ["src.*"],
+    placement: {
+      cluster: cluster[1].config.cluster.name,
+      tags: cluster[1].config.server_tags,
+    },
+  });
+
+  // create a mirror in the server we connected
+  await jsm.streams.add({
+    name: "mirror",
+    placement: {
+      cluster: cluster[2].config.cluster.name,
+      tags: cluster[2].config.server_tags,
+    },
+    mirror: {
+      name: "src",
+    },
+  });
+
+  const js = nc.jetstream();
+  const s = await js.streams.get("src");
+  assertExists(s);
+  assertEquals(s.name, "src");
+
+  const alternates = await s.alternates();
+  assertEquals(2, alternates.length);
+  assertArrayIncludes(alternates.map((a) => a.name), ["src", "mirror"]);
+
+  await assertRejects(
+    async () => {
+      await js.streams.get("another");
+    },
+    Error,
+    "stream not found",
+  );
+
+  const s2 = await s.best();
+  assertEquals(s2.name, alternates[0].name);
+
+  await nc.close();
+  await NatsServer.stopAll(cluster);
+});
+
+Deno.test("streams - consumers", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+  const js = nc.jetstream();
+
+  // add a stream and a message
+  const { stream, subj } = await initStream(nc);
+  await js.publish(subj, JSONCodec().encode({ hello: "world" }));
+
+  // retrieve the stream
+  const s = await js.streams.get(stream);
+  assertExists(s);
+  assertEquals(s.name, stream);
+
+  // get a message
+  const sm = await s.getMessage({ seq: 1 });
+  let d = sm.json<{ hello: string }>();
+  assertEquals(d.hello, "world");
+
+  // attempt to get a named consumer
+  await assertRejects(
+    async () => {
+      await s.getConsumer("a");
+    },
+    Error,
+    "consumer not found",
+  );
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.consumers.add(s.name, {
+    durable_name: "a",
+    ack_policy: AckPolicy.Explicit,
+  });
+  const c = await s.getConsumer("a");
+  const jm = await c.next();
+  assertExists(jm);
+  d = jm?.json<{ hello: string }>();
+  assertEquals(d.hello, "world");
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
[FEAT] added the ability to `get()` a stream name - this API returns an object that allows for easy access to `alternates()`, `best()` (best mirror as per nats-server), `getConsumer()` to get an existing consumer (or ordered consumer) associated with the stream, and `getMessage()` to retrieve a message manually. This functionality is already available via JSM or via the consumer's API; this provides more convenient access.