### PR TITLE
allow internal kv watch consumer to use filtered consumer api

### DIFF
--- a/jetstream/jsclient.ts
+++ b/jetstream/jsclient.ts
@@ -105,7 +105,6 @@ export enum PubHeaders {
 
 class ViewsImpl implements Views {
   js: JetStreamClientImpl;
-  jsm?: JetStreamManager;
   constructor(js: JetStreamClientImpl) {
     this.js = js;
   }

--- a/jetstream/tests/kv_test.ts
+++ b/jetstream/tests/kv_test.ts
@@ -2048,13 +2048,6 @@ Deno.test("kv - watcher will name and filter", async () => {
 
   const js = nc.jetstream();
   const kv = await js.views.kv("A");
-  await Promise.all([
-    kv.put("a.b", "2"),
-    kv.put("a.cc", "3"),
-    kv.put("b.a", "3"),
-    kv.put("b.b", "3"),
-    kv.put("b.c", "3"),
-  ]);
 
   const sub = syncIterator(nc.subscribe("$JS.API.>"));
   const iter = await kv.watch({ key: "a.>" });

--- a/jetstream/tests/kv_test.ts
+++ b/jetstream/tests/kv_test.ts
@@ -26,6 +26,7 @@ import {
   parseSemVer,
   QueuedIterator,
   StringCodec,
+  syncIterator,
 } from "../../nats-base-client/internal_mod.ts";
 
 import {
@@ -2033,6 +2034,37 @@ Deno.test("kv - bind no info", async () => {
   d.resolve();
   // shouldn't have rejected earlier
   await d;
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("kv - watcher will name and filter", async () => {
+  const { ns, nc } = await setup(
+    jetstreamServerConf({}, true),
+  );
+  if (await notCompatible(ns, nc, "2.6.3")) {
+    return;
+  }
+
+  const js = nc.jetstream();
+  const kv = await js.views.kv("A");
+  await Promise.all([
+    kv.put("a.b", "2"),
+    kv.put("a.cc", "3"),
+    kv.put("b.a", "3"),
+    kv.put("b.b", "3"),
+    kv.put("b.c", "3"),
+  ]);
+
+  const sub = syncIterator(nc.subscribe("$JS.API.>"));
+  const iter = await kv.watch({ key: "a.>" });
+
+  const m = await sub.next();
+  console.log(m?.subject);
+  assert(m?.subject.startsWith("$JS.API.CONSUMER.CREATE.KV_A."));
+  assert(m?.subject.endsWith("$KV.A.a.>"));
+
+  iter.stop();
 
   await cleanup(ns, nc);
 });

--- a/jetstream/tests/kv_test.ts
+++ b/jetstream/tests/kv_test.ts
@@ -2060,7 +2060,6 @@ Deno.test("kv - watcher will name and filter", async () => {
   const iter = await kv.watch({ key: "a.>" });
 
   const m = await sub.next();
-  console.log(m?.subject);
   assert(m?.subject.startsWith("$JS.API.CONSUMER.CREATE.KV_A."));
   assert(m?.subject.endsWith("$KV.A.a.>"));
 

--- a/jetstream/types.ts
+++ b/jetstream/types.ts
@@ -749,6 +749,12 @@ export interface ConsumerOptsBuilder {
    * When set do not inherit the replica count from the stream but specifically set it to this amount
    */
   numReplicas(n: number): this;
+
+  /**
+   * The name of the consumer
+   * @param n
+   */
+  consumerName(n: string): this;
 }
 
 /**
@@ -1893,6 +1899,11 @@ export class ConsumerOptsBuilderImpl implements ConsumerOptsBuilder {
 
   numReplicas(n: number) {
     this.config.num_replicas = n;
+    return this;
+  }
+
+  consumerName(n: string) {
+    this.config.name = n;
     return this;
   }
 }


### PR DESCRIPTION
[FIX] changed KV ordered consumers created by watch, to set `name` if supported by the server. This enables the client to be able to use the newer consumer APIs which can then be clamped down with permissions on filter

[FIX] removed unused JSM reference in the Views implementation