### PR TITLE
[FEAT] `handshake_first` support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,9 @@ jobs:
           TMPDIR: ${{ runner.temp }}
           CI: true
           NGS_CI_USER: ${{ secrets.NGS_CI_USER }}
-        run: deno test --allow-all --unstable --parallel --fail-fast --coverage=./cov
+        run: |
+          deno test --allow-all --unstable --parallel --fail-fast --coverage=./cov tests/ jetstream/tests 
+          deno test --allow-all --unstable --parallel --fail-fast --unsafely-ignore-certificate-errors --coverage=./cov unsafe_tests/ 
 
       - name: Build nats.js
         run: deno bundle --unstable src/connect.ts nats.js

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ lint:
 	deno lint --ignore=docs/
 
 test: clean
-	deno test --allow-all --unstable --parallel --reload --quiet --coverage=coverage tests/ jetstream/tests
+	deno test --allow-all --parallel --reload --quiet --coverage=coverage tests/ jetstream/tests
+	deno test --allow-all --parallel --reload --quiet --unsafely-ignore-certificate-errors --coverage=coverage unsafe_tests/
 
 
 testw: clean

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ bundle:
 	deno bundle --log-level info --unstable src/mod.ts ./nats.js
 
 fmt:
-	deno fmt src/ doc/ bin/ nats-base-client/ examples/ tests/ debug/ jetstream/ jetstream.md README.md services.md
+	deno fmt src/ doc/ bin/ nats-base-client/ examples/ tests/ debug/ unsafe_tests/ jetstream/ jetstream.md README.md services.md

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -1213,7 +1213,7 @@ Deno.test("jetstream - detailed errors", async () => {
 });
 
 Deno.test("jetstream - repub on 503", async () => {
-  let servers = await NatsServer.setupDataConnCluster(4);
+  const servers = await NatsServer.setupDataConnCluster(4);
   const nc = await connect({ port: servers[0].port });
 
   const { stream, subj } = await initStream(nc, nuid.next(), {

--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -1397,6 +1397,10 @@ export interface ConnectionOptions {
  * the client is requesting to only use connections that are secured by TLS.
  */
 export interface TlsOptions {
+  /**
+   * handshakeFirst option requires the server to be configured with `handshakeFirst: true`.
+   */
+  handshakeFirst?: boolean;
   certFile?: string;
   cert?: string;
   caFile?: string;

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -33,7 +33,6 @@ import {
   ServerInfo,
   Transport,
 } from "../nats-base-client/internal_mod.ts";
-import StartTlsOptions = Deno.StartTlsOptions;
 
 const VERSION = "1.21.0";
 const LANG = "nats.deno";
@@ -134,7 +133,7 @@ export class DenoTransport implements Transport {
     return JSON.parse(m[1]) as ServerInfo;
   }
 
-  async loadTlsOptions(hostname: string): Promise<StartTlsOptions> {
+  async loadTlsOptions(hostname: string): Promise<Deno.StartTlsOptions> {
     const tls = this.options && this.options.tls
       ? this.options.tls
       : {} as TlsOptions;

--- a/unsafe_tests/tlsunsafe_test.ts
+++ b/unsafe_tests/tlsunsafe_test.ts
@@ -1,0 +1,36 @@
+import {resolve} from "https://deno.land/std@0.221.0/path/resolve.ts";
+import {join} from "https://deno.land/std@0.221.0/path/join.ts";
+import {NatsServer} from "../tests/helpers/launcher.ts";
+import {connect} from "../src/connect.ts";
+
+Deno.test("tls-unsafe - handshake first", async () => {
+    const cwd = Deno.cwd();
+    const config = {
+        host: "localhost",
+        tls: {
+            handshake_first: true,
+            cert_file: resolve(join(cwd, "./tests/certs/localhost.crt")),
+            key_file: resolve(join(cwd, "./tests/certs/localhost.key")),
+            ca_file: resolve(join(cwd, "./tests/certs/RootCA.crt")),
+        },
+    };
+
+    const ns = await NatsServer.start(config);
+    const nc = await connect({
+        debug: true,
+        servers: `localhost:${ns.port}`,
+        tls: {
+            handshakeFirst: true,
+            caFile: config.tls.ca_file,
+        },
+    });
+    nc.subscribe("foo", {
+        callback(_err, msg) {
+            msg.respond(msg.data);
+        },
+    });
+
+    await nc.request("foo", "hello");
+    await nc.close();
+    await ns.stop();
+});

--- a/unsafe_tests/tlsunsafe_test.ts
+++ b/unsafe_tests/tlsunsafe_test.ts
@@ -1,36 +1,36 @@
-import {resolve} from "https://deno.land/std@0.221.0/path/resolve.ts";
-import {join} from "https://deno.land/std@0.221.0/path/join.ts";
-import {NatsServer} from "../tests/helpers/launcher.ts";
-import {connect} from "../src/connect.ts";
+import { resolve } from "https://deno.land/std@0.221.0/path/resolve.ts";
+import { join } from "https://deno.land/std@0.221.0/path/join.ts";
+import { NatsServer } from "../tests/helpers/launcher.ts";
+import { connect } from "../src/connect.ts";
 
 Deno.test("tls-unsafe - handshake first", async () => {
-    const cwd = Deno.cwd();
-    const config = {
-        host: "localhost",
-        tls: {
-            handshake_first: true,
-            cert_file: resolve(join(cwd, "./tests/certs/localhost.crt")),
-            key_file: resolve(join(cwd, "./tests/certs/localhost.key")),
-            ca_file: resolve(join(cwd, "./tests/certs/RootCA.crt")),
-        },
-    };
+  const cwd = Deno.cwd();
+  const config = {
+    host: "localhost",
+    tls: {
+      handshake_first: true,
+      cert_file: resolve(join(cwd, "./tests/certs/localhost.crt")),
+      key_file: resolve(join(cwd, "./tests/certs/localhost.key")),
+      ca_file: resolve(join(cwd, "./tests/certs/RootCA.crt")),
+    },
+  };
 
-    const ns = await NatsServer.start(config);
-    const nc = await connect({
-        debug: true,
-        servers: `localhost:${ns.port}`,
-        tls: {
-            handshakeFirst: true,
-            caFile: config.tls.ca_file,
-        },
-    });
-    nc.subscribe("foo", {
-        callback(_err, msg) {
-            msg.respond(msg.data);
-        },
-    });
+  const ns = await NatsServer.start(config);
+  const nc = await connect({
+    debug: true,
+    servers: `localhost:${ns.port}`,
+    tls: {
+      handshakeFirst: true,
+      caFile: config.tls.ca_file,
+    },
+  });
+  nc.subscribe("foo", {
+    callback(_err, msg) {
+      msg.respond(msg.data);
+    },
+  });
 
-    await nc.request("foo", "hello");
-    await nc.close();
-    await ns.stop();
+  await nc.request("foo", "hello");
+  await nc.close();
+  await ns.stop();
 });


### PR DESCRIPTION
[FEAT] [CORE] connect to `handshake_first` configured NATS servers specify `{tls: {handshakeFirst: true}}` connection option. Note that the server must match the configuration option, and will only accept with a matching option.