### PR TITLE
Fixed bug in code example

### DIFF
--- a/jetstream.md
+++ b/jetstream.md
@@ -369,7 +369,7 @@ Note that it is possible to do an automatic version of `next()` by simply
 setting the maximum number of messages to buffer to `1`:
 
 ```typescript
-const msgs = await c.consume({ max_messages: 1 });
+const messages = await c.consume({ max_messages: 1 });
 for await (const m of messages) {
   console.log(m.seq);
   m.ack();


### PR DESCRIPTION
A variable name changes from the variable assignment when calling `consume` and the variable used in the `for` loop.