### PR TITLE
Map `opts.replicas` to `sc.num_replicas` in Object Store init

### DIFF
--- a/jetstream/objectstore.ts
+++ b/jetstream/objectstore.ts
@@ -788,6 +788,7 @@ export class ObjectStoreImpl implements ObjectStore {
     // pacify the tsc compiler downstream
     const sc = Object.assign({ max_age }, opts) as unknown as StreamConfig;
     sc.name = this.stream;
+    sc.num_replicas = opts.replicas ?? 1
     sc.allow_direct = true;
     sc.allow_rollup_hdrs = true;
     sc.discard = DiscardPolicy.New;


### PR DESCRIPTION
The library interface, defined by the `ObjectStoreOptions` type, currently expects a parameter named `replicas` to specify the number of replicas for the object store. However, internally, the correct parameter to be used is `num_replicas`. To align with the existing initialization method of KV, the initialization method of OB should also map `opts.replicas` to `sc.num_replicas`. This ensures consistency and proper utilization of the `replicas` parameter within the object store configuration.