### PR TITLE
Fix 586

### DIFF
--- a/jetstream/jsm.ts
+++ b/jetstream/jsm.ts
@@ -100,11 +100,11 @@ export class DirectMsgImpl implements DirectMsg {
   }
 
   get subject(): string {
-    return this.header.get(DirectMsgHeaders.Subject);
+    return this.header.last(DirectMsgHeaders.Subject);
   }
 
   get seq(): number {
-    const v = this.header.get(DirectMsgHeaders.Sequence);
+    const v = this.header.last(DirectMsgHeaders.Sequence);
     return typeof v === "string" ? parseInt(v) : 0;
   }
 
@@ -113,11 +113,11 @@ export class DirectMsgImpl implements DirectMsg {
   }
 
   get timestamp(): string {
-    return this.header.get(DirectMsgHeaders.TimeStamp);
+    return this.header.last(DirectMsgHeaders.TimeStamp);
   }
 
   get stream(): string {
-    return this.header.get(DirectMsgHeaders.Stream);
+    return this.header.last(DirectMsgHeaders.Stream);
   }
 
   json<T = unknown>(reviver?: ReviverFn): T {

--- a/jetstream/tests/consumers_test.ts
+++ b/jetstream/tests/consumers_test.ts
@@ -19,13 +19,7 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "https://deno.land/std@0.200.0/assert/mod.ts";
-import {
-  deferred,
-  Empty,
-  NatsConnection,
-  nuid,
-  StringCodec,
-} from "../../nats-base-client/mod.ts";
+import { deferred, Empty, StringCodec } from "../../nats-base-client/mod.ts";
 import {
   AckPolicy,
   Consumer,

--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -384,6 +384,8 @@ export interface MsgHdrs extends Iterable<[string, string[]]> {
   values(k: string, match?: Match): string[];
 
   delete(k: string, match?: Match): void;
+
+  last(k: string, match?: Match): string;
 }
 
 export interface RequestOptions {

--- a/nats-base-client/headers.ts
+++ b/nats-base-client/headers.ts
@@ -217,6 +217,17 @@ export class MsgHdrsImpl implements MsgHdrs {
     return "";
   }
 
+  last(k: string, match = Match.Exact): string {
+    const keys = this.findKeys(k, match);
+    if (keys.length) {
+      const v = this.headers.get(keys[0]);
+      if (v) {
+        return Array.isArray(v) ? v[v.length - 1] : v;
+      }
+    }
+    return "";
+  }
+
   has(k: string, match = Match.Exact): boolean {
     return this.findKeys(k, match).length > 0;
   }

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -14,7 +14,6 @@
  */
 import {
   assert,
-  assertAlmostEquals,
   assertEquals,
   fail,
 } from "https://deno.land/std@0.200.0/assert/mod.ts";


### PR DESCRIPTION
[FEAT] added `last()` to MsgHdrs to retrieve the last header value if multiple headers share the same name.

[FIX] changed direct header implementation to read last header value instead of first. If message was republished, the last header value will be the correct one for the message

Fix #586