### PR TITLE
OS fixes

### DIFF
--- a/jetstream/objectstore.ts
+++ b/jetstream/objectstore.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { validateBucket, validateKey } from "./kv.ts";
+import { validateBucket } from "./kv.ts";
 import { Base64UrlPaddedCodec } from "../nats-base-client/base64.ts";
 import { JSONCodec } from "../nats-base-client/codec.ts";
 import { nuid } from "../nats-base-client/nuid.ts";
@@ -103,14 +103,14 @@ export class ObjectStoreStatusImpl implements ObjectStoreStatus {
   }
 }
 
-type ServerObjectStoreMeta = {
+export type ServerObjectStoreMeta = {
   name: string;
   description?: string;
   headers?: Record<string, string[]>;
   options?: ObjectStoreMetaOptions;
 };
 
-type ServerObjectInfo = {
+export type ServerObjectInfo = {
   bucket: string;
   nuid: string;
   size: number;
@@ -214,22 +214,11 @@ export class ObjectStoreImpl implements ObjectStore {
     this.js = js;
   }
 
-  _sanitizeName(name: string): { name: string; error?: Error } {
+  _checkNotEmpty(name: string): { name: string; error?: Error } {
     if (!name || name.length === 0) {
       return { name, error: new Error("name cannot be empty") };
     }
-    // cannot use replaceAll - node until node 16 is min
-    // name = name.replaceAll(".", "_");
-    // name = name.replaceAll(" ", "_");
-    name = name.replace(/[. ]/g, "_");
-
-    let error = undefined;
-    try {
-      validateKey(name);
-    } catch (err) {
-      error = err;
-    }
-    return { name, error };
+    return { name };
   }
 
   async info(name: string): Promise<ObjectInfo | null> {
@@ -255,7 +244,7 @@ export class ObjectStoreImpl implements ObjectStore {
   }
 
   async rawInfo(name: string): Promise<ServerObjectInfo | null> {
-    const { name: obj, error } = this._sanitizeName(name);
+    const { name: obj, error } = this._checkNotEmpty(name);
     if (error) {
       return Promise.reject(error);
     }
@@ -334,7 +323,7 @@ export class ObjectStoreImpl implements ObjectStore {
     meta.options.max_chunk_size = maxChunk;
 
     const old = await this.info(meta.name);
-    const { name: n, error } = this._sanitizeName(meta.name);
+    const { name: n, error } = this._checkNotEmpty(meta.name);
     if (error) {
       return Promise.reject(error);
     }
@@ -590,7 +579,7 @@ export class ObjectStoreImpl implements ObjectStore {
       return Promise.reject("bucket required");
     }
     const osi = bucket as ObjectStoreImpl;
-    const { name: n, error } = this._sanitizeName(name);
+    const { name: n, error } = this._checkNotEmpty(name);
     if (error) {
       return Promise.reject(error);
     }
@@ -606,7 +595,7 @@ export class ObjectStoreImpl implements ObjectStore {
     if (info.deleted) {
       return Promise.reject(new Error("object is deleted"));
     }
-    const { name: n, error } = this._sanitizeName(name);
+    const { name: n, error } = this._checkNotEmpty(name);
     if (error) {
       return Promise.reject(error);
     }
@@ -670,7 +659,7 @@ export class ObjectStoreImpl implements ObjectStore {
     //  effectively making the object available under 2 names, but it doesn't remove the
     //  older one.
     meta.name = meta.name ?? info.name;
-    const { name: n, error } = this._sanitizeName(meta.name);
+    const { name: n, error } = this._checkNotEmpty(meta.name);
     if (error) {
       return Promise.reject(error);
     }
@@ -773,8 +762,11 @@ export class ObjectStoreImpl implements ObjectStore {
     } catch (err) {
       return Promise.reject(err);
     }
-    const sc = Object.assign({}, opts) as StreamConfig;
+    const max_age = opts?.ttl || 0;
+    delete opts.ttl;
+    const sc = Object.assign({ max_age }, opts) as StreamConfig;
     sc.name = this.stream;
+    sc.allow_direct = true;
     sc.allow_rollup_hdrs = true;
     sc.discard = DiscardPolicy.New;
     sc.subjects = [`$O.${this.name}.C.>`, `$O.${this.name}.M.>`];

--- a/jetstream/tests/consumers_test.ts
+++ b/jetstream/tests/consumers_test.ts
@@ -1006,7 +1006,6 @@ Deno.test("consumers - next listener leaks", async () => {
 
   const consumer = await js.consumers.get("messages", "myconsumer");
 
-  let done = false;
   while (true) {
     const m = await consumer.next();
     if (m) {


### PR DESCRIPTION
[FIX] [OS] [BREAKING] previous versions of javascript objectstore encoded entry names containing periods to underbars prior to generating a metasubject storing the meta information. This is incorrect and makes such entries not accessible to other clients. This fix changes to generate proper meta subjects for such entries. - Note that bin/fix-os.ts contains a migration tool to migrate those meta entries. Please run the migration tool after backing up your objectstore.

[FIX] [OS] [CHANGE] objectstore now always set allow_direct to true on new stores

[FIX] [OS] the `ttl` option was not properly propagated to the underlying stream when specified