### PR TITLE
pub string

### DIFF
--- a/jetstream/jsclient.ts
+++ b/jetstream/jsclient.ts
@@ -80,6 +80,7 @@ import {
   JetStreamOptions,
   Msg,
   NatsConnection,
+  Payload,
   QueuedIterator,
   RequestOptions,
 } from "../nats-base-client/core.ts";
@@ -173,7 +174,7 @@ export class JetStreamClientImpl extends BaseApiClient
 
   async publish(
     subj: string,
-    data: Uint8Array = Empty,
+    data: Payload = Empty,
     opts?: Partial<JetStreamPublishOptions>,
   ): Promise<PubAck> {
     opts = opts || {};

--- a/jetstream/jsm.ts
+++ b/jetstream/jsm.ts
@@ -25,6 +25,7 @@ import {
   DirectStreamAPI,
   JetStreamClient,
   JetStreamManager,
+  ReviverFn,
   StoredMsg,
   StreamAPI,
 } from "./types.ts";
@@ -119,11 +120,8 @@ export class DirectMsgImpl implements DirectMsg {
     return this.header.get(DirectMsgHeaders.Stream);
   }
 
-  json<T = unknown>(): T {
-    if (!DirectMsgImpl.jc) {
-      DirectMsgImpl.jc = JSONCodec();
-    }
-    return DirectMsgImpl.jc.decode(this.data) as T;
+  json<T = unknown>(reviver?: ReviverFn): T {
+    return JSONCodec<T>(reviver).decode(this.data);
   }
 
   string(): string {

--- a/jetstream/jsmstream_api.ts
+++ b/jetstream/jsmstream_api.ts
@@ -29,6 +29,7 @@ import {
   kvPrefix,
   KvStatus,
   ObjectStoreStatus,
+  ReviverFn,
   StoredMsg,
   Stream,
   StreamAPI,
@@ -512,11 +513,8 @@ export class StoredMsgImpl implements StoredMsg {
     return bytes;
   }
 
-  json<T = unknown>(): T {
-    if (!StoredMsgImpl.jc) {
-      StoredMsgImpl.jc = JSONCodec();
-    }
-    return StoredMsgImpl.jc.decode(this.data) as T;
+  json<T = unknown>(reviver?: ReviverFn): T {
+    return JSONCodec<T>(reviver).decode(this.data);
   }
 
   string(): string {

--- a/jetstream/types.ts
+++ b/jetstream/types.ts
@@ -19,6 +19,7 @@ import {
   MsgHdrs,
   Nanos,
   NatsError,
+  Payload,
   QueuedIterator,
   Sub,
 } from "../nats-base-client/core.ts";
@@ -327,12 +328,12 @@ export interface JetStreamClient {
    * request will fail with {@link ErrorCode.NoResponders} error.
    *
    * @param subj - the subject for the message
-   * @param data - the message's data
+   * @param payload - the message's data
    * @param options - the optional message
    */
   publish(
     subj: string,
-    data?: Uint8Array,
+    payload?: Payload,
     options?: Partial<JetStreamPublishOptions>,
   ): Promise<PubAck>;
 
@@ -758,6 +759,12 @@ export interface DirectStreamAPI {
 }
 
 /**
+ * A reviver function
+ */
+//deno-lint-ignore no-explicit-any
+export type ReviverFn = (key: string, value: any) => any;
+
+/**
  * An interface representing a message that retrieved directly from JetStream.
  */
 export interface StoredMsg {
@@ -790,8 +797,9 @@ export interface StoredMsg {
   /**
    * Convenience method to parse the message payload as JSON. This method
    * will throw an exception if there's a parsing error;
+   * @param reviver
    */
-  json<T>(): T;
+  json<T>(reviver?: ReviverFn): T;
 
   /**
    * Convenience method to parse the message payload as string. This method

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -64,6 +64,7 @@ export type {
   Msg,
   Nanos,
   NatsConnection,
+  Payload,
   PublishOptions,
   RequestManyOptions,
   RequestOptions,

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -52,6 +52,7 @@ export type {
   NatsConnection,
   NKeyAuth,
   NoAuth,
+  Payload,
   Perf,
   ProtocolFilterFn,
   PublishOptions,

--- a/nats-base-client/msg.ts
+++ b/nats-base-client/msg.ts
@@ -17,6 +17,7 @@ import type { MsgArg } from "./parser.ts";
 import { Empty, TD } from "./encoders.ts";
 import { Codec, JSONCodec } from "./codec.ts";
 import { ErrorCode, Msg, MsgHdrs, NatsError, Publisher } from "./core.ts";
+import { ReviverFn } from "../jetstream/types.ts";
 
 export function isRequestError(msg: Msg): NatsError | null {
   // NATS core only considers errors 503s on messages that have no payload
@@ -99,11 +100,8 @@ export class MsgImpl implements Msg {
     return subj + reply + payloadAndHeaders;
   }
 
-  json<T = unknown>(): T {
-    if (!MsgImpl.jc) {
-      MsgImpl.jc = JSONCodec();
-    }
-    return MsgImpl.jc.decode(this.data) as T;
+  json<T = unknown>(reviver?: ReviverFn): T {
+    return JSONCodec<T>(reviver).decode(this.data);
   }
 
   string(): string {

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -41,6 +41,7 @@ import {
   JetStreamOptions,
   Msg,
   NatsConnection,
+  Payload,
   PublishOptions,
   QueuedIterator,
   RequestManyOptions,
@@ -116,14 +117,10 @@ export class NatsConnectionImpl implements NatsConnection {
 
   publish(
     subject: string,
-    data: Uint8Array = Empty,
+    data?: Payload,
     options?: PublishOptions,
   ): void {
     this._check(subject, false, true);
-    // if argument is not undefined/null and not a Uint8Array, toss
-    if (data && !(data instanceof Uint8Array)) {
-      throw NatsError.errorForCode(ErrorCode.BadPayload);
-    }
     this.protocol.publish(subject, data, options);
   }
 
@@ -166,7 +163,7 @@ export class NatsConnectionImpl implements NatsConnection {
   // - wait for unknown messages, done when an empty payload is received or timer expires (with possible alt wait)
   requestMany(
     subject: string,
-    data: Uint8Array = Empty,
+    data: Payload = Empty,
     opts: Partial<RequestManyOptions> = { maxWait: 1000, maxMessages: -1 },
   ): Promise<QueuedIterator<Msg>> {
     try {
@@ -329,7 +326,7 @@ export class NatsConnectionImpl implements NatsConnection {
 
   request(
     subject: string,
-    data: Uint8Array = Empty,
+    data?: Payload,
     opts: RequestOptions = { timeout: 1000, noMux: false },
   ): Promise<Msg> {
     try {

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { decode, Empty, encode } from "./encoders.ts";
+import { decode, Empty, encode, TE } from "./encoders.ts";
 import {
   CR_LF,
   CRLF,
@@ -45,6 +45,7 @@ import {
   Events,
   Msg,
   NatsError,
+  Payload,
   Publisher,
   PublishOptions,
   QueuedIterator,
@@ -852,9 +853,18 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
 
   publish(
     subject: string,
-    data: Uint8Array,
+    payload: Payload = Empty,
     options?: PublishOptions,
   ) {
+    let data;
+    if (payload instanceof Uint8Array) {
+      data = payload;
+    } else if (typeof payload === "string") {
+      data = TE.encode(payload);
+    } else {
+      throw NatsError.errorForCode(ErrorCode.BadPayload);
+    }
+
     let len = data.length;
     options = options || {};
     options.reply = options.reply || "";

--- a/nats-base-client/service.ts
+++ b/nats-base-client/service.ts
@@ -29,6 +29,7 @@ import {
   Nanos,
   NatsConnection,
   NatsError,
+  Payload,
   PublishOptions,
   QueuedIterator,
   Service,
@@ -84,7 +85,7 @@ export class ServiceMsgImpl implements ServiceMsg {
     return this.msg.headers;
   }
 
-  respond(data?: Uint8Array, opts?: PublishOptions): boolean {
+  respond(data?: Payload, opts?: PublishOptions): boolean {
     return this.msg.respond(data, opts);
   }
 


### PR DESCRIPTION
[FEAT] client can now publish/request/respond with strings or Uint8Array, not that JSON still requires an encoder

[FEAT] Msg#json() and related can now specify a [reviver](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#the_reviver_parameter) function for rehydrating the JSON input.