### PR TITLE
Update dependencies: Deno, NATS version, and workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     environment: CI
     strategy:
       matrix:
-        deno-version: [1.44.4]
+        deno-version: [1.46.3]
 
     steps:
       - name: Git Checkout Deno Module
@@ -30,7 +30,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set NATS Server Version
-        run: echo "NATS_VERSION=v2.10.17" >> $GITHUB_ENV
+        run: echo "NATS_VERSION=v2.10.24" >> $GITHUB_ENV
 
       # this here because dns seems to be wedged on gha
 #      - name: Add hosts to /etc/hosts

--- a/src/deno_transport.ts
+++ b/src/deno_transport.ts
@@ -34,7 +34,7 @@ import {
   Transport,
 } from "../nats-base-client/internal_mod.ts";
 
-const VERSION = "1.28.2";
+const VERSION = "1.29.0";
 const LANG = "nats.deno";
 
 const ReadBufferSize = 1024 * 256;


### PR DESCRIPTION
Upgraded the Deno version in CI from 1.44.4 to 1.46.3 and updated the NATS version used in the workflow from v2.10.17 to v2.10.24. Also updated the internal version constant in `deno_transport.ts` to 1.29.0