### PR TITLE
nano fixes

### DIFF
--- a/jetstream/jsapi_types.ts
+++ b/jetstream/jsapi_types.ts
@@ -111,7 +111,7 @@ export interface SubjectTransformConfig {
 export interface StreamConsumerLimits {
   /**
    * The default `inactive_threshold` applied to consumers.
-   * This value is specified in nanoseconds. Pleause use the `nanos()`
+   * This value is specified in nanoseconds. Please use the `nanos()`
    * function to convert between millis and nanoseconds. Or `millis()`
    * to convert a nanosecond value to millis.
    */
@@ -983,11 +983,11 @@ export interface ConsumerUpdateConfig {
    */
   "max_batch"?: number;
   /**
-   * The maximum expires value that may be set when doing a pull on a Pull Consumer
+   * The maximum expires value in nanoseconds that may be set when doing a pull on a Pull Consumer
    */
   "max_expires"?: Nanos;
   /**
-   * Duration that instructs the server to clean up ephemeral consumers that are inactive for that long
+   * Duration in nanoseconds that instructs the server to clean up ephemeral consumers that are inactive for that long
    */
   "inactive_threshold"?: Nanos;
   /**

--- a/nats-base-client/core.ts
+++ b/nats-base-client/core.ts
@@ -1017,11 +1017,11 @@ export type NamedEndpointStats = {
    */
   data?: unknown;
   /**
-   * Total processing_time for the service
+   * Total processing_time for the service in nanoseconds
    */
   processing_time: Nanos;
   /**
-   * Average processing_time is the total processing_time divided by the num_requests
+   * Average processing_time, in nanoseconds, is the total processing_time divided by the num_requests
    */
   average_processing_time: Nanos;
   /**

--- a/nats-base-client/service.ts
+++ b/nats-base-client/service.ts
@@ -664,7 +664,7 @@ class NamedEndpointStatsImpl implements NamedEndpointStats {
     const qii = qi as QueuedIteratorImpl<unknown>;
     if (qii?.noIterator === false) {
       // grab stats in the iterator
-      this.processing_time = qii.time;
+      this.processing_time = nanos(qii.time);
       this.num_requests = qii.processed;
       this.average_processing_time =
         this.processing_time > 0 && this.num_requests > 0


### PR DESCRIPTION
doc(core,jetstream): jsdoc for fields that are in nanoseconds, but where not specified in the description - jsdoc erases the type alias and marks as number

fix(services): `processing_time` was reported in millis instead of nanos