### PR TITLE
status iterator doesn't cleanup if the iterator is stopped

### DIFF
--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -452,6 +452,10 @@ export class NatsConnectionImpl implements NatsConnection {
 
   status(): AsyncIterable<Status> {
     const iter = new QueuedIteratorImpl<Status>();
+    iter.iterClosed.then(() => {
+      const idx = this.listeners.indexOf(iter);
+      this.listeners.splice(idx, 1);
+    });
     this.listeners.push(iter);
     return iter;
   }


### PR DESCRIPTION
[FIX] pull adds a status listener on every call, and has no mechanism for removing it - this modifies it so that if the status iterator closes it is removed from the list

Fixes #546 