### PR TITLE
[FEAT] allow micro to specify a queue name

### DIFF
--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -984,6 +984,11 @@ export type ServiceConfig = {
    * Optional metadata about the service
    */
   metadata?: Record<string, string>;
+  /**
+   * Optional queue group to run the service in. By default,
+   * then queue name is "q".
+   */
+  queue?: string;
 };
 /**
  * The stats of a service

--- a/nats-base-client/service.ts
+++ b/nats-base-client/service.ts
@@ -244,9 +244,12 @@ export class ServiceImpl implements Service {
     config: ServiceConfig = { name: "", version: "" },
   ) {
     this.nc = nc;
-    this.config = config;
+    this.config = Object.assign({}, { queue: "q" }, config);
+
     // this will throw if no name
     validateName("name", this.config.name);
+    validateName("queue", this.config.queue);
+
     // this will throw if not semver
     parseSemVer(this.config.version);
     this._id = nuid.next();
@@ -314,7 +317,7 @@ export class ServiceImpl implements Service {
     internal = false,
   ): ServiceSubscription {
     // internals don't use a queue
-    const queue = internal ? "" : "q";
+    const queue = internal ? "" : this.config.queue;
     const { name, subject, handler } = h as NamedEndpoint;
     const sv = h as ServiceSubscription;
     sv.internal = internal;


### PR DESCRIPTION
This allows the same service to be deployed under different queue groups and provide for better rtt when horizontally scaling during deployments