### PR TITLE
[FIX] flusher timers

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -155,6 +155,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
   servers: Servers;
   server!: ServerImpl;
   features: Features;
+  flusher?: unknown;
 
   constructor(options: ConnectionOptions, publisher: Publisher) {
     this._closed = false;
@@ -178,6 +179,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     //@ts-ignore: options.pendingLimit is hidden
     this.pendingLimit = options.pendingLimit || this.pendingLimit;
     this.features = new Features({ major: 0, minor: 0, micro: 0 });
+    this.flusher = null;
 
     const servers = typeof options.servers === "string"
       ? [options.servers]
@@ -603,10 +605,19 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.outbound.fill(buf, ...payloads);
 
     if (len === 0) {
-      setTimeout(() => {
+      //@ts-ignore: node types timer
+      this.flusher = setTimeout(() => {
         this.flushPending();
       });
     } else if (this.outbound.size() >= this.pendingLimit) {
+      // if we have a flusher, clear it - otherwise in a bench
+      // type scenario where the main loop is dominated by a publisher
+      // we create many timers.
+      if (this.flusher) {
+        //@ts-ignore: node types timer
+        clearTimeout(this.flusher);
+        this.flusher = null;
+      }
       this.flushPending();
     }
   }


### PR DESCRIPTION
When a fast producer dominates the event loop and sends more data than can fit into the outbound buffer, an inline flush happens - but on the first command sent to the server, an auto-flush is scheduled on the next event loop. The timer for this auto-schedule flush was not managed. 

In a bench-type scenario where the client is trying to send a significant amount of data, the timers accumulate, degrading the client's performance. This fix removes the scheduled timer whenever an inline flush happens, greatly improving the client's performance.
