### PR TITLE
[FEAT] stream `compression` option

### DIFF
--- a/jetstream/jsapi_types.ts
+++ b/jetstream/jsapi_types.ts
@@ -240,6 +240,11 @@ export interface StreamUpdateConfig {
    * This feature only supported on 2.10.x and better.
    */
   subject_transform?: SubjectTransformConfig;
+  /**
+   * Sets the compression level of the stream. This feature is only supported in
+   * servers 2.10.x and better.
+   */
+  compression?: StoreCompression;
 }
 
 export interface Republish {
@@ -408,6 +413,17 @@ export enum ReplayPolicy {
    * Replays messages following the original delay between messages
    */
   Original = "original",
+}
+
+export enum StoreCompression {
+  /**
+   * No compression
+   */
+  None = "none",
+  /**
+   * S2 compression
+   */
+  S2 = "s2",
 }
 
 /**

--- a/jetstream/jsmstream_api.ts
+++ b/jetstream/jsmstream_api.ts
@@ -237,6 +237,12 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
         throw new Error(`stream 'subject_transform' requires server ${min}`);
       }
     }
+    if (cfg.compression) {
+      const { min, ok } = nci.features.get(Feature.JS_STREAM_COMPRESSION);
+      if (!ok) {
+        throw new Error(`stream 'compression' requires server ${min}`);
+      }
+    }
 
     function validateStreamSource(
       context: string,

--- a/nats-base-client/semver.ts
+++ b/nats-base-client/semver.ts
@@ -50,6 +50,7 @@ export enum Feature {
   JS_STREAM_FIRST_SEQ = "js_stream_first_seq",
   JS_STREAM_SUBJECT_TRANSFORM = "js_stream_subject_transform",
   JS_STREAM_SOURCE_SUBJECT_TRANSFORM = "js_stream_source_subject_transform",
+  JS_STREAM_COMPRESSION = "js_stream_compression",
 }
 
 type FeatureVersion = {
@@ -105,6 +106,7 @@ export class Features {
     this.set(Feature.JS_STREAM_FIRST_SEQ, "2.10.0");
     this.set(Feature.JS_STREAM_SUBJECT_TRANSFORM, "2.10.0");
     this.set(Feature.JS_STREAM_SOURCE_SUBJECT_TRANSFORM, "2.10.0");
+    this.set(Feature.JS_STREAM_COMPRESSION, "2.10.0");
 
     this.disabled.forEach((f) => {
       this.features.delete(f);


### PR DESCRIPTION
added configuration to support the new compression options on the store.

Fixes #594 