### PR TITLE
[FEAT] [KV] added support for listing keys with multiple filters

### DIFF
--- a/jetstream/kv.ts
+++ b/jetstream/kv.ts
@@ -858,12 +858,13 @@ export class Bucket implements KV, KvRemove {
     return qi;
   }
 
-  async keys(k = ">"): Promise<QueuedIterator<string>> {
+  async keys(k: string | string[] = ">"): Promise<QueuedIterator<string>> {
     const keys = new QueuedIteratorImpl<string>();
     const cc = this._buildCC(k, KvWatchInclude.LastValue, {
       headers_only: true,
     });
-    const subj = cc.filter_subject!;
+
+    const subj = Array.isArray(k) ? ">" : cc.filter_subject!;
     const copts = consumerOpts(cc);
     copts.bindStream(this.stream);
     copts.orderedConsumer();

--- a/jetstream/types.ts
+++ b/jetstream/types.ts
@@ -1201,9 +1201,9 @@ export interface RoKV {
   /**
    * Returns an iterator of all the keys optionally matching
    * the specified filter.
-   * @param filter
+   * @param filter default to all keys
    */
-  keys(filter?: string): Promise<QueuedIterator<string>>;
+  keys(filter?: string | string[]): Promise<QueuedIterator<string>>;
 }
 
 export interface KV extends RoKV {


### PR DESCRIPTION
[FEAT] [KV] added support for listing keys with multiple filters (client already supported a single filter, this enables the possibility of specifying additional keys)