### PR TITLE
os changes to update and links

### DIFF
--- a/jetstream/jsclient.ts
+++ b/jetstream/jsclient.ts
@@ -127,7 +127,6 @@ class ViewsImpl implements Views {
     name: string,
     opts: Partial<ObjectStoreOptions> = {},
   ): Promise<ObjectStore> {
-    jetstreamPreview(this.js.nc);
     if (typeof crypto?.subtle?.digest !== "function") {
       return Promise.reject(
         new Error(
@@ -1027,22 +1026,3 @@ function autoAckJsMsg(data: JsMsg | null) {
     data.ack();
   }
 }
-
-const jetstreamPreview = (() => {
-  let once = false;
-  return (nci: NatsConnectionImpl) => {
-    if (!once) {
-      once = true;
-      const { lang } = nci?.protocol?.transport;
-      if (lang) {
-        console.log(
-          `\u001B[33m >> jetstream's materialized views object store functionality in ${lang} is beta functionality \u001B[0m`,
-        );
-      } else {
-        console.log(
-          `\u001B[33m >> jetstream's materialized views object store functionality is beta functionality \u001B[0m`,
-        );
-      }
-    }
-  };
-})();

--- a/jetstream/types.ts
+++ b/jetstream/types.ts
@@ -85,7 +85,7 @@ export interface PubAck {
 export interface JetStreamPublishOptions {
   /**
    * A string identifier used to detect duplicate published messages.
-   * If the msgID is reused within the streams's `duplicate_window`,
+   * If the msgID is reused within the stream's `duplicate_window`,
    * the message will be rejected by the stream, and the {@link PubAck} will
    * mark it as a `duplicate`.
    */
@@ -351,7 +351,7 @@ export interface JetStreamClient {
   pull(stream: string, consumer: string, expires?: number): Promise<JsMsg>;
 
   /**
-   * Similar to pull, but able to configure the number of messages, etc via PullOptions.
+   * Similar to pull, but able to configure the number of messages, etc. via PullOptions.
    * @param stream - the name of the stream
    * @param durable - the consumer's durable name (if durable) or name if ephemeral
    * @param opts
@@ -568,7 +568,7 @@ export interface ConsumerOptsBuilder {
   startAtTimeDelta(millis: number): this;
 
   /**
-   * Messages delivered to the consumer will not have a payload. Instead
+   * Messages delivered to the consumer will not have a payload. Instead,
    * they will have the header `Nats-Msg-Size` indicating the number of bytes
    * in the message as stored by JetStream.
    */
@@ -980,8 +980,8 @@ export interface KvLimits {
   /**
    * The maximum number of millis the key should live
    * in the KV. The server will automatically remove
-   * keys older than this amount. Note that no delete
-   * marker or notifications are performed.
+   * keys older than this amount. Note that deletion of
+   * delete markers are not performed.
    */
   ttl: number; // millis
   /**
@@ -1238,13 +1238,25 @@ export interface KvPutOptions {
 }
 
 export type ObjectStoreLink = {
-  // name of other object store
+  /**
+   * name of object store storing the data
+   */
   bucket: string;
-  // link to single object, when empty this means the whole store
+  /**
+   * link to single object, when empty this means the whole store
+   */
   name?: string;
 };
 export type ObjectStoreMetaOptions = {
+  /**
+   * If set, the object is a reference to another entry.
+   */
   link?: ObjectStoreLink;
+  /**
+   * The maximum size in bytes for each chunk.
+   * Note that if the size exceeds the maximum size of a stream
+   * entry, the number will be clamped to the streams maximum.
+   */
   max_chunk_size?: number;
 };
 export type ObjectStoreMeta = {
@@ -1256,34 +1268,99 @@ export type ObjectStoreMeta = {
 };
 
 export interface ObjectInfo extends ObjectStoreMeta {
+  /**
+   * The name of the bucket where the object is stored.
+   */
   bucket: string;
+  /**
+   * The current ID of the entries holding the data for the object.
+   */
   nuid: string;
+  /**
+   * The size in bytes of the object.
+   */
   size: number;
+  /**
+   * The number of entries storing the object.
+   */
   chunks: number;
+  /**
+   * A cryptographic checksum of the data as a whole.
+   */
   digest: string;
+  /**
+   * True if the object was deleted.
+   */
   deleted: boolean;
+  /**
+   * An UTC timestamp
+   */
   mtime: string;
+  /**
+   * The revision number for the entry
+   */
   revision: number;
 }
 
+/**
+ * A link reference
+ */
 export interface ObjectLink {
+  /**
+   * The object store the source data
+   */
   bucket: string;
+  /**
+   * The name of the entry holding the data. If not
+   * set it is a complete object store reference.
+   */
   name?: string;
 }
 
 export type ObjectStoreStatus = {
+  /**
+   * The bucket name
+   */
   bucket: string;
+  /**
+   * the description associated with the object store.
+   */
   description: string;
+  /**
+   * The time to live for entries in the object store in nanoseconds.
+   * Convert to millis using the `millis()` function.
+   */
   ttl: Nanos;
+  /**
+   * The object store's underlying stream storage type.
+   */
   storage: StorageType;
+  /**
+   * The number of replicas associated with this object store.
+   */
   replicas: number;
+  /**
+   * Set to true if the object store is sealed and will reject edits.
+   */
   sealed: boolean;
+  /**
+   * The size in bytes that the object store occupies.
+   */
   size: number;
+  /**
+   * The underlying storage for the object store. Currently, this always
+   * returns "JetStream".
+   */
   backingStore: string;
   /**
    * The StreamInfo backing up the ObjectStore
    */
   streamInfo: StreamInfo;
+  /**
+   * Metadata the object store. Note that
+   * keys starting with `_nats` are reserved. This feature only supported on servers
+   * 2.10.x and better.
+   */
   metadata?: Record<string, string> | undefined;
 };
 /**
@@ -1291,11 +1368,31 @@ export type ObjectStoreStatus = {
  */
 export type ObjectStoreInfo = ObjectStoreStatus;
 export type ObjectStoreOptions = {
+  /**
+   * A description for the object store
+   */
   description?: string;
+  /**
+   * The time to live for entries in the object store specified
+   * as nanoseconds. Use the `nanos()` function to convert millis to
+   * nanos.
+   */
   ttl?: Nanos;
+  /**
+   * The underlying stream storage type for the object store.
+   */
   storage: StorageType;
+  /**
+   * The number of replicas to create.
+   */
   replicas: number;
+  /**
+   * The maximum amount of data that the object store should store in bytes.
+   */
   "max_bytes": number;
+  /**
+   * Placement hints for the underlying object store stream
+   */
   placement: Placement; /**
    * Metadata field to store additional information about the stream. Note that
    * keys starting with `_nats` are reserved. This feature only supported on servers
@@ -1303,9 +1400,23 @@ export type ObjectStoreOptions = {
    */
   metadata?: Record<string, string>;
 };
+/**
+ * An object that allows reading the object stored under a specified name.
+ */
 export type ObjectResult = {
+  /**
+   * The info of the object that was retrieved.
+   */
   info: ObjectInfo;
+  /**
+   * The readable stream where you can read the data.
+   */
   data: ReadableStream<Uint8Array>;
+  /**
+   * A promise that will resolve to an error if the readable stream failed
+   * to process the entire response. Should be checked when the readable stream
+   * has finished yielding data.
+   */
   error: Promise<Error | null>;
 };
 export type ObjectStorePutOpts = {
@@ -1322,32 +1433,76 @@ export type ObjectStorePutOpts = {
 };
 
 export interface ObjectStore {
+  /**
+   * Returns the ObjectInfo of the named entry. Or null if the
+   * entry doesn't exist.
+   * @param name
+   */
   info(name: string): Promise<ObjectInfo | null>;
-
+  /**
+   * Returns a list of the entries in the ObjectStore
+   */
   list(): Promise<ObjectInfo[]>;
-
+  /**
+   * Returns an object you can use for reading the data from the
+   * named stored object or null if the entry doesn't exist.
+   * @param name
+   */
   get(name: string): Promise<ObjectResult | null>;
-
+  /**
+   * Returns the data stored for the named entry.
+   * @param name
+   */
   getBlob(name: string): Promise<Uint8Array | null>;
-
+  /**
+   * Adds an object to the store with the specified meta
+   * and using the specified ReadableStream to stream the data.
+   * @param meta
+   * @param rs
+   * @param opts
+   */
   put(
     meta: ObjectStoreMeta,
     rs: ReadableStream<Uint8Array>,
     opts?: ObjectStorePutOpts,
   ): Promise<ObjectInfo>;
-
+  /**
+   * Puts the specified bytes into the store with the specified meta.
+   * @param meta
+   * @param data
+   * @param opts
+   */
   putBlob(
     meta: ObjectStoreMeta,
     data: Uint8Array | null,
     opts?: ObjectStorePutOpts,
   ): Promise<ObjectInfo>;
-
+  /**
+   * Deletes the specified entry from the object store.
+   * @param name
+   */
   delete(name: string): Promise<PurgeResponse>;
 
+  /**
+   * Adds a link to another object in the same store or a different one.
+   * Note that links of links are rejected.
+   * object.
+   * @param name
+   * @param meta
+   */
   link(name: string, meta: ObjectInfo): Promise<ObjectInfo>;
 
+  /**
+   * Add a link to another object store
+   * @param name
+   * @param bucket
+   */
   linkStore(name: string, bucket: ObjectStore): Promise<ObjectInfo>;
-
+  /**
+   * Watch an object store and receive updates of modifications via
+   * an iterator.
+   * @param opts
+   */
   watch(
     opts?: Partial<
       {
@@ -1356,13 +1511,26 @@ export interface ObjectStore {
       }
     >,
   ): Promise<QueuedIterator<ObjectInfo | null>>;
-
+  /**
+   * Seals the object store preventing any further modifications.
+   */
   seal(): Promise<ObjectStoreStatus>;
-
+  /**
+   * Returns the runtime status of the object store.
+   * @param opts
+   */
   status(opts?: Partial<StreamInfoRequestOptions>): Promise<ObjectStoreStatus>;
 
+  /**
+   * Update the metadata for an object. If the name is modified, the object
+   * is effectively renamed and will only be accessible by its new name.
+   * @param name
+   * @param meta
+   */
   update(name: string, meta: Partial<ObjectStoreMeta>): Promise<PubAck>;
-
+  /**
+   * Destroys the object store and all its entries.
+   */
   destroy(): Promise<boolean>;
 }
 


### PR DESCRIPTION
[JETSTREAM] [OS] [CHANGE] The `update()` method will now delete the previous meta for an object - previously, it reused the storage of the entry - this matched the original go client implementation.

[JETSTREAM] [OS] [CHANGE] links now always store link metadata - previously, if, on the same object store, it would duplicate the source metadata entry.

[JETSTREAM] [OS] [FIX] links of links are now rejected

[DOC] added documentation on the object store API