### PR TITLE
[FEAT] sync subscription utility

### DIFF
--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -705,6 +705,29 @@ export interface Msg {
   string(): string;
 }
 
+export type SyncIterator<T> = {
+  next(): Promise<T | null>;
+};
+
+/**
+ * syncIterator is a utility function that allows an AsyncIterator to be triggered
+ * by calling next() - the utility will yield null if the underlying iterator is closed.
+ * Note it is possibly an error to call use this function on an AsyncIterable that has
+ * already been started (Symbol.asyncIterator() has been called) from a looping construct.
+ */
+export function syncIterator<T>(src: AsyncIterable<T>): SyncIterator<T> {
+  const iter = src[Symbol.asyncIterator]();
+  return {
+    async next(): Promise<T | null> {
+      const m = await iter.next();
+      if (m.done) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(m.value);
+    },
+  };
+}
+
 /**
  * Basic interface to a Subscription type
  */

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -30,13 +30,13 @@ export {
 export type { Codec } from "./codec.ts";
 export { JSONCodec, StringCodec } from "./codec.ts";
 export * from "./nkeys.ts";
-export type { DispatchedFn } from "./queued_iterator.ts";
-export { QueuedIteratorImpl } from "./queued_iterator.ts";
 export type {
+  DispatchedFn,
   IngestionFilterFn,
   IngestionFilterFnResult,
   ProtocolFilterFn,
 } from "./queued_iterator.ts";
+export { QueuedIteratorImpl } from "./queued_iterator.ts";
 export type { ParserEvent } from "./parser.ts";
 export { Kind, Parser, State } from "./parser.ts";
 export { DenoBuffer, MAX_SIZE, readAll, writeAll } from "./denobuffer.ts";
@@ -61,35 +61,6 @@ export { Empty } from "./types.ts";
 export { extractProtocolMessage } from "./transport.ts";
 
 export type {
-  Msg,
-  Nanos,
-  NatsConnection,
-  Payload,
-  PublishOptions,
-  RequestManyOptions,
-  RequestOptions,
-  ReviverFn,
-  Server,
-  ServerInfo,
-  ServersChanged,
-  Stats,
-  Status,
-  Sub,
-  SubOpts,
-  Subscription,
-  SubscriptionOptions,
-} from "./core.ts";
-
-export {
-  DebugEvents,
-  Events,
-  RequestStrategy,
-  ServiceResponseType,
-} from "./core.ts";
-
-export { ServiceErrorCodeHeader, ServiceErrorHeader } from "./core.ts";
-
-export type {
   ApiError,
   Auth,
   Authenticator,
@@ -100,12 +71,23 @@ export type {
   EndpointOptions,
   EndpointStats,
   JwtAuth,
+  Msg,
   MsgHdrs,
   NamedEndpointStats,
+  Nanos,
+  NatsConnection,
   NKeyAuth,
   NoAuth,
+  Payload,
+  PublishOptions,
   QueuedIterator,
   Request,
+  RequestManyOptions,
+  RequestOptions,
+  ReviverFn,
+  Server,
+  ServerInfo,
+  ServersChanged,
   Service,
   ServiceConfig,
   ServiceGroup,
@@ -117,18 +99,31 @@ export type {
   ServiceResponse,
   ServicesAPI,
   ServiceStats,
+  Stats,
+  Status,
+  Sub,
+  SubOpts,
+  Subscription,
+  SubscriptionOptions,
+  SyncIterator,
   TlsOptions,
   TokenAuth,
   UserPass,
 } from "./core.ts";
 export {
   createInbox,
+  DebugEvents,
   ErrorCode,
+  Events,
   isNatsError,
   Match,
   NatsError,
+  RequestStrategy,
   ServiceError,
+  ServiceErrorCodeHeader,
+  ServiceErrorHeader,
+  ServiceResponseType,
+  ServiceVerb,
+  syncIterator,
 } from "./core.ts";
-export { SubscriptionImpl } from "./protocol.ts";
-export { Subscriptions } from "./protocol.ts";
-export { ServiceVerb } from "./core.ts";
+export { SubscriptionImpl, Subscriptions } from "./protocol.ts";

--- a/nats-base-client/mod.ts
+++ b/nats-base-client/mod.ts
@@ -27,6 +27,7 @@ export {
   ServiceResponseType,
   ServiceVerb,
   StringCodec,
+  syncIterator,
   tokenAuthenticator,
   usernamePasswordAuthenticator,
 } from "./internal_mod.ts";
@@ -83,6 +84,7 @@ export type {
   SubOpts,
   Subscription,
   SubscriptionOptions,
+  SyncIterator,
   TlsOptions,
   TokenAuth,
   TypedCallback,

--- a/nats-base-client/queued_iterator.ts
+++ b/nats-base-client/queued_iterator.ts
@@ -66,6 +66,7 @@ export class QueuedIteratorImpl<T> implements QueuedIterator<T> {
   _data?: unknown; //data is for use by extenders in any way they like
   err?: Error;
   time: number;
+  yielding: boolean;
 
   constructor() {
     this.inflight = 0;
@@ -79,6 +80,7 @@ export class QueuedIteratorImpl<T> implements QueuedIterator<T> {
     this.yields = [];
     this.iterClosed = deferred<void>();
     this.time = 0;
+    this.yielding = false;
   }
 
   [Symbol.asyncIterator]() {
@@ -111,6 +113,10 @@ export class QueuedIteratorImpl<T> implements QueuedIterator<T> {
     if (this.noIterator) {
       throw new NatsError("unsupported iterator", ErrorCode.ApiError);
     }
+    if (this.yielding) {
+      throw new NatsError("already yielding", ErrorCode.ApiError);
+    }
+    this.yielding = true;
     try {
       while (true) {
         if (this.yields.length === 0) {

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -55,6 +55,7 @@ import {
   SubscriptionImpl,
 } from "../nats-base-client/internal_mod.ts";
 import { Feature } from "../nats-base-client/semver.ts";
+import { syncIterator } from "../nats-base-client/core.ts";
 
 Deno.test("basics - connect port", async () => {
   const ns = await NatsServer.start();
@@ -1358,6 +1359,24 @@ Deno.test("basics - json reviver", async () => {
 
   assert(d.date instanceof Date);
   assert(typeof d.auth === "string");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("basics - sync subscription", async () => {
+  const { ns, nc } = await setup();
+  const subj = nuid.next();
+
+  const sub = nc.subscribe(subj);
+  const sync = syncIterator(sub);
+  nc.publish(subj);
+
+  let m = await sync.next();
+  assertExists(m);
+
+  sub.unsubscribe();
+  m = await sync.next();
+  assertEquals(m, null);
 
   await cleanup(ns, nc);
 });


### PR DESCRIPTION
[FEAT] added a utility function `syncIterator()` to wrap an `AsyncIterables` so that elements can be extracted in a `sync` faction. Note messages and elements will continue to buffer in the iterable, so if you don't drain it or stop its source memory will grow - this is syntactic sugar, as the iterator can be had via `src[Symbol.asyncIterator]()`. This can be useful to process subscription messages one at a time; this is especially true on tests.

```javascript
const sub = nc.subscribe("foo");
nc.publish("foo");
nc.publish("foo");
const sync = syncIterator(sub);
console.log((await sync.next()).subject);
console.log((await sync.next()).subject);
```