### PR TITLE
Allow downstream implementations of url parse to know whether we are connected securely or not

### DIFF
--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -1422,7 +1422,7 @@ export interface Base {
 }
 
 export interface URLParseFn {
-  (u: string): string;
+  (u: string, encrypted?: boolean): string;
 }
 
 export enum ServiceVerb {

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -802,7 +802,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     this.info = info;
     const updates = this.options && this.options.ignoreClusterUpdates
       ? undefined
-      : this.servers.update(info);
+      : this.servers.update(info, this.transport.isEncrypted());
     if (!this.infoReceived) {
       this.features.update(parseSemVer(info.version));
       this.infoReceived = true;

--- a/nats-base-client/servers.ts
+++ b/nats-base-client/servers.ts
@@ -282,7 +282,7 @@ export class Servers {
     return this.servers;
   }
 
-  update(info: ServerInfo): ServersChanged {
+  update(info: ServerInfo, encrypted?: boolean): ServersChanged {
     const added: string[] = [];
     let deleted: string[] = [];
 
@@ -290,7 +290,7 @@ export class Servers {
     const discovered = new Map<string, ServerImpl>();
     if (info.connect_urls && info.connect_urls.length > 0) {
       info.connect_urls.forEach((hp) => {
-        hp = urlParseFn ? urlParseFn(hp) : hp;
+        hp = urlParseFn ? urlParseFn(hp, encrypted) : hp;
         const s = new ServerImpl(hp, true);
         discovered.set(hp, s);
       });


### PR DESCRIPTION
[FIX] on websocket rewriting of the urls requires additional information, added a hint to the url parse which designates whether gossiped URLs should be ws or wss based on current transport rather than on other heuristics.