### PR TITLE
reduced latency

### DIFF
--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -405,6 +405,12 @@ export interface RequestOptions {
    * The subject where the response should be sent to. Requires {@link noMux}
    */
   reply?: string;
+  /**
+   * By default, this is set to true, if set to false, the client will perform an
+   * immediate send of the network buffer, this improves latency but reduces throughput,
+   * as more OS calls will be created.
+   */
+  autoFlush?: boolean;
 }
 
 export enum RequestStrategy {
@@ -421,6 +427,12 @@ export interface RequestManyOptions {
   maxMessages?: number;
   noMux?: boolean;
   jitter?: number;
+  /**
+   * By default, this is set to true, if set to false, the client will perform an
+   * immediate send of the network buffer, this improves latency but reduces throughput,
+   * as more OS calls will be created.
+   */
+  autoFlush?: boolean;
 }
 
 export interface Stats {
@@ -784,6 +796,12 @@ export interface PublishOptions {
    * Optional headers to include with the message.
    */
   headers?: MsgHdrs;
+  /**
+   * By default, this is set to true, if set to false, the client will perform an
+   * immediate send of the network buffer, this improves latency but reduces throughput,
+   * as more OS calls will be created.
+   */
+  autoFlush?: boolean;
 }
 
 // JetStream Server Types


### PR DESCRIPTION
nats javascript library when migrated to 2.0.0 and made to support other runtimes removed the use of `setImmediate()` which was used to flush the pending buffer once the main event loop completed. This was changed to setTimeout() executing as soon as possible. In node this had a negative performance issue, as flushing waited minimum timer resolution.