### PR TITLE
Make DirectStreamAPIImpl.getMessage request use the configured timeout

### DIFF
--- a/jetstream/jsm.ts
+++ b/jetstream/jsm.ts
@@ -77,6 +77,7 @@ export class DirectStreamAPIImpl extends BaseApiClient
     const r = await this.nc.request(
       subj,
       payload,
+      { timeout: this.timeout }
     );
 
     // response is not a JS.API response


### PR DESCRIPTION
I was getting weird timeouts when using the KV even though I was setting really high timeouts (20s or so), it turns out that the `get` implementation for the KV didn't pass any timeout, so the default one was being used (If I'm not mistaken it is 1s).

I tried to use `this._request`, which I believe is better suited to avoid this kind of problem in the future, instead of `this.nc.request`, but I was getting weird errors that I don't really understand, so I just added the timeout.

I mentioned that `this._request` would be really helpful as it would allow for setting the timeout in a centralized manner. Plus, the fact that it implements some retry logic would be very very helpful for in some cases if I could simply pass some options from the client library to control this. 