### PR TITLE
[FIX] [CHANGE] [JETSTREAM] [OS] The field `error` in `ObjectResult` is `Error|undefined` instead of `Error|null`.

### DIFF
--- a/jetstream/types.ts
+++ b/jetstream/types.ts
@@ -1306,7 +1306,7 @@ export type ObjectStoreOptions = {
 export type ObjectResult = {
   info: ObjectInfo;
   data: ReadableStream<Uint8Array>;
-  error: Promise<Error | null>;
+  error: Promise<Error | undefined>;
 };
 export type ObjectStorePutOpts = {
   /**


### PR DESCRIPTION
ReadableStream will never yield `null`.