### PR TITLE
optimization change to send outbound messages quicker

### DIFF
--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -604,7 +604,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     throw lastErr;
   }
 
-  async dialLoop(): Promise<void> {
+  dialLoop(): Promise<void> {
     if (this.connectPromise === null) {
       this.connectPromise = this.dodialLoop();
       this.connectPromise


### PR DESCRIPTION
change to queueMicrotask() instead of scheduling a timer for flushing - also made flush() do its work inline rather than scheduling a timer. The original node nats library performed a setImmediate(), which is not available in other runtimes.

The performance change for deno is about 7% improvement; on node the performance is up by 1200%

FIX https://github.com/nats-io/nats.js/issues/581
FIX https://github.com/nats-io/nats.js/issues/438