### PR TITLE
[CHANGE] [JS] [CONSUMERS] fetch()/next() can fail on consumer/stream errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.10.3" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.10.12" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
 #      - name: Add hosts to /etc/hosts

--- a/jetstream/consumer.ts
+++ b/jetstream/consumer.ts
@@ -923,7 +923,6 @@ export type OrderedConsumerOptions = {
   replay_policy: ReplayPolicy;
   inactive_threshold: number;
   headers_only: boolean;
-  abort_on_missing_resource: boolean;
 };
 
 export class OrderedPullConsumerImpl implements Consumer {

--- a/jetstream/consumer.ts
+++ b/jetstream/consumer.ts
@@ -733,7 +733,6 @@ export class OrderedConsumerMessages extends QueuedIteratorImpl<JsMsg>
     }
     this.src = src;
     this.src.setCleanupHandler((err) => {
-      console.log("cleanup handler");
       this.stop(err || undefined);
     });
     (async () => {

--- a/jetstream/consumer.ts
+++ b/jetstream/consumer.ts
@@ -317,7 +317,6 @@ export class PullConsumerMessagesImpl extends QueuedIteratorImpl<JsMsg>
       idle_heartbeat,
       threshold_bytes,
       threshold_messages,
-      abort_on_missing_resource,
     } = this.opts;
 
     // ordered consumer requires the ability to reset the

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The NATS Authors
+ * Copyright 2023-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,8 +33,9 @@ import {
   setup,
 } from "../../tests/helpers/mod.ts";
 import { deadline, delay } from "../../nats-base-client/util.ts";
+import { NatsConnectionImpl } from "../../nats-base-client/nats.ts";
 
-Deno.test("ordered - get", async () => {
+Deno.test("ordered consumers - get", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -60,7 +61,7 @@ Deno.test("ordered - get", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - fetch", async () => {
+Deno.test("ordered consumers - fetch", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -88,7 +89,7 @@ Deno.test("ordered - fetch", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - fetch reset", async () => {
+Deno.test("ordered consumers - fetch reset", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -169,7 +170,7 @@ Deno.test("ordered - fetch reset", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - consume reset", async () => {
+Deno.test("ordered consumers - consume reset", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -211,7 +212,7 @@ Deno.test("ordered - consume reset", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - consume", async () => {
+Deno.test("ordered consumers - consume", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -234,7 +235,7 @@ Deno.test("ordered - consume", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - filters consume", async () => {
+Deno.test("ordered consumers - filters consume", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
@@ -264,7 +265,7 @@ Deno.test("ordered - filters consume", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - filters fetch", async () => {
+Deno.test("ordered consumers - filters fetch", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   if (await notCompatible(ns, nc, "2.10.0")) {
     return;
@@ -290,7 +291,7 @@ Deno.test("ordered - filters fetch", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - fetch reject consumer type change or concurrency", async () => {
+Deno.test("ordered consumers - fetch reject consumer type change or concurrency", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -325,7 +326,7 @@ Deno.test("ordered - fetch reject consumer type change or concurrency", async ()
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - consume reject consumer type change or concurrency", async () => {
+Deno.test("ordered consumers - consume reject consumer type change or concurrency", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -360,7 +361,7 @@ Deno.test("ordered - consume reject consumer type change or concurrency", async 
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - last per subject", async () => {
+Deno.test("ordered consumers - last per subject", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -395,7 +396,7 @@ Deno.test("ordered - last per subject", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - start sequence", async () => {
+Deno.test("ordered consumers - start sequence", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -432,7 +433,7 @@ Deno.test("ordered - start sequence", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - last", async () => {
+Deno.test("ordered consumers - last", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -470,7 +471,7 @@ Deno.test("ordered - last", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - new", async () => {
+Deno.test("ordered consumers - new", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -510,7 +511,7 @@ Deno.test("ordered - new", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - start time", async () => {
+Deno.test("ordered consumers - start time", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -555,7 +556,7 @@ Deno.test("ordered - start time", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - start time reset", async () => {
+Deno.test("ordered consumers - start time reset", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test.*"] });
@@ -593,7 +594,7 @@ Deno.test("ordered - start time reset", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - next", async () => {
+Deno.test("ordered consumers - next", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "test", subjects: ["test"] });
@@ -617,7 +618,7 @@ Deno.test("ordered - next", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - sub leaks next()", async () => {
+Deno.test("ordered consumers - sub leaks next()", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
@@ -631,7 +632,7 @@ Deno.test("ordered - sub leaks next()", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - sub leaks fetch()", async () => {
+Deno.test("ordered consumers - sub leaks fetch()", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
@@ -651,7 +652,7 @@ Deno.test("ordered - sub leaks fetch()", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - sub leaks consume()", async () => {
+Deno.test("ordered consumers - sub leaks consume()", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
@@ -675,7 +676,7 @@ Deno.test("ordered - sub leaks consume()", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - consume drain", async () => {
+Deno.test("ordered consumers - consume drain", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const { stream } = await initStream(nc);
 
@@ -696,7 +697,7 @@ Deno.test("ordered - consume drain", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - headers only", async () => {
+Deno.test("ordered consumers - headers only", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -711,7 +712,7 @@ Deno.test("ordered - headers only", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - max deliver", async () => {
+Deno.test("ordered consumers - max deliver", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -726,7 +727,7 @@ Deno.test("ordered - max deliver", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - mem", async () => {
+Deno.test("ordered consumers - mem", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());
   const js = nc.jetstream();
 
@@ -741,7 +742,7 @@ Deno.test("ordered - mem", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("ordered - inboxPrefix is respected", async () => {
+Deno.test("ordered consumers - inboxPrefix is respected", async () => {
   const { ns, nc } = await setup(jetstreamServerConf(), { inboxPrefix: "x" });
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "messages", subjects: ["hello"] });
@@ -758,5 +759,102 @@ Deno.test("ordered - inboxPrefix is respected", async () => {
   assertStringIncludes(iter.src.inbox, "x.");
   iter.stop();
   await done;
+  await cleanup(ns, nc);
+});
+
+Deno.test("ordered consumers - fetch deleted consumer", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "A", subjects: ["a"] });
+
+  const js = nc.jetstream();
+  const c = await js.consumers.get("A");
+
+  const iter = await c.fetch({
+    expires: 3000,
+  });
+
+  const exited = assertRejects(
+    async () => {
+      for await (const _ of iter) {
+        // nothing
+      }
+    },
+    Error,
+    "consumer deleted",
+  );
+
+  await delay(1000);
+  await c.delete();
+
+  await exited;
+  await cleanup(ns, nc);
+});
+
+Deno.test("ordered consumers - next deleted consumer", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "A", subjects: ["hello"] });
+
+  const js = nc.jetstream();
+  const c = await js.consumers.get("A");
+
+  const exited = assertRejects(
+    () => {
+      return c.next({ expires: 4000 });
+    },
+    Error,
+    "consumer deleted",
+  );
+  await delay(1000);
+  await c.delete();
+
+  await exited;
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("ordered consumers - next stream not found", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "A", subjects: ["hello"] });
+
+  const js = nc.jetstream();
+  const c = await js.consumers.get("A");
+  await jsm.streams.delete("A");
+
+  await assertRejects(
+    () => {
+      return c.next({ expires: 1000 });
+    },
+    Error,
+    "stream not found",
+  );
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("ordered consumers - fetch stream not found", async () => {
+  const { ns, nc } = await setup(jetstreamServerConf());
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({ name: "A", subjects: ["a"] });
+
+  const js = nc.jetstream();
+  const c = await js.consumers.get("A");
+
+  await jsm.streams.delete("A");
+
+  await assertRejects(
+    () => {
+      return c.fetch({
+        expires: 3000,
+      });
+    },
+    Error,
+    "stream not found",
+  );
+
   await cleanup(ns, nc);
 });

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -865,7 +865,7 @@ Deno.test("ordered consumers - consume stream not found request abort", async ()
   await jsm.streams.add({ name: "A", subjects: ["a"] });
 
   const js = nc.jetstream();
-  const c = await js.consumers.get("A", { abort_on_missing_resource: true });
+  const c = await js.consumers.get("A");
   await jsm.streams.delete("A");
 
   await assertRejects(
@@ -888,14 +888,8 @@ Deno.test("ordered consumers - consume consumer deleted request abort", async ()
   const jsm = await nc.jetstreamManager();
   await jsm.streams.add({ name: "A", subjects: ["a"] });
 
-  await jsm.consumers.add("A", {
-    durable_name: "a",
-    deliver_policy: DeliverPolicy.All,
-    ack_policy: AckPolicy.Explicit,
-  });
-
   const js = nc.jetstream();
-  const c = await js.consumers.get("A", "a");
+  const c = await js.consumers.get("A");
   const iter = await c.consume({
     expires: 3000,
     abort_on_missing_resource: true,
@@ -914,40 +908,6 @@ Deno.test("ordered consumers - consume consumer deleted request abort", async ()
   await delay(1000);
   await c.delete();
   await done;
-
-  await cleanup(ns, nc);
-});
-
-Deno.test("ordered consumers - consume consumer not found request abort", async () => {
-  const { ns, nc } = await setup(jetstreamServerConf());
-
-  const jsm = await nc.jetstreamManager();
-  await jsm.streams.add({ name: "A", subjects: ["a"] });
-
-  await jsm.consumers.add("A", {
-    durable_name: "a",
-    deliver_policy: DeliverPolicy.All,
-    ack_policy: AckPolicy.Explicit,
-  });
-
-  const js = nc.jetstream();
-  const c = await js.consumers.get("A", "a");
-  await c.delete();
-
-  const iter = await c.consume({
-    expires: 3000,
-    abort_on_missing_resource: true,
-  });
-
-  await assertRejects(
-    async () => {
-      for await (const _ of iter) {
-        // nothing
-      }
-    },
-    Error,
-    "consumer not found",
-  );
 
   await cleanup(ns, nc);
 });

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -33,7 +33,6 @@ import {
   setup,
 } from "../../tests/helpers/mod.ts";
 import { deadline, delay } from "../../nats-base-client/util.ts";
-import { NatsConnectionImpl } from "../../nats-base-client/nats.ts";
 
 Deno.test("ordered consumers - get", async () => {
   const { ns, nc } = await setup(jetstreamServerConf());

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The NATS Authors
+ * Copyright 2020-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -585,7 +585,7 @@ export class NatsServer implements PortInfo {
         }
       },
       1000,
-      { name: "read ports file" },
+      { name: `read ports file ${portsFile}` },
     );
 
     if (debug) {


### PR DESCRIPTION
This change modifies the behavior of `fetch()` and `next()` to react to `consumer deleted` / `consumer not found` / `stream not found` server responses. Since these operations have a termination condition (the end of the `next()` or `fetch()`), such events are appropriate. 

Ordered consumers work similarly with `next()` and `fetch()` as described above. Applications that use next()/fetch() should trap errors, and re-attempt as desired.

`consume()` API however will keep reporting via its `status()` if there's an error related to the stream or consumer. Clients that want to stop processing during a consume on consumer deleted/stream not found type errors should setup a listener and then call `stop()` on the consumer if those conditions are reported and the desired behavior is to stop processing. If the problem resource becomes available, `consume()` will resume. This is the existing behavior.

This PR also adds the `abort_on_missing_resource` to `consume()` options. If a resource such as a stream is not found or consumer is deleted or not found `consume()` will abort. Note that for ordered consumers will not honor the option if a consumer is not found, as order consumer recreates a consumer on the fly. However deleting an active ordered consumer or its stream will stop it if the option is provided.