### PR TITLE
Changes to service info and stats

### DIFF
--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -926,10 +926,6 @@ export type NamedEndpointStats = {
    * Average processing_time is the total processing_time divided by the num_requests
    */
   average_processing_time: Nanos;
-  /**
-   * Endpoint Metadata
-   */
-  metadata?: Record<string, string>;
 };
 /**
  * Statistics for an endpoint

--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -819,6 +819,12 @@ export type Endpoint = {
 };
 export type EndpointOptions = Partial<Endpoint>;
 
+export type EndpointInfo = {
+  name: string;
+  subject: string;
+  metadata?: Record<string, string>;
+};
+
 export interface Dispatcher<T> {
   push(v: T): void;
 }
@@ -941,13 +947,13 @@ export type ServiceInfo = ServiceIdentity & {
    */
   description: string;
   /**
-   * Subject where the service can be invoked
-   */
-  subjects: string[];
-  /**
    * Service metadata
    */
   metadata?: Record<string, string>;
+  /**
+   * Information about the Endpoints
+   */
+  endpoints: EndpointInfo[];
 };
 export type ServiceConfig = {
   /**

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -95,6 +95,7 @@ export type {
   ConnectionOptions,
   Dispatcher,
   Endpoint,
+  EndpointInfo,
   EndpointOptions,
   EndpointStats,
   JwtAuth,

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -39,6 +39,7 @@ export type {
   Deferred,
   DispatchedFn,
   Endpoint,
+  EndpointInfo,
   EndpointOptions,
   EndpointStats,
   IngestionFilterFn,

--- a/nats-base-client/service.ts
+++ b/nats-base-client/service.ts
@@ -322,7 +322,6 @@ export class ServiceImpl implements Service {
       this.internal.push(sv);
     }
     sv.stats = new NamedEndpointStatsImpl(name, subject);
-    sv.stats.metadata = h.metadata;
 
     const callback = handler
       ? (err: NatsError | null, msg: Msg) => {
@@ -630,7 +629,6 @@ class NamedEndpointStatsImpl implements NamedEndpointStats {
       processing_time,
       last_error,
       data,
-      metadata,
     } = this;
     return {
       name,
@@ -641,7 +639,6 @@ class NamedEndpointStatsImpl implements NamedEndpointStats {
       processing_time,
       last_error,
       data,
-      metadata,
     };
   }
 

--- a/tests/helpers/service-check.ts
+++ b/tests/helpers/service-check.ts
@@ -272,10 +272,6 @@ const statsSchema: JSONSchemaType<ServiceStats> = {
           processing_time: { type: "number" },
           average_processing_time: { type: "number" },
           data: { type: "string" },
-          metadata: {
-            type: "object",
-            minProperties: 1,
-          },
         },
         required: [
           "num_requests",
@@ -284,7 +280,6 @@ const statsSchema: JSONSchemaType<ServiceStats> = {
           "processing_time",
           "average_processing_time",
           "data",
-          "metadata",
         ],
       },
     },

--- a/tests/service_test.ts
+++ b/tests/service_test.ts
@@ -852,7 +852,6 @@ Deno.test("service - metadata", async () => {
   assertEquals(info.metadata, { service: "1" });
   const stats = await srv.stats();
   assertEquals(stats.endpoints?.length, 1);
-  assertEquals(stats.endpoints?.[0].metadata, { endpoint: "endpoint" });
 
   await cleanup(ns, nc);
 });

--- a/tests/service_test.ts
+++ b/tests/service_test.ts
@@ -138,15 +138,20 @@ Deno.test("service - client", async () => {
     const info = infos[0];
     assertEquals(info.type, ServiceResponseType.INFO);
     assertEquals(info.description, srv.description);
-    assertEquals(info.subjects.length, srv.subjects.length);
-    assertArrayIncludes(info.subjects, srv.subjects);
+    assertEquals(info.endpoints.length, srv.endpoints().length);
+    assertArrayIncludes(
+      info.endpoints.map((e) => {
+        return e.subject;
+      }),
+      srv.subjects,
+    );
     const r = info as unknown as Record<string, unknown>;
     delete r.type;
     delete r.version;
     delete r.name;
     delete r.id;
     delete r.description;
-    delete r.subjects;
+    delete r.endpoints;
     assertEquals(Object.keys(r).length, 0, JSON.stringify(r));
   }
 
@@ -605,7 +610,7 @@ Deno.test("service - version must be semver", async () => {
   assertEquals(info.name, srv.name);
   assertEquals(info.version, "v1.2.3-hello");
   assertEquals(info.description, srv.description);
-  assertEquals(info.subjects.length, 0);
+  assertEquals(info.endpoints.length, 0);
 
   await cleanup(ns, nc);
 });
@@ -867,6 +872,34 @@ Deno.test("service - schema metadata", async () => {
       endpoint: "endpoint",
     },
   });
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("service - json reviver", async () => {
+  const { ns, nc } = await setup();
+  const srv = await nc.services.add({
+    name: "example",
+    version: "0.0.1",
+    metadata: { service: "1" },
+  });
+  srv.addGroup("group").addEndpoint("endpoint", {
+    handler: (_err, msg) => {
+      const d = msg.json<{ date: Date }>((k, v) => {
+        if (k === "date") {
+          return new Date(v);
+        }
+        return v;
+      });
+      assert(d.date instanceof Date);
+      msg.respond();
+    },
+    metadata: {
+      endpoint: "endpoint",
+    },
+  });
+
+  await nc.request("group.endpoint", JSONCodec().encode({ date: Date.now() }));
 
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
[CHANGE] [SRV] [BREAKING] info operation now returns endpoints instead of `subjects`. Endpoints contain not only the subject for each of the endpoints but also the associated endpoint metadata

[CHANGE] [SRV] [BREAKING] removed NamedEndpointStats#metadata reference; use `EndpointInfo#metadata` instead

