### PR TITLE
[FEAT] consumer limits

### DIFF
--- a/jetstream/jsapi_types.ts
+++ b/jetstream/jsapi_types.ts
@@ -265,8 +265,9 @@ export interface StreamUpdateConfig {
    */
   compression?: StoreCompression;
   /**
-   * The default consumer limits applied to consumers that don't specify limits
-   * for `inactive_threshold` or `max_ack_pending`.
+   * The consumer limits applied to consumers that don't specify limits
+   * for `inactive_threshold` or `max_ack_pending`. Note that these limits
+   * become an upper bound for all clients.
    */
   "consumer_limits"?: StreamConsumerLimits;
 }

--- a/jetstream/jsapi_types.ts
+++ b/jetstream/jsapi_types.ts
@@ -102,6 +102,25 @@ export interface SubjectTransformConfig {
   dest: string;
 }
 
+/**
+ * Sets default consumer limits for inactive_threshold and max_ack_pending
+ * to consumers of this stream that don't specify specific values.
+ * This functionality requires a server 2.10.x or better.
+ */
+export interface StreamConsumerLimits {
+  /**
+   * The default `inactive_threshold` applied to consumers.
+   * This value is specified in nanoseconds. Pleause use the `nanos()`
+   * function to convert between millis and nanoseconds. Or `millis()`
+   * to convert a nanosecond value to millis.
+   */
+  "inactive_threshold"?: Nanos;
+  /**
+   * The default `max_ack_pending` applied to consumers of the stream.
+   */
+  "max_ack_pending"?: number;
+}
+
 export interface StreamConfig extends StreamUpdateConfig {
   /**
    * A unique name for the Stream
@@ -239,12 +258,17 @@ export interface StreamUpdateConfig {
    * Apply a subject transform to incoming messages before doing anything else.
    * This feature only supported on 2.10.x and better.
    */
-  subject_transform?: SubjectTransformConfig;
+  "subject_transform"?: SubjectTransformConfig;
   /**
    * Sets the compression level of the stream. This feature is only supported in
    * servers 2.10.x and better.
    */
   compression?: StoreCompression;
+  /**
+   * The default consumer limits applied to consumers that don't specify limits
+   * for `inactive_threshold` or `max_ack_pending`.
+   */
+  "consumer_limits"?: StreamConsumerLimits;
 }
 
 export interface Republish {

--- a/jetstream/jsmstream_api.ts
+++ b/jetstream/jsmstream_api.ts
@@ -243,6 +243,12 @@ export class StreamAPIImpl extends BaseApiClient implements StreamAPI {
         throw new Error(`stream 'compression' requires server ${min}`);
       }
     }
+    if (cfg.consumer_limits) {
+      const { min, ok } = nci.features.get(Feature.JS_DEFAULT_CONSUMER_LIMITS);
+      if (!ok) {
+        throw new Error(`stream 'consumer_limits' requires server ${min}`);
+      }
+    }
 
     function validateStreamSource(
       context: string,

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -2589,3 +2589,63 @@ Deno.test("jsm - stream compression", async () => {
 
   await cleanup(ns, nc);
 });
+
+Deno.test("jsm - stream consumer limits", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  if (await notCompatible(ns, nc, "2.10.0")) {
+    return;
+  }
+
+  const jsm = await nc.jetstreamManager();
+  let si = await jsm.streams.add({
+    name: "map",
+    subjects: ["foo"],
+    storage: StorageType.Memory,
+    consumer_limits: {
+      max_ack_pending: 20,
+      inactive_threshold: nanos(60_000),
+    },
+  });
+  assertEquals(si.config.consumer_limits?.max_ack_pending, 20);
+  assertEquals(si.config.consumer_limits?.inactive_threshold, nanos(60_000));
+
+  let ci = await jsm.consumers.add("map", { durable_name: "map" });
+  assertEquals(ci.config.max_ack_pending, 20);
+  assertEquals(ci.config.inactive_threshold, nanos(60_000));
+
+  si = await jsm.streams.update("map", {
+    consumer_limits: {
+      max_ack_pending: 200,
+      inactive_threshold: nanos(120_000),
+    },
+  });
+  assertEquals(si.config.consumer_limits?.max_ack_pending, 200);
+  assertEquals(si.config.consumer_limits?.inactive_threshold, nanos(120_000));
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("jsm - stream consumer limits rejected on old servers", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  const nci = nc as NatsConnectionImpl;
+  nci.features.update("2.9.0");
+  nci.info!.version = "2.9.0";
+
+  const jsm = await nc.jetstreamManager();
+  await assertRejects(
+    async () => {
+      await jsm.streams.add({
+        name: "map",
+        subjects: ["foo"],
+        storage: StorageType.Memory,
+        consumer_limits: {
+          max_ack_pending: 20,
+          inactive_threshold: nanos(60_000),
+        },
+      });
+    },
+    Error,
+    "stream 'consumer_limits' requires server 2.10.0",
+  );
+  await cleanup(ns, nc);
+});

--- a/nats-base-client/semver.ts
+++ b/nats-base-client/semver.ts
@@ -51,6 +51,7 @@ export enum Feature {
   JS_STREAM_SUBJECT_TRANSFORM = "js_stream_subject_transform",
   JS_STREAM_SOURCE_SUBJECT_TRANSFORM = "js_stream_source_subject_transform",
   JS_STREAM_COMPRESSION = "js_stream_compression",
+  JS_DEFAULT_CONSUMER_LIMITS = "js_default_consumer_limits",
 }
 
 type FeatureVersion = {
@@ -107,6 +108,7 @@ export class Features {
     this.set(Feature.JS_STREAM_SUBJECT_TRANSFORM, "2.10.0");
     this.set(Feature.JS_STREAM_SOURCE_SUBJECT_TRANSFORM, "2.10.0");
     this.set(Feature.JS_STREAM_COMPRESSION, "2.10.0");
+    this.set(Feature.JS_DEFAULT_CONSUMER_LIMITS, "2.10.0");
 
     this.disabled.forEach((f) => {
       this.features.delete(f);


### PR DESCRIPTION
[FEAT] [JETSTREAM] added support for `consumer_limits` on stream create/update configurations - this feature enables the stream to provide a default assigned to consumers when values are not specified.