### PR TITLE
[FIX] [JS] [KV] fixed an issue where `maxBucketSize` (deprecated option) overrode `max_bytes`

### DIFF
--- a/jetstream/kv.ts
+++ b/jetstream/kv.ts
@@ -108,7 +108,7 @@ export function defaultBucketOpts(): Partial<KvOptions> {
     replicas: 1,
     history: 1,
     timeout: 2000,
-    maxBucketSize: -1,
+    max_bytes: -1,
     maxValueSize: -1,
     codec: NoopKvCodecs(),
     storage: StorageType.File,

--- a/jetstream/tests/kv_test.ts
+++ b/jetstream/tests/kv_test.ts
@@ -2164,3 +2164,14 @@ Deno.test("kv - watcher on server restart", async () => {
   await d;
   await cleanup(ns, nc);
 });
+
+Deno.test("kv - maxBucketSize doesn't override max_bytes", async () => {
+  let { ns, nc } = await setup(
+    jetstreamServerConf({}),
+  );
+  const js = nc.jetstream();
+  const kv = await js.views.kv("A", { max_bytes: 100 });
+  const info = await kv.status();
+  assertEquals(info.max_bytes, 100);
+  await cleanup(ns, nc);
+});


### PR DESCRIPTION
Fixes #706