### PR TITLE
prevent consumer deleted from stopping iterator

### DIFF
--- a/jetstream/consumer.ts
+++ b/jetstream/consumer.ts
@@ -171,6 +171,13 @@ export enum ConsumerEvents {
   ConsumerNotFound = "consumer_not_found",
 
   /**
+   * Notification that the consumer was deleted. This notification
+   * means the consumer will not get messages unless it is recreated. The client
+   * will continue to attempt to pull messages. Ordered consumer will recreate it.
+   */
+  ConsumerDeleted = "consumer_deleted",
+
+  /**
    * This notification is specific of ordered consumers and will be notified whenever
    * the consumer is recreated. The argument is the name of the newly created consumer.
    */
@@ -358,8 +365,10 @@ export class PullConsumerMessagesImpl extends QueuedIteratorImpl<JsMsg>
                 this.stop(error);
               });
             } else if (code === 409 && description === "consumer deleted") {
-              const error = toErr();
-              this.stop(error);
+              this.notify(
+                ConsumerEvents.ConsumerDeleted,
+                `${code} ${description}`,
+              );
             } else {
               this.notify(
                 ConsumerDebugEvents.DebugEvent,


### PR DESCRIPTION
[FIX] changed consumer so that a server consumer_deleted notification doesn't stop the iterator. The consumer will notify the condition, and continue to re-attempt to retrieve messages.