### PR TITLE
[FIX] more robust watcher in case consumer is recreated while the cluster is flapping

### DIFF
--- a/jetstream/jsclient.ts
+++ b/jetstream/jsclient.ts
@@ -792,7 +792,7 @@ export class JetStreamSubscriptionImpl extends TypedSubscription<JsMsg>
 
     const subj = `${info.api.prefix}.CONSUMER.CREATE.${info.stream}`;
 
-    this.js._request(subj, req)
+    this.js._request(subj, req, { retries: -1 })
       .then((v) => {
         const ci = v as ConsumerInfo;
         this.info!.config = ci.config;


### PR DESCRIPTION
[FIX] [JS] [LEGACY] reset order consumer would throw an error if it failed to recreate the consumer - now if the failure is due to a 503 or a timeout, it will continue to retry,