### PR TITLE
[FIX] allow `headers_only` on the ordered consumer options for new JetStream API

### DIFF
--- a/jetstream/consumer.ts
+++ b/jetstream/consumer.ts
@@ -770,6 +770,7 @@ export type OrderedConsumerOptions = {
   opt_start_time: string;
   replay_policy: ReplayPolicy;
   inactive_threshold: number;
+  headers_only: boolean;
 };
 
 export class OrderedPullConsumerImpl implements Consumer {
@@ -823,6 +824,9 @@ export class OrderedPullConsumerImpl implements Consumer {
       num_replicas: 1,
     } as ConsumerConfig;
 
+    if (this.consumerOpts.headers_only === true) {
+      config.headers_only = true;
+    }
     if (Array.isArray(this.consumerOpts.filterSubjects)) {
       config.filter_subjects = this.consumerOpts.filterSubjects;
     }

--- a/jetstream/tests/consumersordered_test.ts
+++ b/jetstream/tests/consumersordered_test.ts
@@ -653,3 +653,18 @@ Deno.test("ordered - consume drain", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("ordered - headers only", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  const js = nc.jetstream();
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "test", subjects: ["test.*"] });
+
+  const oc = await js.consumers.get("test", { headers_only: true });
+  const ci = await oc.info();
+  assertExists(ci);
+  assertEquals(ci.config.headers_only, true);
+
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION

Fixes #541