### PR TITLE
Fix incorrect type in implementation of `jetstream()` api - it is correct in the interface.

### DIFF
--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -505,7 +505,7 @@ export class NatsConnectionImpl implements NatsConnection {
   }
 
   jetstream(
-    opts: JetStreamOptions | JetStreamManagerImpl = {},
+    opts: JetStreamOptions | JetStreamManagerOptions = {},
   ): JetStreamClient {
     return new JetStreamClientImpl(this, opts);
   }


### PR DESCRIPTION
[FIX] jetstream() api implementation incorrectly typed options as JetStreamManagerImpl - should have been JetStreamManagerOptions - this is only in the implementation, the types are correct on the interface.