### PR TITLE
Package moderniation

### DIFF
--- a/bin/bundle.ts
+++ b/bin/bundle.ts
@@ -12,8 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { cli } from "https://deno.land/x/cobra@v0.0.9/mod.ts";
-import { bundle } from "https://deno.land/x/emit@0.26.0/mod.ts";
+import { cli } from "cobra";
+import { bundle } from "@deno/emit";
 
 const root = cli({
   use: "bundle javascript/typescript",

--- a/bin/dependencies.ts
+++ b/bin/dependencies.ts
@@ -17,7 +17,7 @@ import {
   extname,
   join,
   resolve,
-} from "https://deno.land/std@0.221.0/path/mod.ts";
+} from "@std/path";
 
 // resolve the specified directories to fq
 // let dirs = ["src", "nats-base-client", "jetstream", "bin"].map((n) => {

--- a/bin/exports.ts
+++ b/bin/exports.ts
@@ -13,15 +13,15 @@
  * limitations under the License.
  */
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import {
   basename,
   extname,
   join,
   resolve,
-} from "https://deno.land/std@0.221.0/path/mod.ts";
+} from "@std/path";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {},
 );

--- a/bin/fix-os.ts
+++ b/bin/fix-os.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import { ObjectStoreImpl, ServerObjectInfo } from "../jetstream/objectstore.ts";
 import {
   connect,
@@ -20,7 +20,7 @@ import {
   credsAuthenticator,
 } from "https://raw.githubusercontent.com/nats-io/nats.deno/main/src/mod.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/deno.json
+++ b/deno.json
@@ -21,7 +21,7 @@
   "publish": {},
   "test": {
     "include": [
-      "tests/**/*._test"
+      "tests/**/*.ts"
     ]
   },
   "bench": {},

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,37 @@
+{
+  "name": "@nats-io/client",
+  "version": "",
+  "exports": {
+    ".": "./src/mod.ts"
+  },
+  "imports": {
+    "@deno/emit": "jsr:@deno/emit@^0.41.0",
+    "@nats-io/nkeys": "jsr:@nats-io/nkeys@^1.1.0",
+    "@std/assert": "jsr:@std/assert@^0.226.0",
+    "@std/async": "jsr:@std/async@^0.224.2",
+    "@std/bytes": "jsr:@std/bytes@^1.0.0",
+    "@std/cli": "jsr:@std/cli@^0.224.7",
+    "@std/crypto": "jsr:@std/crypto@^0.224.0",
+    "@std/fmt": "jsr:@std/fmt@^0.225.4",
+    "@std/io": "jsr:@std/io@^0.224.1",
+    "@std/path": "jsr:@std/path@^0.225.2",
+    "ajv": "npm:ajv@^8.16.0",
+    "cobra": "https://deno.land/x/cobra@v0.0.9/mod.ts"
+  },
+  "publish": {},
+  "test": {
+    "include": [
+      "tests/**/*._test"
+    ]
+  },
+  "bench": {},
+  "tasks": {
+    "lint": "deno lint --ignore=docs/,debug/",
+    "test": "deno task clean && deno test --allow-all --parallel --reload --quiet --coverage=coverage tests/ jetstream/tests && deno test --allow-all --parallel --reload --quiet --unsafely-ignore-certificate-errors --coverage=coverage unsafe_tests/",
+    "testw": "deno task clean && deno test --allow-all --unstable --reload --parallel --watch --fail-fast tests/ jetstream/",
+    "cover": "deno coverage --unstable ./coverage --lcov > ./coverage/out.lcov && genhtml -o ./coverage/html ./coverage/out.lcov && open ./coverage/html/index.html",
+    "clean": "rm -rf ./coverage",
+    "bundle": "deno bundle --log-level info --unstable src/mod.ts ./nats.js",
+    "fmt": "deno fmt src/ doc/ bin/ nats-base-client/ examples/ tests/ debug/ unsafe_tests/ jetstream/ jetstream.md README.md services.md"
+  }
+}

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env deno run --allow-all --unstable
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import { Bench, connect, Metric, Nuid } from "../src/mod.ts";
 const defaults = {
   s: "127.0.0.1:4222",
@@ -13,7 +13,7 @@ const defaults = {
   pendingLimit: 32,
 };
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/examples/nats-events.ts
+++ b/examples/nats-events.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import { connect, ConnectionOptions } from "../src/mod.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/examples/nats-pub.ts
+++ b/examples/nats-pub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import {
   connect,
   ConnectionOptions,
@@ -10,7 +10,7 @@ import {
 } from "../src/mod.ts";
 import { delay } from "../nats-base-client/util.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/examples/nats-rep.ts
+++ b/examples/nats-rep.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import {
   connect,
   ConnectionOptions,
@@ -8,7 +8,7 @@ import {
   headers,
 } from "../src/mod.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/examples/nats-req.ts
+++ b/examples/nats-req.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import {
   connect,
   ConnectionOptions,
@@ -9,7 +9,7 @@ import {
 } from "../src/mod.ts";
 import { delay } from "../nats-base-client/util.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/examples/nats-sub.ts
+++ b/examples/nats-sub.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env deno run --allow-all --unstable
 
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import {
   connect,
   ConnectionOptions,
@@ -8,7 +8,7 @@ import {
   StringCodec,
 } from "../src/mod.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/examples/services/01_services.ts
+++ b/examples/services/01_services.ts
@@ -23,7 +23,7 @@ import {
   ServiceMsg,
   ServiceStats,
 } from "../../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 
 // connect to NATS on demo.nats.io
 const nc = await connect({ servers: ["demo.nats.io"] });

--- a/examples/services/03_bigdata-client.ts
+++ b/examples/services/03_bigdata-client.ts
@@ -12,11 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
 import { connect, ConnectionOptions, RequestStrategy } from "../../src/mod.ts";
 import { humanizeBytes } from "./03_util.ts";
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/jetstream/tests/consume_test.ts
+++ b/jetstream/tests/consume_test.ts
@@ -25,7 +25,7 @@ import {
   assertEquals,
   assertExists,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { initStream } from "./jstest_util.ts";
 import { AckPolicy, DeliverPolicy } from "../jsapi_types.ts";
 import {

--- a/jetstream/tests/consumeropts_test.ts
+++ b/jetstream/tests/consumeropts_test.ts
@@ -17,7 +17,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import {
   ConsumerOpts,

--- a/jetstream/tests/consumers_ordered_test.ts
+++ b/jetstream/tests/consumers_ordered_test.ts
@@ -20,7 +20,7 @@ import {
   assertExists,
   assertRejects,
   assertStringIncludes,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   ConsumerDebugEvents,
   ConsumerMessages,

--- a/jetstream/tests/consumers_test.ts
+++ b/jetstream/tests/consumers_test.ts
@@ -18,7 +18,7 @@ import {
   assertExists,
   assertRejects,
   assertStringIncludes,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { deferred, nanos } from "../../nats-base-client/mod.ts";
 import {
   AckPolicy,

--- a/jetstream/tests/fetch_test.ts
+++ b/jetstream/tests/fetch_test.ts
@@ -24,7 +24,7 @@ import {
   assertEquals,
   assertExists,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { Empty } from "../../nats-base-client/encoders.ts";
 import { StringCodec } from "../../nats-base-client/codec.ts";
 import { delay, nanos } from "../../nats-base-client/util.ts";

--- a/jetstream/tests/jetream409_test.ts
+++ b/jetstream/tests/jetream409_test.ts
@@ -29,7 +29,7 @@ import {
 import {
   assertRejects,
   assertStringIncludes,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { initStream } from "./jstest_util.ts";
 import {
   cleanup,

--- a/jetstream/tests/jetstream_fetchconsumer_test.ts
+++ b/jetstream/tests/jetstream_fetchconsumer_test.ts
@@ -28,7 +28,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { Empty } from "../../nats-base-client/encoders.ts";
 import { NatsConnectionImpl } from "../../nats-base-client/nats.ts";
 import {

--- a/jetstream/tests/jetstream_pullconsumer_test.ts
+++ b/jetstream/tests/jetstream_pullconsumer_test.ts
@@ -36,7 +36,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { Empty } from "../../nats-base-client/encoders.ts";
 import { checkJsError } from "../jsutil.ts";
 import { JSONCodec, StringCodec } from "../../nats-base-client/codec.ts";

--- a/jetstream/tests/jetstream_pushconsumer_test.ts
+++ b/jetstream/tests/jetstream_pushconsumer_test.ts
@@ -45,7 +45,7 @@ import {
   assertExists,
   assertIsError,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { callbackConsume } from "./jetstream_test.ts";
 import {
   AckPolicy,

--- a/jetstream/tests/jetstream_test.ts
+++ b/jetstream/tests/jetstream_test.ts
@@ -52,7 +52,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { assert } from "../../nats-base-client/denobuffer.ts";
 import {

--- a/jetstream/tests/jsm_test.ts
+++ b/jetstream/tests/jsm_test.ts
@@ -20,7 +20,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { NatsConnectionImpl } from "../../nats-base-client/nats.ts";
 import {

--- a/jetstream/tests/jsmsg_test.ts
+++ b/jetstream/tests/jsmsg_test.ts
@@ -16,7 +16,7 @@ import {
   assertEquals,
   assertRejects,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   AckPolicy,
   connect,

--- a/jetstream/tests/jstest_util.ts
+++ b/jetstream/tests/jstest_util.ts
@@ -21,7 +21,7 @@ import {
   QueuedIterator,
   StreamConfig,
 } from "../../src/mod.ts";
-import { assert } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assert } from "@std/assert";
 import {
   Empty,
   NatsConnection,

--- a/jetstream/tests/kv_test.ts
+++ b/jetstream/tests/kv_test.ts
@@ -45,7 +45,7 @@ import {
   assertExists,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import {
   Base64KeyCodec,
@@ -64,13 +64,13 @@ import {
 } from "../../tests/helpers/mod.ts";
 import { QueuedIteratorImpl } from "../../nats-base-client/queued_iterator.ts";
 import { connect } from "../../src/mod.ts";
-import { JSONCodec } from "https://deno.land/x/nats@v1.10.2/nats-base-client/codec.ts";
 import { JetStreamOptions } from "../../nats-base-client/core.ts";
 import {
   JetStreamSubscriptionInfoable,
   kvPrefix,
   KvWatchInclude,
 } from "../types.ts";
+import { JSONCodec } from "../../nats-base-client/codec.ts";
 
 Deno.test("kv - key validation", () => {
   const bad = [

--- a/jetstream/tests/next_test.ts
+++ b/jetstream/tests/next_test.ts
@@ -23,7 +23,7 @@ import { AckPolicy, DeliverPolicy } from "../jsapi_types.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { NatsConnectionImpl } from "../../nats-base-client/nats.ts";
 import { delay, nanos } from "../../nats-base-client/util.ts";
 

--- a/jetstream/tests/objectstore_test.ts
+++ b/jetstream/tests/objectstore_test.ts
@@ -25,12 +25,12 @@ import {
   assertExists,
   assertRejects,
   equal,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { DataBuffer } from "../../nats-base-client/databuffer.ts";
-import { crypto } from "https://deno.land/std@0.221.0/crypto/mod.ts";
+import { crypto } from "@std/crypto";
 import { ObjectInfo, ObjectStoreMeta, StorageType } from "../mod.ts";
 import { Empty, headers, nanos, StringCodec } from "../../src/mod.ts";
-import { equals } from "https://deno.land/std@0.221.0/bytes/mod.ts";
+import { equals } from "@std/bytes";
 import { SHA256 } from "../../nats-base-client/sha256.js";
 import { Base64UrlPaddedCodec } from "../../nats-base-client/base64.ts";
 import { digestType } from "../objectstore.ts";

--- a/jetstream/tests/streams_test.ts
+++ b/jetstream/tests/streams_test.ts
@@ -20,7 +20,7 @@ import {
   assertEquals,
   assertExists,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   cleanup,
   jetstreamServerConf,

--- a/nats-base-client/authenticator.ts
+++ b/nats-base-client/authenticator.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { nkeys } from "./nkeys.ts";
+import * as nkeys from "@nats-io/nkeys";
 import { TD, TE } from "./encoders.ts";
 import {
   Auth,

--- a/nats-base-client/internal_mod.ts
+++ b/nats-base-client/internal_mod.ts
@@ -40,7 +40,7 @@ export {
 } from "./authenticator.ts";
 export type { Codec } from "./codec.ts";
 export { JSONCodec, StringCodec } from "./codec.ts";
-export * from "./nkeys.ts";
+export * as nkeys from "@nats-io/nkeys";
 export type {
   DispatchedFn,
   IngestionFilterFn,

--- a/nats-base-client/nkeys.ts
+++ b/nats-base-client/nkeys.ts
@@ -1,1 +1,0 @@
-export * as nkeys from "https://raw.githubusercontent.com/nats-io/nkeys.js/v1.0.4/modules/esm/mod.ts";

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -18,7 +18,7 @@ import {
   deferred,
   TlsOptions,
 } from "../nats-base-client/internal_mod.ts";
-import { writeAll } from "https://deno.land/std@0.221.0/io/write_all.ts";
+import { writeAll } from "@std/io";
 import {
   checkOptions,
   checkUnsupportedOption,

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -20,7 +20,7 @@ import {
   assertRejects,
   assertStringIncludes,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   connect,
   createInbox,

--- a/tests/authenticator_test.ts
+++ b/tests/authenticator_test.ts
@@ -26,8 +26,8 @@ import {
   tokenAuthenticator,
   usernamePasswordAuthenticator,
 } from "../nats-base-client/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
-import { nkeys } from "../nats-base-client/nkeys.ts";
+import { assertEquals } from "@std/assert";
+import * as nkeys from "@nats-io/nkeys";
 import {
   encodeAccount,
   encodeOperator,

--- a/tests/autounsub_test.ts
+++ b/tests/autounsub_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 
 import { createInbox, Empty, ErrorCode, Subscription } from "../src/mod.ts";
 import { cleanup, Lock, setup } from "./helpers/mod.ts";

--- a/tests/basics_test.ts
+++ b/tests/basics_test.ts
@@ -20,7 +20,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { assertThrowsAsyncErrorCode } from "./helpers/asserts.ts";
 
@@ -57,11 +57,8 @@ import {
   SubscriptionImpl,
 } from "../nats-base-client/internal_mod.ts";
 import { Feature } from "../nats-base-client/semver.ts";
-import { syncIterator } from "../nats-base-client/core.ts";
-import {
-  MsgHdrs,
-  Publisher,
-} from "https://deno.land/x/nats@v1.18.0/nats-base-client/core.ts";
+import { Publisher, syncIterator } from "../nats-base-client/core.ts";
+import { MsgHdrs } from "../nats-base-client/types.ts";
 
 Deno.test("basics - connect port", async () => {
   const ns = await NatsServer.start();

--- a/tests/bench_test.ts
+++ b/tests/bench_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { Bench, connect, createInbox } from "../src/mod.ts";
 import { BenchOpts, Metric } from "../nats-base-client/bench.ts";
 

--- a/tests/binary_test.ts
+++ b/tests/binary_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { createInbox, Msg } from "../src/mod.ts";
 import { deferred } from "../nats-base-client/internal_mod.ts";
 import { cleanup, setup } from "./helpers/mod.ts";

--- a/tests/buffer_test.ts
+++ b/tests/buffer_test.ts
@@ -11,7 +11,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   DenoBuffer,
   MAX_SIZE,

--- a/tests/clobber_test.ts
+++ b/tests/clobber_test.ts
@@ -16,7 +16,7 @@
 import { NatsServer } from "./helpers/launcher.ts";
 import { createInbox, DataBuffer } from "../nats-base-client/internal_mod.ts";
 import { connect } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 
 function makeBuffer(N: number): Uint8Array {
   const buf = new Uint8Array(N);

--- a/tests/codec_test.ts
+++ b/tests/codec_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { JSONCodec, StringCodec } from "../nats-base-client/codec.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 
 Deno.test("codec - string", () => {
   const sc = StringCodec();

--- a/tests/databuffer_test.ts
+++ b/tests/databuffer_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { DataBuffer } from "../nats-base-client/internal_mod.ts";
 
 Deno.test("databuffer - empty", () => {

--- a/tests/doublesubs_test.ts
+++ b/tests/doublesubs_test.ts
@@ -25,9 +25,9 @@ import {
 import {
   assertArrayIncludes,
   assertEquals,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { extend } from "../nats-base-client/util.ts";
-import { join, resolve } from "https://deno.land/std@0.221.0/path/mod.ts";
+import { join, resolve } from "@std/path";
 
 async function runDoubleSubsTest(tls: boolean) {
   const cwd = Deno.cwd();

--- a/tests/drain_test.ts
+++ b/tests/drain_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { assertThrowsAsyncErrorCode } from "./helpers/asserts.ts";
 import {
   connect,

--- a/tests/events_test.ts
+++ b/tests/events_test.ts
@@ -14,7 +14,7 @@
  */
 import { Lock, NatsServer, ServerSignals } from "../tests/helpers/mod.ts";
 import { connect, Events, ServersChanged } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { delay, NatsConnectionImpl } from "../nats-base-client/internal_mod.ts";
 import { setup } from "./helpers/mod.ts";
 

--- a/tests/headers_test.ts
+++ b/tests/headers_test.ts
@@ -29,7 +29,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   MsgHdrsImpl,
   MsgImpl,

--- a/tests/heartbeats_test.ts
+++ b/tests/heartbeats_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import {
   DebugEvents,

--- a/tests/helpers/asserts.ts
+++ b/tests/helpers/asserts.ts
@@ -17,7 +17,7 @@ import {
   assert,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { isNatsError, NatsError } from "../../nats-base-client/core.ts";
 
 export function assertErrorCode(err?: Error, ...codes: string[]) {

--- a/tests/helpers/cluster.ts
+++ b/tests/helpers/cluster.ts
@@ -14,8 +14,8 @@
  */
 
 import { NatsServer } from "./mod.ts";
-import { parse } from "https://deno.land/std@0.221.0/flags/mod.ts";
-import { rgb24 } from "https://deno.land/std@0.221.0/fmt/colors.ts";
+import { parseArgs } from "@std/cli/parse-args";
+import { rgb24 } from "@std/fmt/colors";
 
 const defaults = {
   c: 3,
@@ -26,7 +26,7 @@ const defaults = {
   key: "",
 };
 
-const argv = parse(
+const argv = parseArgs(
   Deno.args,
   {
     alias: {

--- a/tests/helpers/conf_test.ts
+++ b/tests/helpers/conf_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { toConf } from "./launcher.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 
 Deno.test("conf - serializing simple", () => {
   const x = {

--- a/tests/helpers/launcher.ts
+++ b/tests/helpers/launcher.ts
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 // deno-lint-ignore-file no-explicit-any
-import * as path from "https://deno.land/std@0.221.0/path/mod.ts";
-import { rgb24 } from "https://deno.land/std@0.221.0/fmt/colors.ts";
+import * as path from "@std/path";
+import { rgb24 } from "@std/fmt/colors";
 import { check, jsopts } from "./mod.ts";
 import {
   Deferred,

--- a/tests/helpers/mod.ts
+++ b/tests/helpers/mod.ts
@@ -15,7 +15,7 @@
 
 import { NatsServer } from "./launcher.ts";
 import { compare, parseSemVer } from "../../nats-base-client/semver.ts";
-import { red, yellow } from "https://deno.land/std@0.221.0/fmt/colors.ts";
+import { red, yellow } from "@std/fmt/colors";
 import { extend } from "../../nats-base-client/util.ts";
 import { connect } from "../../src/connect.ts";
 import {

--- a/tests/helpers/service-check.ts
+++ b/tests/helpers/service-check.ts
@@ -28,7 +28,7 @@ import {
 
 import { collect } from "../../nats-base-client/util.ts";
 import { ServiceClientImpl } from "../../nats-base-client/serviceclient.ts";
-import Ajv, { JSONSchemaType, ValidateFunction } from "ajv";
+import { Ajv, JSONSchemaType, ValidateFunction } from "ajv";
 
 import { parseSemVer } from "../../nats-base-client/semver.ts";
 

--- a/tests/helpers/service-check.ts
+++ b/tests/helpers/service-check.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { cli } from "https://deno.land/x/cobra@v0.0.9/mod.ts";
+import { cli } from "cobra";
 import {
   connect,
   NatsConnection,
@@ -28,7 +28,7 @@ import {
 
 import { collect } from "../../nats-base-client/util.ts";
 import { ServiceClientImpl } from "../../nats-base-client/serviceclient.ts";
-import Ajv, { JSONSchemaType, ValidateFunction } from "npm:ajv";
+import Ajv, { JSONSchemaType, ValidateFunction } from "ajv";
 
 import { parseSemVer } from "../../nats-base-client/semver.ts";
 

--- a/tests/idleheartbeats_test.ts
+++ b/tests/idleheartbeats_test.ts
@@ -17,7 +17,7 @@ import { IdleHeartbeatMonitor } from "../nats-base-client/idleheartbeat_monitor.
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { deferred } from "../nats-base-client/util.ts";
 
 Deno.test("idleheartbeat - basic", async () => {

--- a/tests/iterators_test.ts
+++ b/tests/iterators_test.ts
@@ -16,7 +16,7 @@ import { connect, createInbox, ErrorCode, syncIterator } from "../src/mod.ts";
 import {
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 import { assert } from "../nats-base-client/denobuffer.ts";
 import { QueuedIteratorImpl } from "../nats-base-client/queued_iterator.ts";

--- a/tests/json_test.ts
+++ b/tests/json_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import {
   createInbox,
   ErrorCode,

--- a/tests/mrequest_test.ts
+++ b/tests/mrequest_test.ts
@@ -21,7 +21,7 @@ import {
   assertEquals,
   assertRejects,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { StringCodec } from "../nats-base-client/codec.ts";
 import { deferred, delay } from "../nats-base-client/util.ts";
 

--- a/tests/noresponders_test.ts
+++ b/tests/noresponders_test.ts
@@ -19,7 +19,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 Deno.test("noresponders - option", async () => {
   const srv = await NatsServer.start();

--- a/tests/parseip_test.ts
+++ b/tests/parseip_test.ts
@@ -15,7 +15,7 @@
 
 import { parseIP } from "../nats-base-client/internal_mod.ts";
 
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { ipV4 } from "../nats-base-client/ipparser.ts";
 
 Deno.test("ipparser", () => {

--- a/tests/parser_test.ts
+++ b/tests/parser_test.ts
@@ -30,7 +30,7 @@ import {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { Publisher } from "../nats-base-client/core.ts";
 

--- a/tests/properties_test.ts
+++ b/tests/properties_test.ts
@@ -17,7 +17,7 @@ import {
   assertEquals,
   assertExists,
   assertMatch,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { Authenticator, connect, ConnectionOptions } from "../src/mod.ts";
 import { DenoTransport } from "../src/deno_transport.ts";

--- a/tests/protocol_test.ts
+++ b/tests/protocol_test.ts
@@ -27,7 +27,7 @@ import { assertErrorCode } from "./helpers/mod.ts";
 import {
   assertEquals,
   equal,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { protoLen } from "../nats-base-client/transport.ts";
 

--- a/tests/queues_test.ts
+++ b/tests/queues_test.ts
@@ -14,7 +14,7 @@
  */
 
 import { createInbox, Subscription } from "../src/mod.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { cleanup, setup } from "./helpers/mod.ts";
 
 Deno.test("queues - deliver to single queue", async () => {

--- a/tests/reconnect_test.ts
+++ b/tests/reconnect_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import {
   connect,
   createInbox,
@@ -34,7 +34,7 @@ import {
   NatsConnectionImpl,
 } from "../nats-base-client/internal_mod.ts";
 import { cleanup, setup } from "./helpers/mod.ts";
-import { deadline } from "https://deno.land/std@0.221.0/async/deadline.ts";
+import { deadline } from "@std/async";
 
 Deno.test("reconnect - should receive when some servers are invalid", async () => {
   const lock = Lock(1);

--- a/tests/resub_test.ts
+++ b/tests/resub_test.ts
@@ -20,7 +20,7 @@ import {
   assertEquals,
   assertExists,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { createInbox, Msg, NatsConnection } from "../nats-base-client/core.ts";
 import { NatsServer } from "./helpers/launcher.ts";
 

--- a/tests/semver_test.ts
+++ b/tests/semver_test.ts
@@ -24,7 +24,7 @@ import {
   assertEquals,
   assertFalse,
   assertThrows,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 Deno.test("semver", () => {
   const pt: { a: string; b: string; r: number }[] = [

--- a/tests/servers_test.ts
+++ b/tests/servers_test.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 import { isIPV4OrHostname, Servers } from "../nats-base-client/servers.ts";
-import { assertEquals } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import {
   ServerInfo,
   setTransportFactory,

--- a/tests/service_test.ts
+++ b/tests/service_test.ts
@@ -22,7 +22,7 @@ import {
   assertRejects,
   assertThrows,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 
 import { collect, delay } from "../nats-base-client/util.ts";
 import { NatsConnectionImpl } from "../nats-base-client/nats.ts";

--- a/tests/sub_extensions_test.ts
+++ b/tests/sub_extensions_test.ts
@@ -15,7 +15,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { createInbox, Msg, StringCodec } from "../src/mod.ts";
 import {
   deferred,

--- a/tests/timeout_test.ts
+++ b/tests/timeout_test.ts
@@ -15,7 +15,7 @@
 import {
   assertStringIncludes,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { connect } from "../src/connect.ts";
 import { createInbox, Empty } from "../nats-base-client/mod.ts";
 

--- a/tests/tls_test.ts
+++ b/tests/tls_test.ts
@@ -17,11 +17,11 @@ import {
   assertRejects,
   assertStringIncludes,
   fail,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { connect, ErrorCode } from "../src/mod.ts";
 import { assertErrorCode, Lock, NatsServer } from "./helpers/mod.ts";
 
-import { join, resolve } from "https://deno.land/std@0.221.0/path/mod.ts";
+import { join, resolve } from "@std/path";
 import { NatsConnectionImpl } from "../nats-base-client/nats.ts";
 import { cleanup } from "./helpers/mod.ts";
 

--- a/tests/token_test.ts
+++ b/tests/token_test.ts
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { fail } from "https://deno.land/std@0.221.0/assert/mod.ts";
+import { fail } from "@std/assert";
 import { connect, ErrorCode } from "../src/mod.ts";
 import { assertErrorCode, NatsServer } from "./helpers/mod.ts";
 

--- a/tests/typedsub_test.ts
+++ b/tests/typedsub_test.ts
@@ -16,7 +16,7 @@ import {
   assert,
   assertEquals,
   assertRejects,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { assertErrorCode, assertThrowsErrorCode } from "./helpers/asserts.ts";
 import {
   createInbox,

--- a/tests/types_test.ts
+++ b/tests/types_test.ts
@@ -25,7 +25,7 @@ import { DataBuffer, deferred } from "../nats-base-client/internal_mod.ts";
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { NatsServer } from "./helpers/launcher.ts";
 
 function mh(nc: NatsConnection, subj: string): Promise<Msg> {

--- a/tests/util_test.ts
+++ b/tests/util_test.ts
@@ -15,7 +15,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.221.0/assert/mod.ts";
+} from "@std/assert";
 import { backoff, SimpleMutex } from "../nats-base-client/util.ts";
 
 Deno.test("util - simple mutex", () => {

--- a/unsafe_tests/tlsunsafe_test.ts
+++ b/unsafe_tests/tlsunsafe_test.ts
@@ -1,5 +1,4 @@
-import { resolve } from "https://deno.land/std@0.221.0/path/resolve.ts";
-import { join } from "https://deno.land/std@0.221.0/path/join.ts";
+import { resolve, join } from "@std/path";
 import { NatsServer } from "../tests/helpers/launcher.ts";
 import { connect } from "../src/connect.ts";
 


### PR DESCRIPTION
Hi, A lot has change in the Deno ecosystem as of late and I was wandering if you were open to some changes.

Namely the advent of JSR, Moving to JSR would allow for a single cross-platform package (preferably with Deno as the primary runtime)
Thus far, I have moved all dependencies to an import map (in `deno.json`)
There appears to be a lot of simplification possible with the current "build" process (can likely do away with all of the bundling)

What I would like to know is if there are any major objections with perusing the goal of providing a single cross-platform client library? I'm more than happy to invest some significant maintenance time into this and the associated libraries

Thanks.