### PR TITLE
watcher support for all history, last values or updates as well as get notifications on deletes

### DIFF
--- a/jetstream/internal_mod.ts
+++ b/jetstream/internal_mod.ts
@@ -53,6 +53,7 @@ export type {
   KvOptions,
   KvPutOptions,
   KvStatus,
+  KvWatchInclude,
   KvWatchOptions,
   ObjectInfo,
   ObjectResult,

--- a/jetstream/mod.ts
+++ b/jetstream/mod.ts
@@ -85,6 +85,7 @@ export type {
   KvOptions,
   KvPutOptions,
   KvStatus,
+  KvWatchInclude,
   KvWatchOptions,
   LastForMsgRequest,
   Lister,

--- a/jetstream/tests/kv_test.ts
+++ b/jetstream/tests/kv_test.ts
@@ -66,7 +66,11 @@ import { QueuedIteratorImpl } from "../../nats-base-client/queued_iterator.ts";
 import { connect } from "../../src/mod.ts";
 import { JSONCodec } from "https://deno.land/x/nats@v1.10.2/nats-base-client/codec.ts";
 import { JetStreamOptions } from "../../nats-base-client/core.ts";
-import { JetStreamSubscriptionInfoable, kvPrefix } from "../types.ts";
+import {
+  JetStreamSubscriptionInfoable,
+  kvPrefix,
+  KvWatchInclude,
+} from "../types.ts";
 
 Deno.test("kv - key validation", () => {
   const bad = [
@@ -1778,5 +1782,115 @@ Deno.test("kv - metadata", async () => {
   const kv = await js.views.kv("K", { metadata: { hello: "world" } });
   const status = await kv.status();
   assertEquals(status.metadata?.hello, "world");
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - watch updates only", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+
+  const js = nc.jetstream();
+  const kv = await js.views.kv("K");
+
+  await kv.put("a", "a");
+  await kv.put("b", "b");
+
+  const d = deferred();
+  const iter = await kv.watch({
+    include: KvWatchInclude.UpdatesOnly,
+    initializedFn: () => {
+      d.resolve();
+    },
+  });
+
+  const notifications: string[] = [];
+  (async () => {
+    for await (const e of iter) {
+      notifications.push(e.key);
+    }
+  })().then();
+  await d;
+  await kv.put("c", "c");
+  await delay(1000);
+
+  assertEquals(notifications.length, 1);
+  assertEquals(notifications[0], "c");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - watch history", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+
+  const js = nc.jetstream();
+  const kv = await js.views.kv("K", { history: 10 });
+
+  await kv.put("a", "a");
+  await kv.put("a", "aa");
+  await kv.put("a", "aaa");
+  await kv.delete("a");
+
+  const iter = await kv.watch({
+    include: KvWatchInclude.AllHistory,
+  });
+
+  const notifications: string[] = [];
+  (async () => {
+    for await (const e of iter) {
+      if (e.operation === "DEL") {
+        notifications.push(`${e.key}=del`);
+      } else {
+        notifications.push(`${e.key}=${e.string()}`);
+      }
+    }
+  })().then();
+  await kv.put("c", "c");
+  await delay(1000);
+
+  assertEquals(notifications.length, 5);
+  assertEquals(notifications[0], "a=a");
+  assertEquals(notifications[1], "a=aa");
+  assertEquals(notifications[2], "a=aaa");
+  assertEquals(notifications[3], "a=del");
+  assertEquals(notifications[4], "c=c");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - watch history no deletes", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf({}, true));
+
+  const js = nc.jetstream();
+  const kv = await js.views.kv("K", { history: 10 });
+
+  await kv.put("a", "a");
+  await kv.put("a", "aa");
+  await kv.put("a", "aaa");
+  await kv.delete("a");
+
+  const iter = await kv.watch({
+    include: KvWatchInclude.AllHistory,
+    ignoreDeletes: true,
+  });
+
+  const notifications: string[] = [];
+  (async () => {
+    for await (const e of iter) {
+      if (e.operation === "DEL") {
+        notifications.push(`${e.key}=del`);
+      } else {
+        notifications.push(`${e.key}=${e.string()}`);
+      }
+    }
+  })().then();
+  await kv.put("c", "c");
+  await kv.delete("c");
+  await delay(1000);
+
+  assertEquals(notifications.length, 4);
+  assertEquals(notifications[0], "a=a");
+  assertEquals(notifications[1], "a=aa");
+  assertEquals(notifications[2], "a=aaa");
+  assertEquals(notifications[3], "c=c");
+
   await cleanup(ns, nc);
 });

--- a/jetstream/types.ts
+++ b/jetstream/types.ts
@@ -1087,6 +1087,22 @@ export interface KvRemove {
   remove(k: string): Promise<void>;
 }
 
+export enum KvWatchInclude {
+  /**
+   * Include the last value for all the keys
+   */
+  LastValue = "",
+  /**
+   * Include all available history for all keys
+   */
+  AllHistory = "history",
+  /**
+   * Don't include history or last values, only notify
+   * of updates
+   */
+  UpdatesOnly = "updates",
+}
+
 export type KvWatchOptions = {
   /**
    * A key or wildcarded key following keys as if they were NATS subject names.
@@ -1099,9 +1115,17 @@ export type KvWatchOptions = {
   /**
    * A callback that notifies when the watch has yielded all the initial values.
    * Subsequent notifications are updates since the initial watch was established.
-   * @deprecated
    */
   initializedFn?: () => void;
+  /**
+   * Skips notifying deletes.
+   * @default: false
+   */
+  ignoreDeletes?: boolean;
+  /**
+   * Specify what to include in the watcher, by default all last values.
+   */
+  include?: KvWatchInclude;
 };
 
 export interface RoKV {


### PR DESCRIPTION
[FEAT] added support for specifying whether the watcher should receive all history, last values, or updates only.
[FEAT] added support for specifying whether a watcher should get notified of deletes

Fix #573 