### PR TITLE
[FIX] legacy order consumer subscription leak

### DIFF
--- a/jetstream/jsclient.ts
+++ b/jetstream/jsclient.ts
@@ -795,6 +795,8 @@ export class JetStreamSubscriptionImpl extends TypedSubscription<JsMsg>
     this.js._request(subj, req, { retries: -1 })
       .then((v) => {
         const ci = v as ConsumerInfo;
+        const jinfo = this.sub.info as JetStreamSubscriptionInfo;
+        jinfo.last = ci;
         this.info!.config = ci.config;
         this.info!.name = ci.name;
       })

--- a/nats-base-client/protocol.ts
+++ b/nats-base-client/protocol.ts
@@ -995,6 +995,7 @@ export class ProtocolHandler implements Dispatcher<ParserEvent> {
     if (!s || this.isClosed()) {
       return;
     }
+    this.unsub(s);
     s.subject = subject;
     this.subscriptions.resub(s);
     // we don't auto-unsub here because we don't

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -72,6 +72,45 @@ export interface JSZ {
   };
 }
 
+export interface SubDetails {
+  subject: string;
+  sid: string;
+  msgs: number;
+  cid: number;
+}
+
+export interface Conn {
+  cid: number;
+  kind: string;
+  type: string;
+  ip: string;
+  port: number;
+  start: string;
+  "last_activity": string;
+  "rtt": string;
+  uptime: string;
+  idle: string;
+  "pending_bytes": number;
+  "in_msgs": number;
+  "out_msgs": number;
+  subscriptions: number;
+  name: string;
+  lang: string;
+  version: string;
+  subscriptions_list?: string[];
+  subscriptions_list_detail?: SubDetails[];
+}
+
+export interface ConnZ {
+  "server_id": string;
+  now: string;
+  "num_connections": number;
+  "total": number;
+  "offset": number;
+  "limit": number;
+  "connections": Conn[];
+}
+
 function parseHostport(
   s?: string,
 ): { hostname: string; port: number } | undefined {
@@ -313,6 +352,21 @@ export class NatsServer implements PortInfo {
       return Promise.reject(new Error("server is not monitoring"));
     }
     const resp = await fetch(`http://127.0.0.1:${this.monitoring}/jsz`);
+    return await resp.json();
+  }
+
+  async connz(cid?: number, subs: boolean | "detail" = true): Promise<ConnZ> {
+    if (!this.monitoring) {
+      return Promise.reject(new Error("server is not monitoring"));
+    }
+    const args = [];
+    args.push(`subs=${subs}`);
+    if (cid) {
+      args.push(`cid=${cid}`);
+    }
+
+    const qs = args.length ? args.join("&") : "";
+    const resp = await fetch(`http://127.0.0.1:${this.monitoring}/connz?${qs}`);
     return await resp.json();
   }
 

--- a/tests/resub_test.ts
+++ b/tests/resub_test.ts
@@ -16,6 +16,7 @@
 import { cleanup, setup } from "./helpers/mod.ts";
 import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
 import {
+  assert,
   assertEquals,
   assertExists,
   fail,
@@ -117,6 +118,7 @@ Deno.test("resub - removes server interest", async () => {
       // nothing
     },
   });
+  await nc.flush();
 
   const nci = nc as NatsConnectionImpl;
   let sub = nci.protocol.subscriptions.all().find((s) => {
@@ -129,12 +131,13 @@ Deno.test("resub - removes server interest", async () => {
 
   // change it
   nci._resub(sub, "b");
+  await nc.flush();
 
   // make sure we don't find a
   sub = nci.protocol.subscriptions.all().find((s) => {
     return s.subject === "a";
   });
-  assertEquals(sub, undefined);
+  assert(sub === undefined);
 
   // make sure we find b
   sub = nci.protocol.subscriptions.all().find((s) => {


### PR DESCRIPTION
[FIX] fixed an issue with ordered consumer where resetting the consumer didn't send the UNSUB, creating a situation where if there was no disconnect from the client, two subscriptions would be active on the server.

FIX #691 