### PR TITLE
Honor JS timeout in ackAck() and also allow to override

### DIFF
--- a/jetstream/consumer.ts
+++ b/jetstream/consumer.ts
@@ -420,7 +420,7 @@ export class PullConsumerMessagesImpl extends QueuedIteratorImpl<JsMsg>
           }
         } else {
           // push the user message
-          this._push(toJsMsg(msg));
+          this._push(toJsMsg(msg, this.consumer.api.timeout));
           this.received++;
           if (this.pending.msgs) {
             this.pending.msgs--;

--- a/jetstream/jsmsg.ts
+++ b/jetstream/jsmsg.ts
@@ -225,7 +225,6 @@ export class JsMsgImpl implements JsMsg {
   async ackAck(opts?: Partial<{ timeout: number }>): Promise<boolean> {
     opts = opts || {};
     opts.timeout = opts.timeout || this.timeout;
-    console.log(opts.timeout);
     const d = deferred<boolean>();
     if (!this.didAck) {
       this.didAck = true;

--- a/jetstream/jsmsg.ts
+++ b/jetstream/jsmsg.ts
@@ -110,7 +110,7 @@ export interface JsMsg {
    * successfully and that the JetStream server should acknowledge back
    * that the acknowledgement was received.
    */
-  ackAck(): Promise<boolean>;
+  ackAck(opts?: Partial<{ timeout: number }>): Promise<boolean>;
 
   /**
    * Convenience method to parse the message payload as JSON. This method
@@ -125,8 +125,8 @@ export interface JsMsg {
   string(): string;
 }
 
-export function toJsMsg(m: Msg): JsMsg {
-  return new JsMsgImpl(m);
+export function toJsMsg(m: Msg, ackTimeout = 5000): JsMsg {
+  return new JsMsgImpl(m, ackTimeout);
 }
 
 export function parseInfo(s: string): DeliveryInfo {
@@ -164,10 +164,12 @@ export class JsMsgImpl implements JsMsg {
   msg: Msg;
   di?: DeliveryInfo;
   didAck: boolean;
+  timeout: number;
 
-  constructor(msg: Msg) {
+  constructor(msg: Msg, timeout: number) {
     this.msg = msg;
     this.didAck = false;
+    this.timeout = timeout;
   }
 
   get subject(): string {
@@ -220,7 +222,10 @@ export class JsMsgImpl implements JsMsg {
 
   // this has to dig into the internals as the message has access
   // to the protocol but not the high-level client.
-  async ackAck(): Promise<boolean> {
+  async ackAck(opts?: Partial<{ timeout: number }>): Promise<boolean> {
+    opts = opts || {};
+    opts.timeout = opts.timeout || this.timeout;
+    console.log(opts.timeout);
     const d = deferred<boolean>();
     if (!this.didAck) {
       this.didAck = true;
@@ -229,7 +234,7 @@ export class JsMsgImpl implements JsMsg {
         const proto = mi.publisher as unknown as ProtocolHandler;
         const trace = !(proto.options?.noAsyncTraces || false);
         const r = new RequestOne(proto.muxSubscriptions, this.msg.reply, {
-          timeout: 1000,
+          timeout: opts.timeout,
         }, trace);
         proto.request(r);
         try {


### PR DESCRIPTION
[FIX] [JS] JsMsg#ackAck() didn't provide a way to customize the timeout. Added optional option with timeout for ackAck(), and also defaulted the timeout to match the JSClient's timeout (as provided by the JetStreamOptions)