### PR TITLE
[FEAT] [CORE] added the ability to publish by providing a Msg argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY: build test bundle lint
 
-export DENO_JOBS=4
-
 build: test
 
 lint:

--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -557,6 +557,13 @@ export interface NatsConnection {
   publishMessage(msg: Msg): void;
 
   /**
+   * Replies using the reply subject of the specified message, specifying the
+   * data, headers in the message if any.
+   * @param msg
+   */
+  respondMessage(msg: Msg): boolean;
+
+  /**
    * Subscribe expresses interest in the specified subject. The subject may
    * have wildcards. Messages are delivered to the {@link SubOpts#callback |SubscriptionOptions callback}
    * if specified. Otherwise, the subscription is an async iterator for {@link Msg}.

--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -550,6 +550,13 @@ export interface NatsConnection {
   ): void;
 
   /**
+   * Publishes using the subject of the specified message, specifying the
+   * data, headers and reply found in the message if any.
+   * @param msg
+   */
+  publishMessage(msg: Msg): void;
+
+  /**
    * Subscribe expresses interest in the specified subject. The subject may
    * have wildcards. Messages are delivered to the {@link SubOpts#callback |SubscriptionOptions callback}
    * if specified. Otherwise, the subscription is an async iterator for {@link Msg}.

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -126,6 +126,13 @@ export class NatsConnectionImpl implements NatsConnection {
     this.protocol.publish(subject, data, options);
   }
 
+  publishMessage(msg: Msg) {
+    return this.publish(msg.subject, msg.data, {
+      reply: msg.reply,
+      headers: msg.headers,
+    });
+  }
+
   subscribe(
     subject: string,
     opts: SubscriptionOptions = {},

--- a/nats-base-client/nats.ts
+++ b/nats-base-client/nats.ts
@@ -133,6 +133,17 @@ export class NatsConnectionImpl implements NatsConnection {
     });
   }
 
+  respondMessage(msg: Msg) {
+    if (msg.reply) {
+      this.publish(msg.reply, msg.data, {
+        reply: msg.reply,
+        headers: msg.headers,
+      });
+      return true;
+    }
+    return false;
+  }
+
   subscribe(
     subject: string,
     opts: SubscriptionOptions = {},

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -1381,7 +1381,7 @@ Deno.test("basics - sync subscription", async () => {
   await cleanup(ns, nc);
 });
 
-Deno.test("basics - respond message", async () => {
+Deno.test("basics - publish message", async () => {
   const { ns, nc } = await setup();
   const sub = nc.subscribe("q");
 
@@ -1393,6 +1393,28 @@ Deno.test("basics - respond message", async () => {
       if (m.reply) {
         nis.subject = m.reply;
         nc.publishMessage(nis);
+      }
+    }
+  })().then();
+
+  const r = await nc.request("q");
+  assertEquals(r.string(), "not in service");
+
+  await cleanup(ns, nc);
+});
+
+Deno.test("basics - respond message", async () => {
+  const { ns, nc } = await setup();
+  const sub = nc.subscribe("q");
+
+  const nis = new MM(nc);
+  nis.data = new TextEncoder().encode("not in service");
+
+  (async () => {
+    for await (const m of sub) {
+      if (m.reply) {
+        nis.reply = m.reply;
+        nc.respondMessage(nis);
       }
     }
   })().then();

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -1381,8 +1381,6 @@ Deno.test("basics - sync subscription", async () => {
   await cleanup(ns, nc);
 });
 
-
-
 Deno.test("basics - respond message", async () => {
   const { ns, nc } = await setup();
   const sub = nc.subscribe("q");
@@ -1404,7 +1402,6 @@ Deno.test("basics - respond message", async () => {
 
   await cleanup(ns, nc);
 });
-
 
 class MM implements Msg {
   data!: Uint8Array;


### PR DESCRIPTION
This effectively uses a message as a set of parameters. The client will use the provided message as the source for subject, data, reply and headers. Note that this will work with any argument that satisfies the message interface, but it is not of interest to most applications.