### PR TITLE
remove `subject_transform_dest`

### DIFF
--- a/jetstream/jsapi_types.ts
+++ b/jetstream/jsapi_types.ts
@@ -299,14 +299,7 @@ export interface StreamSource {
    */
   domain?: string;
   /**
-   * Apply a subject transform to sourced messages before doing anything else.
-   * This option is exclusive of {@link subject_transforms}.
-   * This feature only supported on 2.10.x and better.
-   */
-  subject_transform_dest?: string;
-  /**
    * Apply a subject transforms to sourced messages before doing anything else.
-   * This option is exclusive of {@link subject_transform_dest}.
    * This feature only supported on 2.10.x and better.
    */
   subject_transforms?: SubjectTransformConfig[];
@@ -575,14 +568,7 @@ export interface StreamSourceInfo {
    */
   error?: ApiError;
   /**
-   * Subject transform configuration to sourced messages before doing anything else.
-   * This option is exclusive of {@link subject_transforms}.
-   * This feature only supported on 2.10.x and better.
-   */
-  subject_transform_dest?: string;
-  /**
    * Apply a subject transforms to sourced messages before doing anything else.
-   * This option is exclusive of {@link subject_transform_dest}.
    * This feature only supported on 2.10.x and better.
    */
   subject_transforms?: SubjectTransformConfig[];

--- a/jetstream/jsmstream_api.ts
+++ b/jetstream/jsmstream_api.ts
@@ -242,16 +242,6 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
       context: string,
       src: Partial<StreamSource>,
     ): void {
-      if (src.subject_transform_dest) {
-        const { min, ok } = nci.features.get(
-          Feature.JS_STREAM_SUBJECT_TRANSFORM,
-        );
-        if (!ok) {
-          throw new Error(
-            `${context} 'subject_transform_dest' requires server ${min}`,
-          );
-        }
-      }
       const count = src.subject_transforms?.length || 0;
       if (count > 0) {
         const { min, ok } = nci.features.get(

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -4429,7 +4429,7 @@ Deno.test("jetstream - input transform", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("jetstream - source transform", async () => {
+Deno.test("jetstream - source transforms", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
@@ -4456,7 +4456,7 @@ Deno.test("jetstream - source transform", async () => {
     name: "sourced",
     storage: StorageType.Memory,
     sources: [
-      { name: "foo", subject_transform_dest: "foo2.>" },
+      { name: "foo", subject_transforms: [{ src: ">", dest: "foo2.>" }] },
       { name: "bar" },
       { name: "baz" },
     ],

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2528,23 +2528,6 @@ Deno.test("jsm - source transforms rejected on old servers", async () => {
           storage: StorageType.Memory,
           sources: [{
             name: "src",
-            subject_transform_dest: "foo-transformed.>",
-          }],
-        },
-      );
-    },
-    Error,
-    "stream sources 'subject_transform_dest' requires server 2.10.0",
-  );
-
-  await assertRejects(
-    async () => {
-      await jsm.streams.add(
-        {
-          name: "n",
-          storage: StorageType.Memory,
-          sources: [{
-            name: "src",
             subject_transforms: [
               {
                 src: "foo",


### PR DESCRIPTION
[CHANGE] remove `subject_transform_dest` from `StreamSource` and `StreamSourceInfo` - this feature is replaced with `subject_transforms`. Note this feature was never released on nats-server, and was retracted in favor of `subject_transforms`.

https://github.com/nats-io/nats-server/pull/4557