### PR TITLE
[FIX] Kv Watcher reliability during server restarts

### DIFF
--- a/jetstream/jsclient.ts
+++ b/jetstream/jsclient.ts
@@ -98,6 +98,7 @@ import {
   PullOptions,
   ReplayPolicy,
 } from "./jsapi_types.ts";
+import { nuid } from "../nats-base-client/nuid.ts";
 
 export enum PubHeaders {
   MsgIdHdr = "Nats-Msg-Id",
@@ -775,6 +776,7 @@ export class JetStreamSubscriptionImpl extends TypedSubscription<JsMsg>
     const nci = this.js.nc;
     nci._resub(this.sub, newDeliver);
     const info = this.info;
+    info.config.name = nuid.next();
     info.ordered_consumer_sequence.delivery_seq = 0;
     info.flow_control.heartbeat_count = 0;
     info.flow_control.fc_count = 0;
@@ -842,6 +844,7 @@ export class JetStreamSubscriptionImpl extends TypedSubscription<JsMsg>
         // reset the consumer
         const seq = this.info?.ordered_consumer_sequence?.stream_seq || 0;
         this._resetOrderedConsumer(seq + 1);
+        this.monitor?.restart();
         // if we are ordered, we will reset the consumer and keep
         // feeding the iterator or callback - we are not stopping
         return false;

--- a/nats-base-client/idleheartbeat_monitor.ts
+++ b/nats-base-client/idleheartbeat_monitor.ts
@@ -78,6 +78,7 @@ export class IdleHeartbeatMonitor {
     }
     this.timer = 0;
     this.autoCancelTimer = 0;
+    this.missed = 0;
   }
 
   /**

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -157,7 +157,7 @@ export class DenoTransport implements Transport {
     const sto = await (this.loadTlsOptions(hostname));
     this.conn = await Deno.startTls(
       //@ts-ignore: just the conn
-      this.conn,
+      this.conn as Deno.TcpConn,
       sto,
     );
     // this is necessary because the startTls process doesn't


### PR DESCRIPTION
[FIX] [JS] [KV] watcher reset due to a server restart could fail because the server would report the consumer as existing

[FIX] [JS] [KV] watcher reset if successful, could still get heartbeat missing reports which would cause the ordered consumer to reset when it didn't need to.

Fix #688